### PR TITLE
fix: remove reference to non-existent TrackState.PAUSED_AUDIO

### DIFF
--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -286,20 +286,21 @@ class NowPlaying(MediaEntry):
         self.status = state
 
         if state in (TrackState.PLAYING_AUDIO, TrackState.PLAYING_VIDEO,
-                     TrackState.PLAYING_WEBVIEW, TrackState.PLAYING_SKILL):
+                     TrackState.PLAYING_WEBVIEW, TrackState.PLAYING_SKILL,
+                     TrackState.PLAYING_AUDIOSERVICE, TrackState.PLAYING_MPRIS):
             # backend confirmed playback started — mark player as PLAYING
             if hasattr(self, '_player') and self._player is not None:
                 self._player.set_player_state(PlayerState.PLAYING)
-        elif state == TrackState.PAUSED_AUDIO:
-            if hasattr(self, '_player') and self._player is not None:
-                self._player.set_player_state(PlayerState.PAUSED)
         elif state in (TrackState.QUEUED_SKILL, TrackState.QUEUED_VIDEO,
-                       TrackState.QUEUED_AUDIO):
+                       TrackState.QUEUED_AUDIO, TrackState.QUEUED_AUDIOSERVICE,
+                       TrackState.QUEUED_WEBVIEW):
             # audio service is handling playback and this is queued in playlist
             pass
         elif state == TrackState.DISAMBIGUATION:
             # alternative results list — no playback state change
             pass
+        # NOTE: pause is a PlayerState/MediaState concern, never a TrackState —
+        # there is no TrackState.PAUSED_* member, so no pause branch belongs here.
 
     def handle_media_state_change(self, message):
         """

--- a/test/unittests/test_player_coverage.py
+++ b/test/unittests/test_player_coverage.py
@@ -198,6 +198,33 @@ class TestNowPlayingInit(unittest.TestCase):
         with self.assertRaises(ValueError):
             np.handle_track_state_change(msg)
 
+    def test_handle_track_state_change_queued_does_not_crash(self):
+        """Regression: a non-PLAYING state (QUEUED/…) used to hit a reference to
+        the non-existent ``TrackState.PAUSED_AUDIO`` and raise AttributeError."""
+        np, _ = self._make_now_playing()
+        np._player = MagicMock()
+        for st in (TrackState.QUEUED_AUDIO, TrackState.QUEUED_VIDEO,
+                   TrackState.QUEUED_AUDIOSERVICE, TrackState.DISAMBIGUATION):
+            np.status = TrackState.PLAYING_AUDIO  # force a transition each time
+            np.handle_track_state_change(
+                Message("ovos.common_play.track.state", {"state": int(st)}))
+        # queued/disambiguation never change the player state
+        np._player.set_player_state.assert_not_called()
+
+    def test_handle_track_state_change_playing_sets_player_playing(self):
+        """Every PLAYING_* track state (incl. AUDIOSERVICE and MPRIS) marks the
+        player PLAYING — a paused track stays PLAYING_*, pause is a PlayerState."""
+        from ovos_utils.ocp import PlayerState
+        for st in (TrackState.PLAYING_AUDIO, TrackState.PLAYING_VIDEO,
+                   TrackState.PLAYING_WEBVIEW, TrackState.PLAYING_SKILL,
+                   TrackState.PLAYING_AUDIOSERVICE, TrackState.PLAYING_MPRIS):
+            np, _ = self._make_now_playing()
+            np._player = MagicMock()
+            np.status = TrackState.DISAMBIGUATION
+            np.handle_track_state_change(
+                Message("ovos.common_play.track.state", {"state": int(st)}))
+            np._player.set_player_state.assert_called_once_with(PlayerState.PLAYING)
+
     def test_handle_track_state_change_raises_on_bad_type(self):
         np, _ = self._make_now_playing()
         msg = Message("ovos.common_play.track.state", {"state": "playing"})


### PR DESCRIPTION
`handle_track_state_change` referenced `TrackState.PAUSED_AUDIO`, which is **not a member** of `ovos_utils.ocp.TrackState`. So any non-PLAYING track state (`QUEUED_*`, `DISAMBIGUATION`, …) raised `AttributeError` the moment that `elif` was evaluated — surfaced while writing the MPRIS/OCP e2e tests.

Pause is a `PlayerState`/`MediaState` concern, never a `TrackState` — a paused track stays `PLAYING_*` — so the branch is simply wrong and is removed. Also folds the remaining `PLAYING_*` (`AUDIOSERVICE`, `MPRIS`) and `QUEUED_*` (`AUDIOSERVICE`, `WEBVIEW`) members into the existing tuples, so every playing track marks the player PLAYING and queued states stay no-ops.

Regression tests added (queued states don't crash; every PLAYING_* sets the player PLAYING).

🤖 Generated with [Claude Code](https://claude.com/claude-code)