### PR TITLE
update player.py to avoid no keyword arguments error

### DIFF
--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -353,8 +353,9 @@ class OCPMediaPlayer(OVOSAbstractApplication):
 
         # Define things referenced in `bind`
         self.now_playing: NowPlaying = None
-        self.playlist: Playlist = Playlist("Search Results",
-                                           skill_id="")  # TODO icon
+        # self.playlist: Playlist = Playlist("Search Results",
+        #                                    skill_id="")  # TODO icon
+        self.playlist: Playlist = Playlist("Search Results")
         self.media: OCPMediaCatalog = None
         self.audio_service = None
         self.video_service = None


### PR DESCRIPTION
ovos-media would not load. It was failing with the error:
```
 File "/home/pi/.venvs/ovos/lib/python3.11/site-packages/ovos_media/player.py", line 356, in __init__
    self.playlist: Playlist = Playlist("Search Results",
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/.venvs/ovos/lib/python3.11/site-packages/ovos_utils/ocp.py", line 268, in __init__
    super().__init__(**kwargs)
TypeError: list() takes no keyword arguments
```
This fix removes the ``skill_id=""`` arg.