### PR TITLE
feat: stop OCP playback on external MPRIS takeover

### DIFF
--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -691,6 +691,15 @@ class OCPMediaPlayer:
             return
         state = data.get("state") or "Playing"
 
+        # an external player taking over playback should stop OCP's own backends
+        # first so the two don't overlap. Only on the transition (a different/new
+        # external player starting to play), and BEFORE active_skill is switched
+        # so stop_skill targets the currently-active skill, not the new player.
+        is_new_external = (self.playback_type != PlaybackType.MPRIS or
+                           self.active_skill != player_id)
+        if state == "Playing" and is_new_external:
+            self.handle_MPRIS_takeover()
+
         self.active_skill = player_id
         self.playback_type = PlaybackType.MPRIS
 

--- a/test/unittests/test_player_handlers.py
+++ b/test/unittests/test_player_handlers.py
@@ -822,6 +822,27 @@ class TestExternalMprisNowPlaying(unittest.TestCase):
         p.handle_mpris_now_playing(Message("x", {"title": "no id"}))
         p.set_now_playing.assert_not_called()
 
+    def test_new_external_player_triggers_takeover(self):
+        """A new external player starting playback stops OCP's own backends."""
+        p = self._player()
+        p.handle_MPRIS_takeover = MagicMock()
+        p.playback_type = PlaybackType.AUDIO  # OCP was playing its own audio
+        p.active_skill = "some.ocp.skill"
+        p.handle_mpris_now_playing(Message("x", {
+            "external_player": "org.mpris.MediaPlayer2.spotify", "state": "Playing"}))
+        p.handle_MPRIS_takeover.assert_called_once()
+
+    def test_same_external_player_does_not_repeat_takeover(self):
+        """Metadata/position updates from the already-active external player must
+        not re-trigger the takeover (which would stop it)."""
+        p = self._player()
+        p.handle_MPRIS_takeover = MagicMock()
+        p.playback_type = PlaybackType.MPRIS
+        p.active_skill = "org.mpris.MediaPlayer2.spotify"
+        p.handle_mpris_now_playing(Message("x", {
+            "external_player": "org.mpris.MediaPlayer2.spotify", "state": "Playing"}))
+        p.handle_MPRIS_takeover.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up to #47. `set_external_now_playing` now calls `handle_MPRIS_takeover` when a **new** external player starts playing (on the transition only, before `active_skill` switches so `stop_skill` targets the right skill) — so OCP's own audio/video/web/skill backends stop and don't overlap the external player. Repeated updates from the same external player don't re-trigger it. Tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)