### PR TITLE
docs: drop NeonGecko sponsorship credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,3 @@ under mycroft.conf
   }
 }
 ```
-
-
-## Credits
-
-This work and [Dataset collection](https://github.com/NeonGeckoCom/OCP-dataset) for training the classifiers has been sponsored by [@NeonGeckoCom](https://github.com/NeonGeckoCom/) as part of [The OCP Sprint](https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/issues/74)


### PR DESCRIPTION
Removes the NeonGecko sponsorship Credits section from the README (No-Neon policy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the credits section from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->