### PR TITLE
feat: reflect external MPRIS players as OCP now_playing (bus primitive)

### DIFF
--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -424,6 +424,8 @@ class OCPMediaPlayer:
         self.bus.on("ovos.common_play.like", self.handle_like)
         self.bus.on("ovos.common_play.unlike", self.handle_unlike)
         self.bus.on("ovos.common_play.status", self.handle_status)
+        # external MPRIS player → reflect as OCP now_playing (no local backend)
+        self.bus.on("ovos.common_play.mpris.now_playing", self.handle_mpris_now_playing)
         self.handle_get_SEIs(Message("ovos.common_play.SEI.get"))  # report to ovos-core
         self.handle_status(Message("ovos.common_play.status"))  # report to ovos-core
 
@@ -663,6 +665,61 @@ class OCPMediaPlayer:
                 {"Metadata": self.now_playing.mpris_metadata}
             )
         self.handle_status(Message("ovos.common_play.status"))  # report full status to ovos-core
+
+    def set_external_now_playing(self, data: dict):
+        """Reflect an **external** MPRIS player's track as OCP now_playing.
+
+        This is the playback-less path: it updates now_playing + player/media
+        state to mirror a player OCP does not itself drive (Spotify, a browser,
+        VLC, …), so the GUI / voice queries see what's actually playing, WITHOUT
+        invoking any OCP backend (``PlaybackType.MPRIS`` is external).
+
+        Used both in-process by :class:`~ovos_media.mpris.OcpMprisExporter` and,
+        out-of-process, by the standalone ``ovos-media-plugin-mpris`` watcher via
+        the ``ovos.common_play.mpris.now_playing`` bus message.
+
+        Args:
+            data: external track metadata. Recognised keys: ``external_player``
+                (or ``skill_id``) — the MPRIS bus name; ``title``/``artist``/
+                ``image``/``length`` (ms); ``state`` — ``"Playing"`` (default),
+                ``"Paused"`` or ``"Stopped"``; optional ``skill_icon``.
+        """
+        player_id = data.get("external_player") or data.get("skill_id")
+        if not player_id:
+            LOG.warning("external MPRIS now_playing with no player id; ignoring")
+            return
+        state = data.get("state") or "Playing"
+
+        self.active_skill = player_id
+        self.playback_type = PlaybackType.MPRIS
+
+        data = dict(data)
+        data.setdefault("skill_id", player_id)
+        data["playback"] = PlaybackType.MPRIS
+        data["status"] = TrackState.PLAYING_MPRIS
+        data["bg_image"] = (data.get("bg_image") or data.get("image")
+                            or data.get("thumbnail"))
+
+        # update metadata first so the GUI shows the right track for every state
+        self.set_now_playing(data)
+        if state == "Paused":
+            self.set_player_state(PlayerState.PAUSED)
+            self.set_media_state(MediaState.BUFFERED_MEDIA)
+        elif state == "Stopped":
+            self.set_player_state(PlayerState.STOPPED)
+            self.set_media_state(MediaState.END_OF_MEDIA)
+        else:  # Playing
+            self.set_player_state(PlayerState.PLAYING)
+            self.set_media_state(MediaState.BUFFERED_MEDIA)
+        self._update_gui()
+
+    def handle_mpris_now_playing(self, message: Message):
+        """Bus entry point for :meth:`set_external_now_playing`.
+
+        Lets the out-of-process ``ovos-media-plugin-mpris`` watcher reflect an
+        external player into OCP without a direct object reference.
+        """
+        self.set_external_now_playing(dict(message.data))
 
     def _resolve_preferred_service(self, media_service):
         """Resolve preferred backend from config and return the matching service instance.

--- a/test/unittests/test_player_handlers.py
+++ b/test/unittests/test_player_handlers.py
@@ -32,6 +32,7 @@ from ovos_utils.ocp import (
     MediaState,
     LoopState,
     PlaybackType,
+    TrackState,
     MediaEntry,
     Playlist,
 )
@@ -763,6 +764,63 @@ class TestHandlePlayRequest(unittest.TestCase):
         msg = Message("ovos.common_play.play", {"media": media})
         p.handle_play_request(msg)
         p.play_media.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# handle_mpris_now_playing / set_external_now_playing
+# ---------------------------------------------------------------------------
+
+class TestExternalMprisNowPlaying(unittest.TestCase):
+    """An external MPRIS player is reflected as OCP now_playing with NO local
+    backend playback (PlaybackType.MPRIS)."""
+
+    def _player(self):
+        p = _make_player(PlaybackType.AUDIO)
+        p.set_now_playing = MagicMock()
+        p._update_gui = MagicMock()
+        p.handle_status = MagicMock()
+        return p
+
+    def test_playing_reflects_and_sets_playing(self):
+        p = self._player()
+        p.handle_mpris_now_playing(Message(
+            "ovos.common_play.mpris.now_playing",
+            {"external_player": "org.mpris.MediaPlayer2.spotify",
+             "title": "Song", "artist": "Artist",
+             "uri": "spotify:track:1", "state": "Playing"}))
+        self.assertEqual(p.playback_type, PlaybackType.MPRIS)
+        self.assertEqual(p.active_skill, "org.mpris.MediaPlayer2.spotify")
+        self.assertEqual(p.state, PlayerState.PLAYING)
+        # metadata reflected as an MPRIS track
+        data = p.set_now_playing.call_args[0][0]
+        self.assertEqual(data["playback"], PlaybackType.MPRIS)
+        self.assertEqual(data["status"], TrackState.PLAYING_MPRIS)
+        self.assertEqual(data["skill_id"], "org.mpris.MediaPlayer2.spotify")
+        # NO local backend invoked
+        p.audio_service.play.assert_not_called()
+        p.video_service.play.assert_not_called()
+
+    def test_paused_sets_paused(self):
+        p = self._player()
+        p.handle_mpris_now_playing(Message("x", {
+            "external_player": "vlc", "state": "Paused"}))
+        self.assertEqual(p.state, PlayerState.PAUSED)
+        p.audio_service.play.assert_not_called()
+
+    def test_stopped_sets_stopped(self):
+        p = self._player()
+        p.handle_mpris_now_playing(Message("x", {
+            "external_player": "vlc", "state": "Stopped"}))
+        self.assertEqual(p.state, PlayerState.STOPPED)
+
+    def test_no_player_id_is_ignored(self):
+        p = self._player()
+        p.handle_mpris_now_playing(Message("x", {"title": "no id"}))
+        p.set_now_playing.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds the ovos-media side of the MPRIS *now_playing* story (the goal behind the watcher's pause).

`OCPMediaPlayer.set_external_now_playing(data)` + the `ovos.common_play.mpris.now_playing` bus handler reflect an **external** MPRIS player (Spotify, a browser, VLC, …) — one OCP does **not** itself drive — as OCP now_playing: metadata + player/media state, with **no** OCP backend invoked (`PlaybackType.MPRIS` is external).

This is the primitive the standalone `ovos-media-plugin-mpris` watcher emits to (out-of-process), so the GUI and 'what's playing' voice queries reflect the external track; `OcpMprisExporter` can reuse it in-process to dedupe its own logic. Additive — the existing exporter path is untouched.

Tests cover playing/paused/stopped reflection and the no-player-id guard.

Depends conceptually on the `PLAYING_MPRIS` handling in #45 (independent change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)