### PR TITLE
docs: complete + verify ovos-media documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Every arrow is a plugin boundary, so each piece can be replaced independently:
 
 | Concern | Plugin group | Examples |
 |---|---|---|
-| **Find media** (catalogs/search) | `opm.media.provider` | youtube, bandcamp, soundcloud, tunein, somafm, … |
-| **Play audio** | `opm.media.audio` | vlc, mplayer, simple, spotify, chromecast |
-| **Play video** | `opm.media.video` | vlc, mpv, chromecast |
-| **Render web/webview** | `opm.media.web` | browser, gui |
+| **Find media** (catalogs/search) | `opm.media.provider` | youtube, bandcamp, soundcloud, tunein, somafm, pyradios |
+| **Play audio** | `opm.media.audio` | vlc, mplayer, simple (cli), ffplay, spotify, chromecast, mass, mpris |
+| **Play video** | `opm.media.video` | vlc, mplayer, chromecast |
+| **Render web/webview** | `opm.media.web` | (rendered via the GUI WebView) |
 | **Resolve a stream URI** | `opm.ocp.extractor` | youtube, m3u, rss, files |
 
 Search results flow as [`mediavocab.Release`](https://github.com/TigreGotico/mediavocab)
@@ -101,9 +101,8 @@ All configuration lives under the `"media"` key in `mycroft.conf`. The essential
 
     // order of preference per playback type; the first backend that can
     // handle the URI wins. Users may also name a backend in the utterance.
-    "preferred_audio_services": ["gui", "vlc", "mplayer", "cli"],
-    "preferred_video_services": ["gui", "vlc"],
-    "preferred_web_services":   ["gui", "browser"],
+    "preferred_audio_services": ["vlc", "mplayer", "cli"],
+    "preferred_video_services": ["vlc"],
 
     // declare the backends available to each playback type.
     // "module" is the plugin's entry-point name; "aliases" are spoken names.
@@ -113,9 +112,6 @@ All configuration lives under the `"media"` key in `mycroft.conf`. The essential
     },
     "video_players": {
       "vlc": { "module": "ovos-media-video-plugin-vlc", "aliases": ["VLC"], "active": true }
-    },
-    "web_players": {
-      "browser": { "module": "ovos-media-web-plugin-browser", "aliases": ["Browser"], "active": true }
     }
   }
 }
@@ -142,10 +138,10 @@ Start at **[docs/index.md](docs/index.md)**.
 
 ## Status
 
-`ovos-media` is the upcoming default playback stack and is opt-in today. The
-`MediaProvider` plugin model that supplies catalogs is replacing the older OCP
-*skills* approach — see [docs/media-providers.md](docs/media-providers.md) for the
-current migration state.
+`ovos-media` is the OCP-native playback stack and is opt-in today (enable it by
+turning off the legacy audio service). Catalogs are supplied by
+[`MediaProvider` plugins](docs/media-providers.md) (`opm.media.provider`); the
+legacy OCP *search skills* still work during the transition.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,7 @@
 # Architecture
 
 This document describes the runtime architecture of `ovos-media` — the playback
-daemon — and how it sits inside the wider OCP media flow. Behavioural claims cite
-a source location as `ClassName.method — path/to/file.py`.
+daemon — and how it sits inside the wider OCP media flow.
 
 ---
 
@@ -16,7 +15,7 @@ a source location as `ClassName.method — path/to/file.py`.
    ▼
  ovos-core ─ OCP pipeline (ovos-ocp-pipeline-plugin)
    │   classifies the media type, parses title/artist/genre into mediavocab.Signals,
-   │   gates + dispatches MediaProvider plugins in-process, ranks the Release results
+   │   dispatches MediaProvider plugins in-process, ranks the Release results
    ▼
  ovos-media (this daemon)
    │   receives the winning result, picks a playback backend, manages the
@@ -44,13 +43,40 @@ The rest of this document focuses on the daemon itself.
 
 `ovos-media` is structured as three cooperating layers:
 
-1. **`MediaService`** (`ovos_media/service.py`) — the process entry point. It runs as a `Thread`, owns the `MessageBusClient` connection, instantiates `OCPMediaPlayer`, and registers a small set of top-level bus handlers. `MediaService.__init__ — ovos_media/service.py:33`
+1. **`MediaService`** (`ovos_media/service.py`) — the process entry point. It runs
+   as a `Thread`, owns the `MessageBusClient` connection, instantiates
+   `OCPMediaPlayer`, installs the `LegacyAudioServiceCompat` shim, and registers a
+   small set of top-level bus handlers.
 
-2. **`OCPMediaPlayer`** (`ovos_media/player.py`) — the virtual media player. It subclasses `OVOSAbstractApplication`, manages the playback state machine (`PlayerState`, `MediaState`), owns three backend service objects (`AudioService`, `VideoService`, `WebService`), drives the GUI via `GUIInterface`, and optionally drives MPRIS. `OCPMediaPlayer.__init__ — ovos_media/player.py:343`
+2. **`OCPMediaPlayer`** (`ovos_media/player.py`) — the virtual media player. It is
+   a plain bus-connected class (it is *not* a skill or an `OVOSAbstractApplication`)
+   that manages the playback state machine (`PlayerState`, `MediaState`), owns the
+   `NowPlaying` tracker and three backend service objects (`AudioService`,
+   `VideoService`, `WebService`), drives the GUI via `GUIInterface`, and optionally
+   drives MPRIS. All of this is wired up in `OCPMediaPlayer.__init__`.
 
-3. **Backend plugins** (`ovos_media/media_backends/`) — three concrete `BaseMediaService` subclasses (`AudioService`, `VideoService`, `WebService`). Each loads OPM plugins at startup and delegates actual playback to the selected plugin instance.
+3. **Backend services** (`ovos_media/media_backends/`) — three concrete
+   `BaseMediaService` subclasses (`AudioService`, `VideoService`, `WebService`).
+   Each loads OPM plugins at startup and delegates actual playback to the selected
+   plugin instance.
 
-These layers communicate via the OVOS MessageBus (WebSocket pub/sub). The `MediaService` layer handles service-lifecycle and discovery events; `OCPMediaPlayer` handles all media-control events from external callers; backend services handle low-level playback over namespaced bus events.
+These layers communicate via the OVOS MessageBus (WebSocket pub/sub). The
+`MediaService` layer handles service-lifecycle and discovery events;
+`OCPMediaPlayer` handles all media-control events from external callers; backend
+services handle low-level playback over namespaced bus events.
+
+### NowPlaying
+
+`OCPMediaPlayer.now_playing` is a `NowPlaying` instance — a `MediaEntry` subclass
+that subscribes to bus events to keep the currently-playing track's metadata,
+status (`TrackState`), and seek position live. It updates on
+`ovos.common_play.track.state`, `ovos.common_play.media.state`,
+`ovos.common_play.play`, and `ovos.common_play.playback_time`. When a backend
+confirms playback (`TrackState.PLAYING_*`), `NowPlaying` calls back into the
+player to set `PlayerState.PLAYING`; on `MediaState.END_OF_MEDIA` it resets.
+
+> There is no paused `TrackState`. Pause/resume are `PlayerState`/`MediaState`
+> concerns; `TrackState` only describes queued/playing/disambiguation status.
 
 ---
 
@@ -58,19 +84,25 @@ These layers communicate via the OVOS MessageBus (WebSocket pub/sub). The `Media
 
 ### MediaService handlers
 
-Registered in `MediaService.__init__` — `ovos_media/service.py:60` and `MediaService.init_messagebus` — `ovos_media/service.py:117`.
+Registered in `MediaService.__init__` and `MediaService.init_messagebus`
+(`ovos_media/service.py`).
 
 | Message type | Handler | Notes |
 | :--- | :--- | :--- |
-| `ovos.common_play.home` | `handle_home` | Calls `ocp._update_gui()` to refresh the GUI home screen. `MediaService.handle_home — ovos_media/service.py:66` |
-| `ovos.common_play.ping` | `handle_ping` | Replies immediately with `ovos.common_play.pong`. `MediaService.handle_ping — ovos_media/service.py:69` |
-| `ovos.common_play.search.start` | `handle_search_start` | Calls `ocp.gui.show_media_player(state="loading")` to display a loading animation. `MediaService.handle_search_start — ovos_media/service.py:76` |
-| `ovos.common_play.search.end` | `handle_search_end` | Marks the end of a search dispatch. `MediaService.handle_search_end — ovos_media/service.py:85` |
-| `opm.audio.query` | `handle_opm_audio_query` | Replies with the dict returned by `audio_service.available_backends()`, preserving the legacy OPM discovery contract. `MediaService.handle_opm_audio_query — ovos_media/service.py:92` |
+| `ovos.common_play.home` | `handle_home` | Calls `ocp._update_gui()` to refresh the GUI home screen. |
+| `ovos.common_play.ping` | `handle_ping` | Replies immediately with `ovos.common_play.pong`. |
+| `ovos.common_play.search.start` | `handle_search_start` | Calls `ocp.gui.show_media_player(state="loading")` to display a loading animation. |
+| `ovos.common_play.search.end` | `handle_search_end` | Dismisses the spinner and refreshes the player GUI. |
+| `opm.audio.query` | `handle_opm_audio_query` | Replies with the dict returned by `audio_service.available_backends()`, preserving the legacy OPM discovery contract. |
+
+The `LegacyAudioServiceCompat` shim (`ovos_media/legacy_api.py`) registers all
+`mycroft.audio.service.*` handlers and translates them to `ovos.common_play.*`
+commands, so unmigrated skills that still call the classic AudioService API keep
+working.
 
 ### OCPMediaPlayer handlers
 
-Registered in `OCPMediaPlayer.register_bus_handlers` — `ovos_media/player.py:393`.
+Registered in `OCPMediaPlayer.register_bus_handlers` (`ovos_media/player.py`).
 
 | Message type | Handler | Notes |
 | :--- | :--- | :--- |
@@ -81,52 +113,57 @@ Registered in `OCPMediaPlayer.register_bus_handlers` — `ovos_media/player.py:3
 | `ovos.common_play.stop` | `handle_stop_request` | Stops all active backends and sets `PlayerState.STOPPED`. |
 | `ovos.common_play.next` | `handle_next_request` | Advances to the next track, respecting shuffle and loop state. |
 | `ovos.common_play.previous` | `handle_prev_request` | Returns to the previous track. |
-| `ovos.common_play.seek` | `handle_seek_request` | Seeks audio to a position in milliseconds. `OCPMediaPlayer.seek — ovos_media/player.py:949` |
+| `ovos.common_play.seek` | `handle_seek_request` | Seeks to a position (data in seconds or a GUI `seekValue`). |
 | `ovos.common_play.get_track_length` | `handle_track_length_request` | Replies with the current track length. |
 | `ovos.common_play.set_track_position` | `handle_set_track_position_request` | Seeks to an absolute track position. |
 | `ovos.common_play.get_track_position` | `handle_track_position_request` | Replies with current playback position. |
-| `ovos.common_play.track_info` | `handle_track_info_request` | Replies with track metadata as `ovos.common_play.track.info.reply`. |
-| `ovos.common_play.list_backends` | `handle_list_backends_request` | Replies with the list of loaded backend plugins. |
+| `ovos.common_play.track_info` | `handle_track_info_request` | Replies with track metadata (via `message.response`). |
+| `ovos.common_play.list_backends` | `handle_list_backends_request` | Replies with the dict of loaded audio backends. |
 | `ovos.common_play.playlist.set` | `handle_playlist_set_request` | Replaces the current playlist. |
 | `ovos.common_play.playlist.queue` | `handle_playlist_queue_request` | Appends tracks to the current playlist. |
 | `ovos.common_play.playlist.clear` | `handle_playlist_clear_request` | Clears the current playlist. |
-| `ovos.common_play.shuffle.toggle` | `handle_shuffle_toggle_request` | Toggles shuffle mode. |
-| `ovos.common_play.shuffle.set` | `handle_set_shuffle` | Enables shuffle. |
-| `ovos.common_play.shuffle.unset` | `handle_unset_shuffle` | Disables shuffle. |
-| `ovos.common_play.repeat.toggle` | `handle_repeat_toggle_request` | Toggles repeat mode. |
-| `ovos.common_play.repeat.set` | `handle_set_repeat` | Enables repeat. |
-| `ovos.common_play.repeat.unset` | `handle_unset_repeat` | Disables repeat. |
+| `ovos.common_play.shuffle.toggle` / `.set` / `.unset` | `handle_shuffle_toggle_request` / `handle_set_shuffle` / `handle_unset_shuffle` | Shuffle controls. |
+| `ovos.common_play.repeat.toggle` / `.set` / `.unset` | `handle_repeat_toggle_request` / `handle_set_repeat` / `handle_unset_repeat` | Repeat / loop controls. |
 | `ovos.common_play.duck` | `handle_duck_request` | Lowers backend volume. |
 | `ovos.common_play.unduck` | `handle_unduck_request` | Restores backend volume. |
-| `ovos.common_play.cork` | `handle_cork_request` | Pauses playback while TTS/recording is active. |
-| `ovos.common_play.uncork` | `handle_uncork_request` | Resumes playback after TTS/recording finishes. |
-| `recognizer_loop:audio_output_start` | `handle_duck_request` | Legacy ducking alias — same semantics as `ovos.common_play.duck`. `OCPMediaPlayer.register_bus_handlers — ovos_media/player.py:418` |
-| `recognizer_loop:audio_output_end` | `handle_unduck_request` | Legacy ducking alias. |
-| `recognizer_loop:record_begin` | `handle_cork_request` | Legacy cork alias. |
-| `mycroft.stop` | `handle_mycroft_stop` | Global stop — stops all backends and resets state. `OCPMediaPlayer.register_bus_handlers — ovos_media/player.py:424` |
-| `ovos.common_play.like` | `handle_like` | Adds the current track to the liked-songs store. |
-| `ovos.common_play.unlike` | `handle_unlike` | Removes the current track from the liked-songs store. |
-| `ovos.common_play.status` | `handle_status` | Replies with full player status (state, media type, position, shuffle, loop). `OCPMediaPlayer.handle_status — ovos_media/player.py:454` |
+| `ovos.common_play.cork` | `handle_cork_request` | Pauses playback while the mic is open. |
+| `ovos.common_play.uncork` | `handle_uncork_request` | Resumes playback after recording finishes. |
+| `ovos.common_play.SEI.get` | `handle_get_SEIs` | Replies with the supported stream-extractor identifiers. |
+| `ovos.common_play.search.start` | `handle_search_start` | Shows the GUI loading state. |
+| `ovos.common_play.like` / `.unlike` | `handle_like` / `handle_unlike` | Add/remove the current track in the liked-songs store. |
+| `ovos.common_play.status` | `handle_status` | Replies with full player status (state, media type, position, shuffle, loop). |
+| `ovos.common_play.mpris.now_playing` | `handle_mpris_now_playing` | Reflects an **external** MPRIS player as OCP now-playing — see [MPRIS](#mpris-integration). |
+| `recognizer_loop:audio_output_start` / `:audio_output_end` | `handle_duck_request` / `handle_unduck_request` | Legacy ducking aliases — same semantics as `ovos.common_play.duck` / `.unduck`. |
+| `recognizer_loop:record_begin` / `:record_end` | `handle_cork_request` / `handle_record_end` | Legacy cork alias; `record_end` auto-uncorks if no `speak` arrives within 8 s. |
+| `ovos.utterance.handled` | `handle_utterance_handled` | Restores volume once speech finishes. |
+| `mycroft.stop` | `handle_mycroft_stop` | Global stop — stops all backends, resets state, replies `mycroft.stop.handled`. |
 
 ### Emitted events
 
 | Message type | Emitter | Payload |
 | :--- | :--- | :--- |
-| `ovos.common_play.player.state` | `OCPMediaPlayer.set_player_state` — `ovos_media/player.py:586` | `{"state": PlayerState}` |
-| `ovos.common_play.media.state` | `OCPMediaPlayer.set_media_state` — `ovos_media/player.py:573` | `{"state": MediaState}` |
-| `ovos.common_play.pong` | `MediaService.handle_ping` — `ovos_media/service.py:74` | empty data |
-| `ovos.common_play.track.info.reply` | `handle_track_info_request` | dict of track metadata |
-| `ovos.common_play.track.state` | `BaseMediaService.handle_media_state_change` — `ovos_media/media_backends/base.py:133` | `{"state": TrackState}` |
+| `ovos.common_play.player.state` | `OCPMediaPlayer.set_player_state` | `{"state": PlayerState}` |
+| `ovos.common_play.media.state` | `OCPMediaPlayer.set_media_state` | `{"state": MediaState}` |
+| `ovos.common_play.track.state` | `BaseMediaService.handle_media_state_change` (and the backend templates) | `{"state": TrackState}` |
+| `ovos.common_play.status` (response) | `OCPMediaPlayer.handle_status` | full status snapshot |
+| `ovos.common_play.pong` | `MediaService.handle_ping` | empty data |
+| `mycroft.audio.play_sound` | `OCPMediaPlayer.on_invalid_stream` / `handle_like` | `{"uri": "snd/…"}` |
+| `mycroft.stop.handled` | `OCPMediaPlayer.handle_mycroft_stop` | `{"by": "ovos-media"}` |
+
+`handle_status` is also emitted (as a self-addressed `ovos.common_play.status`
+response) on startup and after every `set_player_state` / `set_now_playing`, so
+ovos-core's OCP pipeline always has a current snapshot for the session.
 
 ---
 
 ## State Machine
 
-Two orthogonal state enums are tracked by `OCPMediaPlayer`:
+Two orthogonal state enums are tracked by `OCPMediaPlayer`, both defined in
+`ovos_utils.ocp`.
 
 ### PlayerState
 
-Represents the action the player is currently performing. Defined in `ovos_utils.ocp`.
+Represents the action the player is currently performing.
 
 | Value | Meaning |
 | :--- | :--- |
@@ -134,70 +171,113 @@ Represents the action the player is currently performing. Defined in `ovos_utils
 | `PAUSED` | Playback is paused; resumable. |
 | `STOPPED` | No active playback. |
 
-State changes are made exclusively through `OCPMediaPlayer.set_player_state` — `ovos_media/player.py:586`, which updates `self.state`, emits `ovos.common_play.player.state`, notifies MPRIS, and calls `handle_status` to report full status to ovos-core.
+State changes are made exclusively through `OCPMediaPlayer.set_player_state`,
+which updates `self.state`, emits `ovos.common_play.player.state`, updates MPRIS
+props, refreshes the GUI, and calls `handle_status` to report full status to
+ovos-core.
 
 ### MediaState
 
-Represents the lifecycle stage of the loaded media item. Defined in `ovos_utils.ocp`.
+Represents the lifecycle stage of the loaded media item.
 
 | Value | Meaning |
 | :--- | :--- |
 | `NO_MEDIA` | No media is loaded. |
-| `LOADING` | Media URI is being loaded by a backend plugin. |
-| `LOADED_MEDIA` | Media is loaded and ready; backend begins playback automatically. `BaseMediaService.handle_media_state_change — ovos_media/media_backends/base.py:133` |
-| `END_OF_MEDIA` | Playback has finished; `NowPlaying.reset()` is called. `NowPlaying.handle_media_state_change — ovos_media/player.py:300` |
+| `LOADED_MEDIA` | Media is loaded and ready; the backend begins playback automatically (`BaseMediaService.handle_media_state_change`). |
+| `BUFFERED_MEDIA` | Media is buffered/playing (used by the external-player reflection path). |
+| `END_OF_MEDIA` | Playback has finished; `NowPlaying.reset()` is called. |
+| `INVALID_MEDIA` | The loaded URI could not be played; the player advances or shows an error. |
 
-State changes are made through `OCPMediaPlayer.set_media_state` — `ovos_media/player.py:573`, which emits `ovos.common_play.media.state`.
+State changes are made through `OCPMediaPlayer.set_media_state`, which emits
+`ovos.common_play.media.state`.
 
 ---
 
 ## GUI Integration
 
-`OCPMediaPlayer` holds a `GUIInterface("ovos.common_play")` instance, created in `OCPMediaPlayer.bind` — `ovos_media/player.py:391`.
+`OCPMediaPlayer` holds a `GUIInterface("ovos.common_play")` instance, created in
+`OCPMediaPlayer.__init__`.
 
-After every state change, `OCPMediaPlayer._update_gui` — `ovos_media/player.py:439` is called. It maps the current `PlayerState` to one of the strings `"playing"`, `"paused"`, or `"stopped"` and invokes:
+After every state change, `OCPMediaPlayer._update_gui` is called. It maps the
+current `PlayerState` to one of the strings `"playing"`, `"paused"`, or
+`"stopped"` and invokes:
 
 ```python
 self.gui.show_media_player(
     now_playing=np.as_dict if np and np.uri else None,
-    playlist=self.playlist.as_list(),
-    search_results=self._last_search_results,
-    state=state_map[self.state],
+    playlist=[e.as_dict for e in self.playlist.entries],
+    search_results=self._last_search_results or [],
+    state=state_map.get(self.state, "stopped"),
 )
 ```
 
-The GUI client (`ovos-gui` or another `GUIInterface` consumer) renders the media player screen. Individual backend plugins that handle video or web content render in their own GUI namespaces, independent of the `"ovos.common_play"` namespace.
+Other `state` strings are pushed directly: `"loading"` while the OCP pipeline is
+searching (`MediaService.handle_search_start` / `OCPMediaPlayer.handle_search_start`)
+and `"error"` when a stream is invalid (`on_invalid_stream` /
+`handle_invalid_media`).
 
-`MediaService.handle_search_start` — `ovos_media/service.py:76` calls `show_media_player(state="loading")` directly when the OCP pipeline begins searching, before any results are available.
+The GUI client (`ovos-gui` with the `ovos-media-plugin-qt5` rendering backend, or
+another `GUIInterface` consumer) renders the media-player screen. Video and web
+backend plugins that draw their own content render in their own GUI namespaces,
+independent of the `"ovos.common_play"` namespace.
 
 ---
 
 ## MPRIS Integration
 
-`OcpMprisExporter` (`ovos_media/mpris.py`) runs in a background thread. It serves two roles:
+`OcpMprisExporter` (`ovos_media/mpris.py`) runs in a background thread. MPRIS
+participation is enabled with the `enable_mpris` config key (off by default); when
+enabled, `OCPMediaPlayer.__init__` creates the exporter, passing `manage_players`
+from `ocp_config.get("manage_external_players", False)`.
 
-- **Role A (always active when enabled)**: Exposes OCP as a D-Bus MPRIS 2.0 player so that external desktop widgets and media keys interact with it.
-- **Role B (optional)**: When `manage_external_players = true` in config, it also monitors external MPRIS players and hands control to `OCPMediaPlayer` when they become active.
+There are two distinct directions:
 
-MPRIS is enabled via the `enable_mpris` config key. It is disabled by default. When enabled, `OCPMediaPlayer.bind` — `ovos_media/player.py:383` creates the `OcpMprisExporter` and passes `manage_players` from `ocp_config.get("manage_external_players", False)`.
+- **OCP *as* an MPRIS server (Role A, outbound).** `OcpMprisExporter` registers
+  `org.mpris.MediaPlayer2.OCP` on the D-Bus session bus so desktop widgets, media
+  keys, and `playerctl` can control OCP. When player state changes,
+  `set_player_state` calls `self.mpris.update_props({...})` to keep PlaybackStatus,
+  CanPause/CanPlay, Metadata, and the rest in sync.
 
-When player state changes, `set_player_state` — `ovos_media/player.py:586` calls `self.mpris.update_props({"PlaybackStatus": ..., "CanPause": ..., "CanPlay": ...})`.
+- **External player → OCP now-playing (inbound reflection).** An external player
+  (Spotify, a browser, VLC…) can be reflected *as* OCP's now-playing without OCP
+  driving any backend, via
+  `OCPMediaPlayer.set_external_now_playing` / the `ovos.common_play.mpris.now_playing`
+  bus message handled by `handle_mpris_now_playing`. The reflection sets
+  `playback_type = PlaybackType.MPRIS`, updates now-playing metadata and
+  player/media state, and on a *new* external player taking over it first calls
+  `handle_MPRIS_takeover()` to stop OCP's own audio/video/web backends so the two
+  do not overlap. This message is emitted by the standalone
+  `ovos-media-plugin-mpris` watcher; the same reflection also runs in-process when
+  `manage_external_players` is enabled. See [mpris.md](mpris.md) for the full
+  picture.
 
 ---
 
 ## Plugin System
 
-Backend services are loaded by `BaseMediaService.load_services` — `ovos_media/media_backends/base.py:75`. At startup it calls the injected `plugin_loader` callable (one of `find_ocp_audio_plugins`, `find_ocp_video_plugins`, or `find_ocp_web_plugins` from `ovos-plugin-manager`) to get a dict of available plugin classes, then instantiates each plugin that is present in the `media.<namespace>_players` configuration block and not marked `active: false`.
+Backend services are loaded by `BaseMediaService.load_services`
+(`ovos_media/media_backends/base.py`). At startup it calls the injected
+`plugin_loader` callable (one of `find_ocp_audio_plugins`, `find_ocp_video_plugins`,
+or `find_ocp_web_plugins` from `ovos-plugin-manager`) to get a dict of available
+plugin classes, then instantiates each plugin that is present in the
+`media.<namespace>_players` configuration block and not marked `active: false`.
 
-Local (non-remote) backend instances are placed before remote instances in `self.services` — `ovos_media/media_backends/base.py:106`, so local backends are tried first when selecting a playback backend by URI type.
+Local (non-remote) backend instances are placed before remote instances in
+`self.services`, so local backends are tried first when selecting a playback
+backend by URI type.
 
-The three concrete subclasses and their OPM discovery functions are:
+The three concrete subclasses and their OPM discovery functions and entry-point
+groups are:
 
-| Class | Module | OPM function |
-| :--- | :--- | :--- |
-| `AudioService` | `ovos_media/media_backends/audio.py:8` | `find_ocp_audio_plugins` |
-| `VideoService` | `ovos_media/media_backends/video.py:8` | `find_ocp_video_plugins` |
-| `WebService` | `ovos_media/media_backends/web.py:8` | `find_ocp_web_plugins` |
+| Class | Module | OPM function | Entry-point group |
+| :--- | :--- | :--- | :--- |
+| `AudioService` | `ovos_media/media_backends/audio.py` | `find_ocp_audio_plugins` | `opm.media.audio` |
+| `VideoService` | `ovos_media/media_backends/video.py` | `find_ocp_video_plugins` | `opm.media.video` |
+| `WebService` | `ovos_media/media_backends/web.py` | `find_ocp_web_plugins` | `opm.media.web` |
+
+Catalog/search providers (`opm.media.provider`) are *not* loaded by this daemon —
+they are loaded in-process by the OCP pipeline plugin. See
+[media-providers.md](media-providers.md).
 
 ---
 
@@ -209,9 +289,9 @@ state, the classified media type, and which extractors that player can resolve.
 
 This matters for distributed setups (for example HiveMind satellites): each
 device has its own session, so a user on a satellite plays media on **that**
-device's player rather than the hub's. `ovos-media` participates by announcing
-itself on the bus and reporting its state through `handle_status`, which the
-pipeline associates with the originating session.
+device's player rather than the hub's. `ovos-media` participates by reporting its
+state through `handle_status`, which the pipeline associates with the originating
+session.
 
 ---
 
@@ -220,5 +300,5 @@ pipeline associates with the originating session.
 - [Media providers](media-providers.md) — the catalog/search layer feeding this daemon
 - [Backends](backends.md) — the audio/video/web playback plugins
 - [Configuration](configuration.md) — the `media` config block
-- [MPRIS integration](mpris.md) — the D-Bus exporter in depth
+- [MPRIS integration](mpris.md) — the D-Bus exporter and external-player reflection
 - [Migration guide](migration-guide.md) — moving from the legacy audio service

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -12,44 +12,79 @@ type and the configured preferences.
 
 `ovos-media` does not implement audio or video playback itself. Actual media playback is delegated to backend plugins discovered at runtime via `ovos-plugin-manager` (OPM). There are three backend types, each managed by a dedicated `BaseMediaService` subclass:
 
-| Backend type | Manager class | Content type |
-| :--- | :--- | :--- |
-| Audio | `AudioService` — `ovos_media/media_backends/audio.py` | Audio streams and files |
-| Video | `VideoService` — `ovos_media/media_backends/video.py` | Video streams and files |
-| Web | `WebService` — `ovos_media/media_backends/web.py` | Web views (`MediaType.WEBVIEW`) |
+| Backend type | Manager class | Content type | Entry-point group |
+| :--- | :--- | :--- | :--- |
+| Audio | `AudioService` (`ovos_media/media_backends/audio.py`) | Audio streams and files | `opm.media.audio` |
+| Video | `VideoService` (`ovos_media/media_backends/video.py`) | Video streams and files | `opm.media.video` |
+| Web | `WebService` (`ovos_media/media_backends/web.py`) | Web views (`PlaybackType.WEBVIEW`) | `opm.media.web` |
 
-All three classes inherit from `BaseMediaService` — `ovos_media/media_backends/base.py:17`, which provides shared plugin loading, bus event registration, and backend-selection logic.
+All three classes inherit from `BaseMediaService` (`ovos_media/media_backends/base.py`), which provides shared plugin loading, bus event registration, and backend-selection logic.
+
+### Dual-target plugins (ovos-media and legacy ovos-audio)
+
+A backend plugin can serve **both** the new `ovos-media` daemon and the legacy
+`ovos-audio` AudioService at once. Plugins do this by declaring two entry points
+in their `pyproject.toml`:
+
+```toml
+[project.entry-points."opm.media.audio"]
+ovos-media-audio-plugin-vlc = "ovos_media_plugin_vlc:VLCOCPAudioService"
+
+[project.entry-points."mycroft.plugin.audioservice"]
+ovos-vlc = "ovos_media_plugin_vlc:load_service"
+```
+
+- `opm.media.audio` (/`.video`/`.web`) is what `ovos-media` discovers and loads.
+- `mycroft.plugin.audioservice` is the legacy group consumed by `ovos-audio`'s
+  old AudioService.
+
+The published plugins (`ovos-media-plugin-vlc`, `-mplayer`, `-simple`, `-spotify`,
+`-chromecast`, `-ffplay`, `-mass`, `-mpris`) ship both so the same install works
+on either stack. When writing your own backend you only need the
+`opm.media.audio` group for `ovos-media`; add the legacy group only if you also
+want to support unmigrated `ovos-audio` deployments.
 
 ---
 
 ## Plugin Discovery
 
-Plugin discovery runs at startup in `BaseMediaService.load_services` — `ovos_media/media_backends/base.py:75`.
+Plugin discovery runs at startup in `BaseMediaService.load_services`.
 
 The method:
 
 1. Calls the injected `plugin_loader` callable to obtain a dict of `{plugin_name: plugin_class}` for all installed OPM plugins of that type.
-2. Iterates the `media.<namespace>_players` configuration block (e.g. `media.audio_players` for audio). Each entry names a plugin module and optional aliases. Plugins absent from the installed set are skipped with an error log; plugins with `active: false` are skipped with an info log.
-3. Instantiates each accepted plugin and appends it to either the `local` or `remote` list depending on whether the instance is a subclass of `RemoteAudioPlayerBackend`, `RemoteVideoPlayerBackend`, or `RemoteWebPlayerBackend` — `ovos_media/media_backends/base.py:97`.
-4. Concatenates `local + remote` into `self.services` — `ovos_media/media_backends/base.py:106`, ensuring local backends are checked before remote ones.
-5. Registers the `ovos.common_play.media.state` bus event and the per-namespace service control events — `ovos_media/media_backends/base.py:113`.
-6. Sets a `MonotonicEvent` (`self._loaded`) to signal that loading is complete — `ovos_media/media_backends/base.py:127`.
+2. Iterates the `media.<namespace>_players` configuration block (e.g. `media.audio_players` for audio). Each entry names a plugin `module` and optional `aliases`. Plugins absent from the installed set are skipped with an error log; plugins with `active: false` are skipped with an info log.
+3. Instantiates each accepted plugin as `plugin_class(plug_cfg, bus)` and appends it to either the `local` or `remote` list depending on whether the instance is a `RemoteAudioPlayerBackend` / `RemoteVideoPlayerBackend` / `RemoteWebPlayerBackend`.
+4. Concatenates `local + remote` into `self.services`, ensuring local backends are checked before remote ones.
+5. Registers the `ovos.common_play.media.state` bus event and the per-namespace `ovos.<namespace>.service.*` control events.
+6. Sets a `MonotonicEvent` (`self._loaded`) to signal that loading is complete.
+
+If no backends load at all, an error is logged and a `MediaState.NO_MEDIA` event
+is emitted, since all playback for that namespace would otherwise silently fail.
 
 ### Preferred backend resolution
 
-`OCPMediaPlayer._resolve_preferred_service` — `ovos_media/player.py:650` reads the preferred backend list from `AudioService.get_preferred_players` — `ovos_media/media_backends/audio.py:21` (or the equivalent for video/web), which returns the value of `config.get("preferred_audio_services")` / `preferred_video_services` / `preferred_web_services`. It then walks `media_service.services` looking for a backend whose `.name` or `.aliases` match any name in that list. The first match is returned as the preferred backend; if no match is found, `None` is returned and the default URI-type matching logic applies.
+`OCPMediaPlayer._resolve_preferred_service` reads the preferred backend list from `<Service>.get_preferred_players()`, which returns the value of `preferred_audio_services` / `preferred_video_services` / `preferred_web_services` (falling back to every loaded backend's name when no preference is configured). It then walks `media_service.services` looking for a backend whose `.name` or `.aliases` match any name in that list. The first match is returned as the preferred backend; if no match is found, `None` is returned and the default URI-type matching logic in `BaseMediaService.play` applies.
 
 ---
 
 ## Audio Backends
 
-- **Class**: `AudioService` — `ovos_media/media_backends/audio.py`
+- **Class**: `AudioService` (`ovos_media/media_backends/audio.py`)
 - **Entry-point group**: `opm.media.audio`
 - **OPM plugin loader**: `ovos_plugin_manager.ocp.find_ocp_audio_plugins`
 - **Config key**: `media.audio_players`
 - **Preferred service config key**: `media.preferred_audio_services`
 
-Example plugins: `ovos-media-plugin-vlc`, `ovos-media-plugin-mplayer`, `ovos-media-plugin-simple`, `ovos-media-plugin-spotify`, `ovos-media-plugin-chromecast`.
+Example plugins (pip package → entry-point `module` name):
+`ovos-media-plugin-vlc` (`ovos-media-audio-plugin-vlc`),
+`ovos-media-plugin-mplayer` (`ovos-media-audio-plugin-mplayer`),
+`ovos-media-plugin-simple` (`ovos-media-audio-plugin-cli`),
+`ovos-media-plugin-ffplay` (`ovos-media-audio-plugin-ffplay`),
+`ovos-media-plugin-spotify` (`ovos-media-audio-plugin-spotify`),
+`ovos-media-plugin-chromecast` (remote, `ovos-media-audio-plugin-chromecast`),
+`ovos-media-plugin-mass` (Music Assistant),
+`ovos-media-plugin-mpris` (drives an external MPRIS player).
 
 Audio backends support: play, pause, resume, stop, seek, volume ducking, track position query, and track length query. URI type support is plugin-specific (e.g. `http`, `https`, `file`).
 
@@ -57,41 +92,41 @@ Audio backends support: play, pause, resume, stop, seek, volume ducking, track p
 
 ## Video Backends
 
-- **Class**: `VideoService` — `ovos_media/media_backends/video.py`
+- **Class**: `VideoService` (`ovos_media/media_backends/video.py`)
 - **Entry-point group**: `opm.media.video`
 - **OPM plugin loader**: `ovos_plugin_manager.ocp.find_ocp_video_plugins`
 - **Config key**: `media.video_players`
 - **Preferred service config key**: `media.preferred_video_services`
 
-Video backends are selected when `now_playing.playback == PlaybackType.VIDEO` — `ovos_media/player.py:802`. They render video content; the GUI namespace used for display is managed by the backend plugin, not by the `"ovos.common_play"` GUIInterface.
+Example plugins: `ovos-media-plugin-vlc` (`ovos-media-video-plugin-vlc`),
+`ovos-media-plugin-mplayer` (`ovos-media-video-plugin-mplayer`),
+`ovos-media-plugin-chromecast` (`ovos-media-video-plugin-chromecast`).
+
+Video backends are selected when `now_playing.playback == PlaybackType.VIDEO`. They render video content; the GUI namespace used for display is managed by the backend plugin, not by the `"ovos.common_play"` GUIInterface.
 
 ---
 
 ## Web Backends
 
-- **Class**: `WebService` — `ovos_media/media_backends/web.py`
+- **Class**: `WebService` (`ovos_media/media_backends/web.py`)
 - **Entry-point group**: `opm.media.web`
 - **OPM plugin loader**: `ovos_plugin_manager.ocp.find_ocp_web_plugins`
 - **Config key**: `media.web_players`
 - **Preferred service config key**: `media.preferred_web_services`
 
-Web backends are selected when `now_playing.playback == PlaybackType.WEBVIEW` — `ovos_media/player.py:807`. They display arbitrary web URLs inside a GUI WebView component.
+Web backends are selected when `now_playing.playback == PlaybackType.WEBVIEW`. They display arbitrary web URLs inside a GUI WebView component.
 
 ---
 
 ## BaseMediaService API
 
-`BaseMediaService` — `ovos_media/media_backends/base.py:17` provides the following methods that backend manager classes inherit. Individual plugin instances (subclasses of `MediaBackend` from OPM) implement the actual playback logic.
+`BaseMediaService` (`ovos_media/media_backends/base.py`) provides the following methods that backend manager classes inherit. Individual plugin instances (subclasses of `MediaBackend` from OPM) implement the actual playback logic.
 
 ### `available_backends()`
 
-`BaseMediaService.available_backends — ovos_media/media_backends/base.py:43`
-
-Returns a dict of `{backend_name: {"supported_uris": [...], "remote": bool}}` for every loaded service instance. Used by `MediaService.handle_opm_audio_query` — `ovos_media/service.py:92` to respond to OPM discovery queries.
+Returns a dict of `{backend_name: {"supported_uris": [...], "remote": bool}}` for every loaded service instance. Used by `MediaService.handle_opm_audio_query` to respond to OPM discovery queries.
 
 ### `play(uri, preferred_service=None)`
-
-`BaseMediaService.play — ovos_media/media_backends/base.py:250`
 
 Selects the appropriate backend for `uri` (by URI scheme prefix) and calls `backend.load_track(uri)`. Selection order:
 
@@ -103,28 +138,17 @@ If no backend supports the URI, playback is skipped with a log message.
 
 ### `pause()` / `resume()` / `stop()`
 
-`BaseMediaService.pause — ovos_media/media_backends/base.py:165`
-`BaseMediaService.resume — ovos_media/media_backends/base.py:179`
-`BaseMediaService.stop — ovos_media/media_backends/base.py:210`
-
-Delegate to `self.current.pause()` / `resume()` / `stop()` and emit the corresponding OCP state events. `stop` only fires if at least 1 second has elapsed since playback started (guard against accidental immediate stop) — `ovos_media/media_backends/base.py:219`.
+Delegate to `self.current.pause()` / `resume()` / `stop()` and emit the corresponding OCP state events. `stop` only fires if at least 1 second has elapsed since playback started (guard against accidental immediate stop).
 
 ### `lower_volume()` / `restore_volume()`
 
-`BaseMediaService.lower_volume — ovos_media/media_backends/base.py:227`
-`BaseMediaService.restore_volume — ovos_media/media_backends/base.py:241`
-
-Ducking hooks. `lower_volume` calls `self.current.lower_volume()` and sets `self.volume_is_low = True`. `restore_volume` calls `self.current.restore_volume()` and clears the flag. These are invoked by the `ovos.common_play.duck` / `ovos.common_play.unduck` bus events, which are also aliased to the legacy `recognizer_loop:audio_output_start` / `recognizer_loop:audio_output_end` events — `ovos_media/player.py:418`.
+Ducking hooks. `lower_volume` calls `self.current.lower_volume()` and sets `self.volume_is_low = True`. `restore_volume` calls `self.current.restore_volume()` and clears the flag. These are invoked by the `ovos.common_play.duck` / `ovos.common_play.unduck` bus events, which are also aliased to the legacy `recognizer_loop:audio_output_start` / `recognizer_loop:audio_output_end` events.
 
 ### `handle_media_state_change(message)`
 
-`BaseMediaService.handle_media_state_change — ovos_media/media_backends/base.py:133`
-
-Listens for `ovos.common_play.media.state`. When `MediaState.LOADED_MEDIA` is received and `self.current` is set, calls `self.current.play()` and emits the appropriate `ovos.common_play.track.state` (PLAYING_AUDIO, PLAYING_VIDEO, or PLAYING_WEBVIEW depending on `self.namespace`).
+Listens for `ovos.common_play.media.state`. When `MediaState.LOADED_MEDIA` is received and `self.current` is set, calls `self.current.play()` and emits the appropriate `ovos.common_play.track.state` (`PLAYING_AUDIO`, `PLAYING_VIDEO`, or `PLAYING_WEBVIEW` depending on `self.namespace`).
 
 ### `wait_for_load(timeout=180)`
-
-`BaseMediaService.wait_for_load — ovos_media/media_backends/base.py:155`
 
 Blocks until plugin loading completes or the timeout expires. Returns `True` on success.
 
@@ -132,7 +156,7 @@ Blocks until plugin loading completes or the timeout expires. Returns `True` on 
 
 ## Playback Type Routing
 
-`OCPMediaPlayer.play` — `ovos_media/player.py:763` checks `self.playback_type` (which reads `self.now_playing.playback`) and routes to the correct service:
+`OCPMediaPlayer.play` checks `self.playback_type` (which reads `self.now_playing.playback`) and routes to the correct service:
 
 ```
 PlaybackType.AUDIO   -> audio_service.play(uri, preferred_service)
@@ -141,9 +165,9 @@ PlaybackType.WEBVIEW -> web_service.play(uri, preferred_service)
 PlaybackType.SKILL   -> emit ovos.common_play.<skill_id>.play
 ```
 
-The `preferred_service` argument in each case is resolved by `_resolve_preferred_service` — `ovos_media/player.py:650`.
+The `preferred_service` argument in each case is resolved by `_resolve_preferred_service`.
 
-Before routing, `OCPMediaPlayer.validate_stream` — `ovos_media/player.py:675` calls `NowPlaying.extract_stream()` to resolve any stream extractor identifiers (SEIs) into real URIs. If no GUI is connected or `force_audioservice` is set in config, the playback type is coerced to `PlaybackType.AUDIO` regardless of the original value — `ovos_media/player.py:693`.
+Before routing, `OCPMediaPlayer.validate_stream` calls `NowPlaying.extract_stream()` to resolve any stream extractor identifiers (SEIs) into real URIs. If no GUI is connected, `force_audioservice` is set, or `playback_mode == PlaybackMode.FORCE_AUDIO`, the playback type is coerced to `PlaybackType.AUDIO` regardless of the original value. `PlaybackType.SKILL` and `PlaybackType.MPRIS` skip stream extraction entirely (the skill or external player owns the stream).
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,15 +35,13 @@ Minimal example:
 }
 ```
 
-`MediaService.__init__` reads this section via `Configuration().get("media", {})` — `ovos_media/service.py:47`.
-
-`OCPMediaPlayer.__init__` stores it as `self.ocp_config` — `ovos_media/player.py:345`.
+`MediaService.__init__` reads this section via `Configuration().get("media", {})`, and `OCPMediaPlayer.__init__` stores it as `self.ocp_config`.
 
 ---
 
 ## Backend Selection
 
-`OCPMediaPlayer._resolve_preferred_service` — `ovos_media/player.py:650`
+`OCPMediaPlayer._resolve_preferred_service`
 
 When `ovos-media` is about to play a track it resolves a preferred backend by
 walking the ordered list of names in the relevant config key and returning the
@@ -53,8 +51,8 @@ match is found, any available backend is used.
 | Key | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
 | `preferred_audio_services` | list of strings | `[]` | Ordered preference list for audio backends (e.g. `["vlc", "mpv", "simple"]`). Also used as a generic fallback when no type-specific list is set. |
-| `preferred_video_services` | list of strings | `[]` | Ordered preference list for video backends. Read by `VideoService.get_preferred_players` — `ovos_media/media_backends/video.py:21`. |
-| `preferred_web_services` | list of strings | `[]` | Ordered preference list for web/webview backends. Read by `WebService.get_preferred_players` — `ovos_media/media_backends/web.py:21`. |
+| `preferred_video_services` | list of strings | `[]` | Ordered preference list for video backends. |
+| `preferred_web_services` | list of strings | `[]` | Ordered preference list for web/webview backends. |
 
 Backend plugin names are the entry-point keys registered under `opm.media.audio`,
 `opm.media.video`, or `opm.media.web` in each plugin's `pyproject.toml`.
@@ -79,18 +77,24 @@ loads-time-disables a backend without removing it.
     "video_players": {
       "vlc": { "module": "ovos-media-video-plugin-vlc", "aliases": ["VLC"], "active": true }
     },
-    "web_players": {
-      "browser": { "module": "ovos-media-web-plugin-browser", "aliases": ["Browser"], "active": true }
-    }
+    "web_players": {}
   }
 }
 ```
 
+Web backends register under `opm.media.web`; add their declarations to
+`web_players` once one is installed.
+
 | Key | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `audio_players` | dict | `{}` | Audio backends to load, keyed by local name. |
-| `video_players` | dict | `{}` | Video backends to load. |
-| `web_players` | dict | `{}` | Web/webview backends to load. |
+| `audio_players` | dict | `{}` | Audio backends to load (`opm.media.audio`), keyed by local name. |
+| `video_players` | dict | `{}` | Video backends to load (`opm.media.video`). |
+| `web_players` | dict | `{}` | Web/webview backends to load (`opm.media.web`). |
+
+The `module` value is the plugin's **entry-point name** (e.g.
+`ovos-media-audio-plugin-vlc`), which often differs from its pip package name
+(`ovos-media-plugin-vlc`). See [backends.md](backends.md) for each plugin's
+entry-point name.
 
 Any additional keys inside a player entry are passed through to that backend
 plugin's own `config` dict. See [backends.md](backends.md) for the backend API.
@@ -101,16 +105,14 @@ plugin's own `config` dict. See [backends.md](backends.md) for the backend API.
 
 | Key | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `autoplay` | bool | `true` | Automatically start playback when search results arrive. Checked at `ovos_media/player.py:1074`. |
-| `merge_search` | bool | `true` | Merge incoming search results into the existing playlist rather than replacing it. Checked at `ovos_media/player.py:565`. |
-| `force_audioservice` | bool | `false` | Force audio-only playback even when a GUI is connected; bypasses video backend selection. Checked at `ovos_media/player.py:690`. |
-| `playback_mode` | string | `""` | Set to `"force_audio"` (`PlaybackMode.FORCE_AUDIO`) to always use audio backends regardless of GUI availability. Checked at `ovos_media/player.py:691`. |
+| `autoplay` | bool | `true` | Automatically advance to the next track when the current one ends (and on invalid media). |
+| `merge_search` | bool | `true` | Merge incoming search results into the playback queue alongside the user playlist rather than ignoring them. |
+| `force_audioservice` | bool | `false` | Force audio-only playback even when a GUI is connected; bypasses video/web backend selection. |
+| `playback_mode` | enum | unset | Set to `PlaybackMode.FORCE_AUDIO` to always use audio backends regardless of GUI availability. |
 
 ---
 
 ## MPRIS Integration
-
-`OcpMprisExporter` — `ovos_media/mpris.py:57`
 
 MPRIS (Media Player Remote Interfacing Specification) is the standard D-Bus
 protocol used by desktop environments to control media players. When enabled,
@@ -120,12 +122,11 @@ media widget, and similar tools.
 
 | Key | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `enable_mpris` | bool | `false` | Start the D-Bus MPRIS exporter. When `false`, `self.mpris` is set to `None` and no D-Bus registration occurs. Checked at `ovos_media/player.py:384`. |
-| `manage_external_players` | bool | `false` | Role B behaviour: poll for external MPRIS players and pause OCP when another player becomes active; also proxies skip/pause/shuffle/repeat to the external player. Read by `OcpMprisExporter.__init__` — `ovos_media/mpris.py:99`. |
-| `ignored_players` | list of strings | `["org.mpris.MediaPlayer2.OCP", "org.mpris.MediaPlayer2.plasma-browser-integration"]` | D-Bus player names excluded from external player scanning. Read by `OcpMprisExporter.__init__` — `ovos_media/mpris.py:100`. |
-| `mpris_poll_interval` | int (seconds) | `1` | Interval between external player scans. Only relevant when `manage_external_players` is `true`. Read inside `OcpMprisExporter.event_loop` — `ovos_media/mpris.py:633`. |
-
-`OcpMprisExporter.event_loop` — `ovos_media/mpris.py:575`
+| `enable_mpris` | bool | `false` | Start the D-Bus MPRIS exporter. When `false`, `self.mpris` is `None` and no D-Bus registration occurs. |
+| `manage_external_players` | bool | `false` | Role B behaviour: poll for external MPRIS players and pause OCP when another player becomes active; also proxies skip/pause/shuffle/repeat to the external player. |
+| `ignored_players` | list of strings | `["org.mpris.MediaPlayer2.OCP", "org.mpris.MediaPlayer2.plasma-browser-integration"]` | D-Bus player names excluded from external player scanning. |
+| `mpris_poll_interval` | int (seconds) | `1` | Interval between external player scans. Only relevant when `manage_external_players` is `true`. |
+| `dbus_type` | string | `"session"` | `"session"` or `"system"` D-Bus to connect to. |
 
 The event loop runs two passes per poll interval when `manage_external_players`
 is `true`: one `scan_players` call followed by a `query_player` pass over all
@@ -139,9 +140,7 @@ control-signal checks.
 
 | Key | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `native_sources` | list of strings | `["debug_cli", "audio"]` | Message sources treated as trusted native callers. Requests from these sources bypass skill-search validation. |
-
-`MediaService.__init__` — `ovos_media/service.py:48`
+| `native_sources` | list of strings | `["debug_cli", "audio"]` | Message sources treated as trusted native callers. Requests from these sources bypass message-context validation in the backend services. Read by `MediaService.__init__`. |
 
 ---
 
@@ -159,6 +158,7 @@ control-signal checks.
     "enable_mpris": true,
     "manage_external_players": true,
     "mpris_poll_interval": 2,
+    "dbus_type": "session",
     "ignored_players": [
       "org.mpris.MediaPlayer2.OCP",
       "org.mpris.MediaPlayer2.plasma-browser-integration",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,16 +73,21 @@ readiness via the `ProcessStatus` machinery (`ovos_media/__main__.py`).
 ### Running it embedded
 
 ```python
+from ovos_utils import wait_for_exit_signal
 from ovos_media.service import MediaService
 
-svc = MediaService()
-svc.start()   # starts the daemon thread
-svc.run()     # marks ProcessStatus READY; returns
+svc = MediaService()   # connects to the bus, builds OCPMediaPlayer
+svc.daemon = True
+svc.start()            # starts the daemon thread; run() marks ProcessStatus READY
+wait_for_exit_signal()
+svc.shutdown()
 ```
 
 `MediaService.__init__` reads the `media` section of `mycroft.conf` / `ovos.conf`,
-creates an `OCPMediaPlayer`, and wires up the bus handlers. Calling `run()` emits
-the `READY` status signal.
+opens (or reuses) a `MessageBusClient`, creates an `OCPMediaPlayer`, installs the
+`LegacyAudioServiceCompat` shim, and wires up the bus handlers. The thread's
+`run()` emits the `READY` status signal. This is exactly what the `ovos-media`
+console entry point (`ovos_media/__main__.py`) does.
 
 ---
 
@@ -113,7 +118,7 @@ bus.emit(Message("ovos.common_play.ping"))
 # expect an "ovos.common_play.pong" reply
 ```
 
-`MediaService.handle_ping` — `ovos_media/service.py`.
+(handled by `MediaService.handle_ping`).
 
 ---
 
@@ -137,7 +142,7 @@ bus.emit(Message("ovos.common_play.ping"))
 | `ovos-bus-client` | WebSocket MessageBus client |
 | `ovos-config` | Configuration loader (`mycroft.conf` / `ovos.conf`) |
 | `ovos-plugin-manager` | Backend and media-provider plugin discovery via entry points |
-| `ovos-workshop` | Base application classes |
+| `ovos-workshop` | `OVOSCommonPlaybackSkill` base used by the built-in liked-songs catalog, plus OCP decorators |
 | `ovos-gui-api-client` | GUI interface (`GUIInterface`) for the media player screen |
 | `json-database` | Persistent liked-songs storage (`JsonStorageXDG`) |
 | `dbus-next` | Async D-Bus implementation used by the MPRIS exporter |

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,9 +35,9 @@ Every arrow is a plugin boundary, so each concern can be replaced independently:
 | Concern | Plugin group | Examples |
 |---|---|---|
 | **Find media** (catalog/search) | `opm.media.provider` | youtube, bandcamp, soundcloud, tunein, somafm, pyradios |
-| **Play audio** | `opm.media.audio` | vlc, mplayer, simple, spotify, chromecast |
-| **Play video** | `opm.media.video` | vlc, mpv, chromecast |
-| **Render web/webview** | `opm.media.web` | browser, gui |
+| **Play audio** | `opm.media.audio` | vlc, mplayer, simple (cli), ffplay, spotify, chromecast, mass, mpris |
+| **Play video** | `opm.media.video` | vlc, mplayer, chromecast |
+| **Render web/webview** | `opm.media.web` | rendered via the GUI WebView |
 | **Resolve a stream URI** | `opm.ocp.extractor` | youtube, m3u, rss, files |
 
 Search results flow as [`mediavocab.Release`](https://github.com/TigreGotico/mediavocab)

--- a/docs/media-providers.md
+++ b/docs/media-providers.md
@@ -5,11 +5,12 @@ returns candidate playables. Providers are the layer that turns *"play Viagra
 Boys"* into a ranked list of streamable tracks, and they are the catalog layer
 of the `ovos-media` stack.
 
-Providers supersede the older OCP *search skills* (`OVOSCommonPlaybackSkill` +
-`@ocp_search`). Instead of broadcasting `ovos.common_play.query` over the bus and
-waiting for skills to answer, the OCP pipeline loads providers **in-process**,
-gates each one by routing, and calls its `search()` method directly. See
-[Migration: from OCP search skills](#migration-from-ocp-search-skills) below.
+Providers are the in-process replacement for the older OCP *search skills*
+(`OVOSCommonPlaybackSkill` + `@ocp_search`). Instead of broadcasting
+`ovos.common_play.query` over the bus and waiting for skills to answer, the OCP
+pipeline loads providers **in-process** and calls each provider's `search()`
+method directly. See [Migration: from OCP search skills](#migration-from-ocp-search-skills)
+below.
 
 ---
 
@@ -23,51 +24,70 @@ Providers register under the `opm.media.provider` entry-point group and subclass
 bandcamp = "ovos_media_provider_bandcamp:BandcampMediaProvider"
 ```
 
-The entry-point key (`bandcamp`) is the provider's registry name and its
-per-instance config key under `media_providers`.
+The entry-point key (`bandcamp`) is the provider's registry name, its `skill_id`
+downstream, and its per-instance config key under `media_providers`.
 
 ---
 
-## The three-axis routing contract
+## The contract: one method
 
-Every provider declares three class-level sets that let the pipeline skip it
-*before* paying for a search. This mirrors mediavocab's canonical routing gate
-(`mediavocab.models.protocols.provider_matches`):
-
-| Class attribute | Type | Meaning | Empty set means |
-|---|---|---|---|
-| `media` | `set[mediavocab.MediaType]` | Which media types the provider serves (`MUSIC`, `RADIO`, `PODCAST`, `MOVIE`, …) | universal — matches any media type |
-| `playback_type` | `set[mediavocab.taxonomy.PlaybackType]` | Player surface: `AUDIO`, `VIDEO`, `PAGED`, `INTERACTIVE` | universal — matches any surface |
-| `genre_filter` | `set[str]` | Genre tags (`mediavocab.taxonomy.genre`) the provider is scoped to | no genre gate |
-
-> **Two `PlaybackType` enums.** The routing axis here is
-> `mediavocab.taxonomy.PlaybackType` (`AUDIO`/`VIDEO`/`PAGED`/`INTERACTIVE`),
-> which is distinct from `ovos_utils.ocp.PlaybackType` (the backend selector used
-> by the daemon when it picks an audio/video/web player). The two are bridged in
-> the pipeline and player — not inside a provider.
-
-The default `matches(signals)` implementation applies all three axes. Override it
-only if your provider needs routing logic the three sets cannot express.
-
----
-
-## The `search()` contract
+`MediaProvider` has a **single abstract method**:
 
 ```python
-def search(self, signals: Signals, lang: str = "en-us") -> list[Release]:
+def search(self, signals: Signals, lang: str = "en-us",
+           **context) -> list[Release]:
     ...
 ```
+
+There is nothing else to implement. There is no `is_available`, no `matches`, no
+`serves`, no routing class attributes, and no `QueryContext` object — a provider
+decides for itself whether it can serve a query and returns an empty list when it
+cannot. Availability and routing are the provider's own concern.
+
+```python
+class MediaProvider(metaclass=ABCMeta):
+    name: ClassVar[str] = ""        # stable registry key / downstream skill_id
+
+    def __init__(self, config: Optional[dict] = None):
+        self.config = config or {}
+
+    @abstractmethod
+    def search(self, signals, lang="en-us", **context) -> list[Release]: ...
+
+    def shutdown(self) -> None:     # optional — release resources
+        ...
+```
+
+### Arguments
 
 - **`signals`** is a `mediavocab.Signals` — the parsed request. The fields a
   provider usually reads are `signals.title` (the search phrase) and
   `signals.artist` (artist, or director for video). `signals.medium` carries the
   classified `MediaType` and `signals.content_genres` the requested genres.
-- **Return** zero or more `mediavocab.Release` objects. Each `Release` is a
-  typed, playable catalog entry shared across the whole media ecosystem. A
-  provider returns **playables**, not identities — drop artist/label hits.
-- **Ranking** rides on each result via `Release.match_confidence` (`0.0`–`1.0`).
-  The pipeline filters and ranks *across* all providers, so you only need to
-  score within your own results.
+- **`lang`** is the BCP-47 language tag for the request (default `"en-us"`).
+- **`**context`** carries whatever the pipeline knows about the request
+  environment. A provider reads the kwargs it cares about and ignores the rest.
+  Recognised keys include:
+
+  | Context kwarg | Meaning |
+  |---|---|
+  | `supported_playback_types` | which player surfaces the requesting device can render (so a video-only provider can bail out on an audio-only device) |
+  | `blocked_genres` | genres the session/profile has blocked |
+  | `region` | the requester's region/country, for geo-scoped catalogs |
+  | `session_id` | the originating MessageBus session |
+
+### Return value
+
+Return zero or more `mediavocab.Release` objects. Each `Release` is a typed,
+playable catalog entry shared across the whole media ecosystem. A provider
+returns **playables**, not identities — drop artist/label hits. Return an empty
+list `[]` whenever the provider cannot serve the query: wrong media type, the
+device can't render the result, a blocked genre, no network or API key, no
+match, and so on.
+
+**Ranking** rides on each result via `Release.match_confidence` (`0.0`–`1.0`).
+The pipeline filters and ranks *across* all providers, so a provider only needs
+to score within its own results.
 
 ### `mediavocab.Release` in brief
 
@@ -97,40 +117,21 @@ does not resolve streams itself. See [Architecture](architecture.md) and
 
 ---
 
-## Lifecycle methods
-
-| Method | Required | Purpose |
-|---|---|---|
-| `is_available() -> bool` | yes | Return `True` only when the provider can run now — API keys present, optional deps importable, network reachable. Unavailable providers are skipped at load. |
-| `search(signals, lang) -> list[Release]` | yes | The search itself (above). |
-| `featured_media(lang) -> list[Release]` | no | Curated/home content for the browse screen. Defaults to `[]`. |
-| `matches(signals) -> bool` | no | Routing gate; defaults to the three-axis test. |
-| `shutdown()` | no | Release any held resources. |
-
-The pipeline calls providers through `search_safe()`, which wraps `search()` so a
-single misbehaving provider cannot abort a multi-provider dispatch — it logs and
-returns `[]` on error.
-
----
-
 ## How the pipeline discovers and dispatches providers
 
-Discovery and instantiation live in `ovos_plugin_manager.media_provider`:
+The OCP pipeline loads every installed `opm.media.provider` entry point,
+instantiating each with its per-provider config (`media_providers.<name>`) and
+skipping any whose config sets `"enabled": false`.
 
-1. `find_media_provider_plugins()` enumerates every installed `opm.media.provider`
-   entry point.
-2. `load_media_providers(config)` instantiates each one with its per-provider
-   config (`media_providers.<name>`), skips any whose config sets
-   `"enabled": false`, and skips any whose `is_available()` returns `False`.
-   It returns a `dict` of `{name: instance}`.
-
-At query time the OCP pipeline:
+At query time the pipeline:
 
 1. Classifies the utterance into a `Signals` (media type, title, artist, genres).
-2. Gates the loaded providers with `provider.matches(signals)`, dropping any
-   whose routing axes exclude the query.
-3. Dispatches `search_safe(signals, lang)` to the surviving providers
-   **concurrently** (thread pool).
+2. Builds the `**context` (supported playback types, blocked genres, region,
+   session) from the requesting session's state.
+3. Calls `search(signals, lang, **context)` on each loaded provider
+   **concurrently** (thread pool). A provider that cannot serve the request
+   returns `[]`; a misbehaving provider that raises is caught and treated as `[]`
+   so it cannot abort a multi-provider dispatch.
 4. Collects, filters, and ranks the returned `Release` objects across providers,
    then hands the winner(s) to the `ovos-media` daemon to play.
 
@@ -144,11 +145,10 @@ announce/response handshake.
 A complete provider over a client library that already emits `Release` objects:
 
 ```python
-from typing import ClassVar, List, Optional, Set
+from typing import ClassVar, List, Optional
 
 from ovos_utils.log import LOG
-from mediavocab import MediaType, Release, Signals, Entity
-from mediavocab.taxonomy import PlaybackType
+from mediavocab import Release, Signals
 from ovos_plugin_manager.templates.media_provider import MediaProvider
 
 from py_bandcamp import BandCamp
@@ -158,23 +158,18 @@ class BandcampMediaProvider(MediaProvider):
     """Search Bandcamp's public catalog for playable music releases."""
 
     name: ClassVar[str] = "bandcamp"
-    media: ClassVar[Set[MediaType]] = {MediaType.MUSIC}
-    playback_type: ClassVar[Set[PlaybackType]] = {PlaybackType.AUDIO}
 
     def __init__(self, config: Optional[dict] = None):
         super().__init__(config)
         self.max_pages = self.config.get("max_pages", 1)
 
-    def is_available(self) -> bool:
-        # public search endpoint, no API key required
-        return True
-
-    def search(self, signals: Signals, lang: str = "en-us") -> List[Release]:
+    def search(self, signals: Signals, lang: str = "en-us",
+               **context) -> List[Release]:
         title = (signals.title or "").strip()
         artist = (signals.artist or "").strip()
         query = " ".join(p for p in (artist, title) if p).strip()
         if not query:
-            return []
+            return []  # nothing to search for
 
         results: List[Release] = []
         try:
@@ -186,7 +181,7 @@ class BandcampMediaProvider(MediaProvider):
                 # Entity (artist/label identity) hits are not playable — skip
         except Exception:
             LOG.exception("Bandcamp search failed")
-            return []
+            return []  # no network / API failure — serve nothing
         return results
 ```
 
@@ -197,6 +192,10 @@ Register it in `pyproject.toml`:
 bandcamp = "ovos_media_provider_bandcamp:BandcampMediaProvider"
 ```
 
+Notice the provider never declares what it serves up front: if the query is for a
+movie, Bandcamp's client simply returns nothing and the provider yields `[]`.
+That is the whole gating contract.
+
 ---
 
 ## Existing providers
@@ -204,15 +203,15 @@ bandcamp = "ovos_media_provider_bandcamp:BandcampMediaProvider"
 Each wraps a standalone scraper/client library that emits `mediavocab.Release`
 objects, and each replaces a legacy OCP search skill.
 
-| Provider | Entry point | Routing (`media` → `playback_type`) | Replaces |
+| Provider | Entry point | Serves | Replaces |
 |---|---|---|---|
-| [`ovos-media-provider-youtube`](https://github.com/OpenVoiceOS/ovos-media-provider-youtube) | `youtube` | `MOVIE, EPISODIC_SERIES, MUSIC_VIDEO, PODCAST, TV, GENERIC` → `VIDEO, AUDIO` | `ovos-skill-youtube` |
-| [`ovos-media-provider-youtube-music`](https://github.com/OpenVoiceOS/ovos-media-provider-youtube-music) | `youtube_music` | music → `AUDIO` | `ovos-skill-youtube-music` |
-| [`ovos-media-provider-bandcamp`](https://github.com/OpenVoiceOS/ovos-media-provider-bandcamp) | `bandcamp` | `MUSIC` → `AUDIO` | `ovos-skill-bandcamp` |
-| [`ovos-media-provider-soundcloud`](https://github.com/OpenVoiceOS/ovos-media-provider-soundcloud) | `soundcloud` | `MUSIC, PLAYLIST` → `AUDIO` | `ovos-skill-soundcloud` |
-| [`ovos-media-provider-tunein`](https://github.com/OpenVoiceOS/ovos-media-provider-tunein) | `tunein` | `RADIO` → `AUDIO` | `ovos-skill-tunein` |
-| [`ovos-media-provider-somafm`](https://github.com/OpenVoiceOS/ovos-media-provider-somafm) | `somafm` | `RADIO` → `AUDIO` | `ovos-skill-somafm` |
-| [`ovos-media-provider-pyradios`](https://github.com/OpenVoiceOS/ovos-media-provider-pyradios) | `pyradios` | `RADIO` → `AUDIO` | `ovos-skill-pyradios` |
+| [`ovos-media-provider-youtube`](https://github.com/OpenVoiceOS/ovos-media-provider-youtube) | `youtube` | video / music videos / podcasts | `ovos-skill-youtube` |
+| [`ovos-media-provider-youtube-music`](https://github.com/OpenVoiceOS/ovos-media-provider-youtube-music) | `youtube_music` | music | `ovos-skill-youtube-music` |
+| [`ovos-media-provider-bandcamp`](https://github.com/OpenVoiceOS/ovos-media-provider-bandcamp) | `bandcamp` | music | `ovos-skill-bandcamp` |
+| [`ovos-media-provider-soundcloud`](https://github.com/OpenVoiceOS/ovos-media-provider-soundcloud) | `soundcloud` | music / playlists | `ovos-skill-soundcloud` |
+| [`ovos-media-provider-tunein`](https://github.com/OpenVoiceOS/ovos-media-provider-tunein) | `tunein` | radio | `ovos-skill-tunein` |
+| [`ovos-media-provider-somafm`](https://github.com/OpenVoiceOS/ovos-media-provider-somafm) | `somafm` | radio | `ovos-skill-somafm` |
+| [`ovos-media-provider-pyradios`](https://github.com/OpenVoiceOS/ovos-media-provider-pyradios) | `pyradios` | radio | `ovos-skill-pyradios` |
 
 ---
 
@@ -253,9 +252,9 @@ playback halves are unchanged — those live in the OCP pipeline and the
 | Old (OCP search skill) | New (MediaProvider) |
 |---|---|
 | Subclass `OVOSCommonPlaybackSkill` | Subclass `MediaProvider` |
-| `@ocp_search` method returning `MediaEntry`/`Playlist` | `search(signals, lang)` returning `list[Release]` |
+| `@ocp_search` method returning `MediaEntry`/`Playlist` | `search(signals, lang, **context)` returning `list[Release]` |
 | Registered as a skill; replies to `ovos.common_play.query` over the bus | Registered under `opm.media.provider`; called in-process |
-| Routing implied by the skill's vocab and per-result `media_type` | Explicit three-axis routing (`media`, `playback_type`, `genre_filter`) |
+| Routing implied by the skill's vocab and per-result `media_type` | The provider decides per call and returns `[]` when it can't serve |
 | Match score `0`–`100` on each `MediaEntry` | `match_confidence` `0.0`–`1.0` on each `Release` |
 | Provider-specific result dicts | Typed `mediavocab.Release`, shared across the ecosystem |
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -174,6 +174,8 @@ callers keep working.
 | Backend discovery | `opm.audio.query` | `opm.audio.query` (unchanged) |
 | Full status snapshot | — | `ovos.common_play.status` |
 | Like / unlike track | — | `ovos.common_play.like` / `ovos.common_play.unlike` |
+| Reflect external MPRIS player | — | `ovos.common_play.mpris.now_playing` (see [mpris.md](mpris.md)) |
+| Supported stream extractors | — | `ovos.common_play.SEI.get` |
 
 See [architecture.md](architecture.md) for the complete handler and emitted-event
 tables.

--- a/docs/mpris.md
+++ b/docs/mpris.md
@@ -1,17 +1,21 @@
 # MPRIS Integration
 
-MPRIS (Media Player Remote Interfacing Specification) is a D-Bus standard that allows external media controllers — KDE Connect, Plasma media widget, `playerctl`, GNOME Shell, and others — to discover and control any compliant media player on the same desktop session. `ovos-media` implements both sides of this interface: it exposes OCP as a controllable player, and it can optionally observe and manage other MPRIS players running on the same session bus.
+MPRIS (Media Player Remote Interfacing Specification) is a D-Bus standard that allows external media controllers — KDE Connect, Plasma media widget, `playerctl`, GNOME Shell, and others — to discover and control any compliant media player on the same desktop session. `ovos-media` participates in MPRIS in three ways:
+
+1. **OCP as an MPRIS server (Role A, outbound).** OCP exposes itself as a controllable `org.mpris.MediaPlayer2.OCP` player so desktop tools and media keys can drive it.
+2. **External player → OCP now-playing (inbound reflection).** What another MPRIS player is playing is mirrored *into* OCP as its now-playing, without OCP driving any backend, so the GUI and voice queries reflect reality.
+3. **OCP managing external players (Role B, opt-in).** OCP polls the session bus and proxies its transport controls onto a chosen external player.
+
+All three are gated behind `enable_mpris: true`. Roles B and the in-process reflection additionally require `manage_external_players: true`; the inbound reflection also arrives over the bus from the standalone [`ovos-media-plugin-mpris`](https://github.com/OpenVoiceOS/ovos-media-plugin-mpris) watcher.
 
 ## Architecture
 
-The entry point is `OcpMprisExporter` — `ovos_media/mpris.py:57`. It is a `Thread` subclass that runs an `asyncio` event loop and owns two D-Bus service interfaces:
+The entry point is `OcpMprisExporter` (`ovos_media/mpris.py`). It is a `Thread` subclass that runs an `asyncio` event loop and owns two D-Bus service interfaces:
 
-- `_MediaPlayer2Interface` (`org.mpris.MediaPlayer2`) — identity, MIME type list, URI scheme list — `ovos_media/mpris.py:695`
-- `_MediaPlayer2PlayerInterface` (`org.mpris.MediaPlayer2.Player`) — playback state, metadata, transport controls — `ovos_media/mpris.py:760`
+- `_MediaPlayer2Interface` (`org.mpris.MediaPlayer2`) — identity, MIME type list, URI scheme list
+- `_MediaPlayer2PlayerInterface` (`org.mpris.MediaPlayer2.Player`) — playback state, metadata, transport controls
 
-Both interfaces are exported at the object path `/org/mpris/MediaPlayer2` and the well-known name `org.mpris.MediaPlayer2.OCP` is requested from the session bus — `OcpMprisExporter.export_ocp` — `ovos_media/mpris.py:113`.
-
-The backward-compatibility alias `MprisPlayerCtl = OcpMprisExporter` is defined at `ovos_media/mpris.py:692`.
+Both interfaces are exported at the object path `/org/mpris/MediaPlayer2` and the well-known name `org.mpris.MediaPlayer2.OCP` is requested from the session bus (`OcpMprisExporter.export_ocp`).
 
 ## Role A: OCP as an MPRIS player
 
@@ -19,63 +23,98 @@ This role is always active when `enable_mpris: true`. Any MPRIS controller on th
 
 ### Exposed properties
 
-| MPRIS property | Source | Notes |
-|---|---|---|
-| `PlaybackStatus` | `_MediaPlayer2PlayerInterface.PlaybackStatus` — `ovos_media/mpris.py:772` | Maps `PlayerState.PLAYING` → `"Playing"`, `PlayerState.PAUSED` → `"Paused"`, anything else → `"Stopped"` |
-| `Metadata` | `_MediaPlayer2PlayerInterface.Metadata` — `ovos_media/mpris.py:766` | Returns `now_playing.mpris_metadata` when a track is loaded, otherwise an empty dict |
-| `Position` | `_MediaPlayer2PlayerInterface.Position` — `ovos_media/mpris.py:822` | Returns `now_playing.position * 1e6` (microseconds, as required by the MPRIS spec) when a track is loaded, otherwise `0` |
-| `Volume` | `_MediaPlayer2PlayerInterface.Volume` — `ovos_media/mpris.py:807` | Read via `mycroft.volume.get` bus message with a 0.5-second timeout; falls back to `1.0` if no reply |
-| `Shuffle` | `_MediaPlayer2PlayerInterface.Shuffle` — `ovos_media/mpris.py:799` | Mirrors `OCPMediaPlayer.shuffle`; writable |
-| `LoopStatus` | `_MediaPlayer2PlayerInterface.LoopStatus` — `ovos_media/mpris.py:781` | See mapping table below; writable |
-| `Rate` | `_MediaPlayer2PlayerInterface.Rate` — `ovos_media/mpris.py:818` | Always returns `1.0`; not writable |
-| `CanSeek` | `_MediaPlayer2PlayerInterface.CanSeek` — `ovos_media/mpris.py:836` | Always returns `False` |
-| `CanPlay` | `_MediaPlayer2PlayerInterface.CanPlay` — `ovos_media/mpris.py:828` | `True` when `PlayerState.PAUSED` |
-| `CanPause` | `_MediaPlayer2PlayerInterface.CanPause` — `ovos_media/mpris.py:832` | `True` when `PlayerState.PLAYING` |
-| `CanGoNext` | `_MediaPlayer2PlayerInterface.CanGoNext` — `ovos_media/mpris.py:840` | Mirrors `OCPMediaPlayer.can_next` |
-| `CanGoPrevious` | `_MediaPlayer2PlayerInterface.CanGoPrevious` — `ovos_media/mpris.py:844` | Mirrors `OCPMediaPlayer.can_prev` |
-| `CanControl` | `_MediaPlayer2PlayerInterface.CanControl` — `ovos_media/mpris.py:848` | Always `True` |
+| MPRIS property | Notes |
+|---|---|
+| `PlaybackStatus` | Maps `PlayerState.PLAYING` → `"Playing"`, `PlayerState.PAUSED` → `"Paused"`, anything else → `"Stopped"` |
+| `Metadata` | Returns `now_playing.mpris_metadata` when a track is loaded, otherwise an empty dict |
+| `Position` | Returns `now_playing.position * 1e6` (microseconds, as required by the MPRIS spec) when a track is loaded, otherwise `0` |
+| `Volume` | Read via `mycroft.volume.get` bus message with a 0.5-second timeout; falls back to `1.0` if no reply. Writable (`mycroft.volume.set`) |
+| `Shuffle` | Mirrors `OCPMediaPlayer.shuffle`; writable |
+| `LoopStatus` | See mapping table below; writable |
+| `Rate` | Always returns `1.0`; not writable |
+| `CanSeek` | Always returns `False` |
+| `CanPlay` | `True` when `PlayerState.PAUSED` |
+| `CanPause` | `True` when `PlayerState.PLAYING` |
+| `CanGoNext` | Mirrors `OCPMediaPlayer.can_next` |
+| `CanGoPrevious` | Mirrors `OCPMediaPlayer.can_prev` |
+| `CanControl` | Always `True` |
 
 ### LoopStatus mapping
 
-`LoopStatus` translates between the MPRIS string values and the `LoopState` enum from `ovos_utils.ocp`. The getter and setter are defined at `_MediaPlayer2PlayerInterface.LoopStatus` — `ovos_media/mpris.py:781` and `LoopStatus_setter` — `ovos_media/mpris.py:789`.
+`LoopStatus` translates between the MPRIS 2.2 string values (`"None"`, `"Track"`,
+`"Playlist"`) and the `LoopState` enum from `ovos_utils.ocp`. Both the getter and
+the setter use the same canonical MPRIS strings.
 
-| MPRIS string (getter output) | `LoopState` (internal) | MPRIS string (setter input) |
-|---|---|---|
-| `"RepeatTrack"` | `LoopState.REPEAT_TRACK` | `"Track"` |
-| `"Repeat"` | `LoopState.REPEAT` | `"Playlist"` |
-| `"None"` | `LoopState.NONE` | anything else |
-
-Note that the getter returns `"RepeatTrack"` but the setter recognises `"Track"` — this asymmetry matches the MPRIS specification, where the getter uses freeform strings and the setter uses the canonical set `{"None", "Track", "Playlist"}`.
+| MPRIS string | `LoopState` (internal) |
+|---|---|
+| `"Track"` | `LoopState.REPEAT_TRACK` |
+| `"Playlist"` | `LoopState.REPEAT` |
+| `"None"` | `LoopState.NONE` |
 
 ### Volume control
 
-Volume reads and writes are delegated to the OCP bus rather than a direct audio API. Reading sends `mycroft.volume.get` and writing sends `mycroft.volume.set` with `{"percent": value}` — `_MediaPlayer2PlayerInterface.Volume_setter` — `ovos_media/mpris.py:814`.
+Volume reads and writes are delegated to the OCP bus rather than a direct audio API. Reading sends `mycroft.volume.get` and writing sends `mycroft.volume.set` with `{"percent": value}`.
+
+## Inbound reflection: an external player as OCP now-playing
+
+Independent of who *controls* whom, OCP can mirror what an external MPRIS player
+is playing into its own now-playing state — title, artist, art, and player/media
+state — **without driving any OCP backend**. This is the playback-less path: it
+exists so the OCP GUI and voice queries ("what song is this?") reflect a player
+that OCP did not itself start, such as Spotify, a browser, or VLC.
+
+The entry point is `OCPMediaPlayer.set_external_now_playing(data)`, reachable two
+ways:
+
+- **Over the bus** — the `ovos.common_play.mpris.now_playing` message (handled by
+  `OCPMediaPlayer.handle_mpris_now_playing`). The standalone
+  [`ovos-media-plugin-mpris`](https://github.com/OpenVoiceOS/ovos-media-plugin-mpris)
+  watcher runs out-of-process, observes external MPRIS players, and emits this
+  message. This is the recommended way to watch external players.
+- **In-process** — the inline Role B below calls `set_external_now_playing`
+  directly via `_update_ocp` when `manage_external_players` is enabled.
+
+`set_external_now_playing` recognises these keys in `data`:
+
+| Key | Meaning |
+|---|---|
+| `external_player` (or `skill_id`) | the external player's MPRIS bus name — required |
+| `title` / `artist` / `image` / `length` | track metadata (`length` in ms) |
+| `state` | `"Playing"` (default), `"Paused"`, or `"Stopped"` |
+| `skill_icon` | optional player icon |
+
+The reflection sets `playback_type = PlaybackType.MPRIS`, status
+`TrackState.PLAYING_MPRIS`, and updates now-playing + player/media state to match
+`state`. When a *new* external player starts playing (a different player than the
+one currently reflected), it first calls `OCPMediaPlayer.handle_MPRIS_takeover()`
+— stopping OCP's own audio/video/web backends and any active skill — so OCP and
+the external player do not overlap.
 
 ## Role B: External player management
 
-When `manage_external_players: true`, `OcpMprisExporter` additionally scans the session bus for other MPRIS players and coordinates playback between them and OCP.
+When `manage_external_players: true`, `OcpMprisExporter` additionally scans the session bus for other MPRIS players and coordinates playback between them and OCP. The dedicated, recommended home for this is the standalone [`ovos-media-plugin-mpris`](https://github.com/OpenVoiceOS/ovos-media-plugin-mpris) plugin, which also provides a player backend that drives an external MPRIS player. The inline implementation below mirrors that behaviour.
 
 ### Discovery
 
-`OcpMprisExporter.scan_players` — `ovos_media/mpris.py:422` — calls `org.freedesktop.DBus.ListNames` and filters results to names that contain `org.mpris.MediaPlayer2`. Players already tracked, KDE Connect proxy players (`org.mpris.MediaPlayer2.kdeconnect.*`), and players listed in `ignored_players` are skipped. Each new player is introspected and a D-Bus property-change signal handler is attached via `_create_player_handler` — `ovos_media/mpris.py:453`.
+`OcpMprisExporter.scan_players` calls `org.freedesktop.DBus.ListNames` and filters results to names that contain `org.mpris.MediaPlayer2`. Players already tracked, KDE Connect proxy players (`org.mpris.MediaPlayer2.kdeconnect.*`), and players listed in `ignored_players` are skipped. Each new player is introspected and a D-Bus property-change signal handler is attached via `_create_player_handler`.
 
 ### Active player selection
 
-`OcpMprisExporter._set_main_player` — `ovos_media/mpris.py:230` — designates one external player as the "main player". When an external player reports `PlaybackStatus = "Playing"`, it becomes the main player. If a second player also starts playing, the previous one is stopped — `ovos_media/mpris.py:239-246`.
+`OcpMprisExporter._set_main_player` designates one external player as the "main player". When an external player reports `PlaybackStatus = "Playing"`, it becomes the main player. If a second player also starts playing, the previous one is stopped.
 
 ### OCP takeover
 
-When an external player becomes active, `handle_player_state` — `ovos_media/mpris.py:204` — calls `OCPMediaPlayer.handle_MPRIS_takeover()` and sets `playback_type = PlaybackType.MPRIS`. OCP then reflects the external player's metadata (title, artist, album, art) in the GUI via `_update_ocp` — `ovos_media/mpris.py:121`.
+When an external player becomes active, `handle_player_state` calls `OCPMediaPlayer.handle_MPRIS_takeover()` and sets `playback_type = PlaybackType.MPRIS`. OCP then reflects the external player's metadata (title, artist, album, art) via `_update_ocp`, which calls `set_now_playing` so the reflected track shows in the GUI (see [Inbound reflection](#inbound-reflection-an-external-player-as-ocp-now-playing)).
 
-Dedicated icons are substituted for known players: Spotify, Firefox, Chromium, VLC, MPV, and Audacious — `OcpMprisExporter._update_ocp` — `ovos_media/mpris.py:165-178`. All others receive the generic MPRIS icon.
+Dedicated icons are substituted for known players: Spotify, Firefox, Chromium, VLC, MPV, and Audacious. All others receive the generic MPRIS icon.
 
 ### Poll interval
 
-The event loop polls at `mpris_poll_interval` seconds (default `1`) — `OcpMprisExporter.event_loop` — `ovos_media/mpris.py:633`. Two polls occur per cycle: one for discovering new players and one for re-querying existing players (to catch browsers that do not emit events on autoplay).
+The event loop polls at `mpris_poll_interval` seconds (default `1`). Two polls occur per cycle: one for discovering new players and one for re-querying existing players (to catch browsers that do not emit events on autoplay).
 
 ### Failure handling
 
-`query_player` — `ovos_media/mpris.py:536` — increments a failure counter per player. After three consecutive failures the player is treated as gone and removed — `ovos_media/mpris.py:571-573`.
+`query_player` increments a failure counter per player. After three consecutive failures the player is treated as gone and removed.
 
 ## Configuration
 
@@ -104,7 +143,7 @@ All options live under the `"media"` section of the OVOS configuration.
 | `dbus_type` | `str` | `"session"` | `"session"` or `"system"` |
 | `ignored_players` | `list[str]` | see default | D-Bus names to skip during external player scanning |
 
-The default `ignored_players` list is set in `OcpMprisExporter.__init__` — `ovos_media/mpris.py:100-103`.
+The default `ignored_players` list is set in `OcpMprisExporter.__init__`.
 
 ## Using playerctl
 
@@ -129,10 +168,10 @@ playerctl --player=OCP previous
 
 ## Behaviour notes
 
-- `CanSeek` always reports `False`; seeking is not exposed over MPRIS — `_MediaPlayer2PlayerInterface.CanSeek` — `ovos_media/mpris.py:836`.
-- `Rate` always reports `1.0`; variable playback speed is not exposed over MPRIS — `_MediaPlayer2PlayerInterface.Rate` — `ovos_media/mpris.py:818`.
-- Volume read uses a 0.5-second bus timeout; if the volume service is unavailable the getter returns `1.0` — `_MediaPlayer2PlayerInterface.Volume` — `ovos_media/mpris.py:808-811`.
-- The `dbus_next` library is patched at import time to ignore malformed introspection XML — `patch_dbus_next` — `ovos_media/mpris.py:7`. This accommodates players that expose invalid D-Bus introspection data.
+- `CanSeek` always reports `False`; seeking is not exposed over MPRIS.
+- `Rate` always reports `1.0`; variable playback speed is not exposed over MPRIS.
+- Volume read uses a 0.5-second bus timeout; if the volume service is unavailable the getter returns `1.0`.
+- The `dbus_next` library is patched at import time (`patch_dbus_next`) to ignore malformed introspection XML. This accommodates players that expose invalid D-Bus introspection data.
 
 ---
 
@@ -141,3 +180,4 @@ playerctl --player=OCP previous
 - [Architecture](architecture.md) — the MPRIS exporter inside the daemon
 - [Configuration](configuration.md) — the `media` config block
 - [Backends](backends.md) — the playback plugins MPRIS controls
+- [`ovos-media-plugin-mpris`](https://github.com/OpenVoiceOS/ovos-media-plugin-mpris) — the standalone external-player watcher and MPRIS player backend

--- a/docs/ocp-skills.md
+++ b/docs/ocp-skills.md
@@ -12,7 +12,7 @@ OCP (OpenVoiceOS Common Play) is the media pipeline that routes voice utterances
 
 1. **OCP pipeline plugin** (`ovos-ocp-pipeline-plugin`) — an intent pipeline stage that classifies utterances as media queries, determines the `MediaType`, and broadcasts search requests to registered OCP skills.
 2. **OCP skills** — domain-specific skills (YouTube, Spotify, local music, radio, etc.) that respond to search requests by returning lists of `MediaEntry` objects ranked by confidence.
-3. **`ovos-media`** — receives the winning `MediaEntry`, resolves the appropriate audio/video/web backend, and drives playback. The central class is `OCPMediaPlayer` — `ovos_media/player.py:338`.
+3. **`ovos-media`** — receives the winning `MediaEntry`, resolves the appropriate audio/video/web backend, and drives playback. The central class is `OCPMediaPlayer` (`ovos_media/player.py`).
 
 ## The OCP query flow
 
@@ -32,7 +32,7 @@ User says "play jazz"
   -> Playback begins; MPRIS metadata updated if enabled
 ```
 
-`OCPMediaPlayer.set_now_playing` — `ovos_media/player.py:608` — accepts a `MediaEntry`, a `dict` representation of one, or a `Playlist`. It updates `self.now_playing`, adds the entry to the internal playlist, and notifies any connected MPRIS client by emitting a property-changed signal with the new `Metadata`.
+`OCPMediaPlayer.set_now_playing` accepts a `MediaEntry`, a `dict` representation of one, or a `Playlist`. It updates `self.now_playing`, adds the entry to the internal playlist, and notifies any connected MPRIS client by emitting a property-changed signal with the new `Metadata`.
 
 ## MediaEntry structure
 
@@ -53,11 +53,11 @@ User says "play jazz"
 
 ## NowPlaying
 
-`NowPlaying` — `ovos_media/player.py:146` — is a `MediaEntry` subclass that additionally subscribes to bus events to track live playback state. It is instantiated in `OCPMediaPlayer.bind` — `ovos_media/player.py:376` — and stored as `OCPMediaPlayer.now_playing` — `ovos_media/player.py:355`.
+`NowPlaying` is a `MediaEntry` subclass that additionally subscribes to bus events to track live playback state. It is instantiated in `OCPMediaPlayer.__init__` and stored as `OCPMediaPlayer.now_playing`.
 
-The `as_dict` property — `NowPlaying.as_dict` — `ovos_media/player.py:167` — returns a plain `dict` with the current track's metadata fields (uri, title, artist, image, playback type, etc.). It is a property, not a method; access it as `player.now_playing.as_dict` without calling it.
+The `as_dict` property returns a plain `dict` with the current track's metadata fields (uri, title, artist, image, playback type, etc.). It is a property, not a method; access it as `player.now_playing.as_dict` without calling it.
 
-`NowPlaying` tracks the seek position via the `ovos.common_play.playback_time` bus event — `NowPlaying.__init__` — `ovos_media/player.py:158`. This position is exposed through MPRIS as `Position` in microseconds — see `docs/mpris.md`.
+`NowPlaying` tracks the seek position via the `ovos.common_play.playback_time` bus event. This position is exposed through MPRIS as `Position` in microseconds — see [mpris.md](mpris.md).
 
 ## Writing an OCP skill
 
@@ -65,24 +65,25 @@ The `as_dict` property — `NowPlaying.as_dict` — `ovos_media/player.py:167` �
 > is loaded in-process and returns typed `mediavocab.Release` objects. The skill
 > approach below is retained for compatibility.
 
-OCP skills subclass `OVOSCommonPlaybackSkill` from `ovos-workshop` and implement a `search_ocp` method that returns a list of `MediaEntry` objects. Full documentation and the base class API are in the `ovos-workshop` package.
+OCP skills subclass `OVOSCommonPlaybackSkill` from `ovos-workshop` and decorate a search method with `@ocp_search`. The method (any name) returns or yields `MediaEntry` objects / result dicts. Full documentation and the base class API are in the `ovos-workshop` package.
 
 A minimal skeleton:
 
 ```python
 from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill, MediaType, PlaybackType
+from ovos_workshop.decorators.ocp import ocp_search
 from ovos_utils.ocp import MediaEntry
 
 
 class MyMusicSkill(OVOSCommonPlaybackSkill):
-    def search_ocp(self, phrase: str, media_type: MediaType):
+    @ocp_search()
+    def search(self, phrase: str, media_type: MediaType):
         if media_type not in (MediaType.MUSIC, MediaType.GENERIC):
-            return []
+            return
 
         # Query your source here
-        results = []
         for item in self._my_search(phrase):
-            results.append(MediaEntry(
+            yield MediaEntry(
                 uri=item["stream_url"],
                 title=item["title"],
                 artist=item["artist"],
@@ -91,15 +92,14 @@ class MyMusicSkill(OVOSCommonPlaybackSkill):
                 playback=PlaybackType.AUDIO,
                 skill_id=self.skill_id,
                 match_confidence=item["score"],
-            ))
-        return results
+            )
 ```
 
 OCP skills are regular OVOS skills: they announce themselves on the bus with `ovos.common_play.announce` when they load, and the OCP pipeline tracks the available skills from those announcements.
 
 ## Backend selection
 
-After `set_now_playing`, `OCPMediaPlayer` calls `_resolve_preferred_service` — `ovos_media/player.py:650` — which reads `preferred_audio_services`, `preferred_video_services`, or `preferred_web_services` from the `"media"` configuration section and returns the first matching loaded backend. If no preference is configured, the first available backend is used. The three service wrappers are `AudioService`, `VideoService`, and `WebService`, assigned in `OCPMediaPlayer.bind` — `ovos_media/player.py:378-380`.
+When it plays, `OCPMediaPlayer` calls `_resolve_preferred_service`, which reads `preferred_audio_services`, `preferred_video_services`, or `preferred_web_services` from the `"media"` configuration section and returns the first matching loaded backend. If no preference is configured, the first available backend is used. The three service wrappers are `AudioService`, `VideoService`, and `WebService`, created in `OCPMediaPlayer.__init__`.
 
 ## Testing OCP skills with ovoscope
 
@@ -118,6 +118,10 @@ result = OCPTest(
 The test fires a `recognizer_loop:utterance` message on a `FakeBus`, waits for the pipeline to select a result, and asserts the returned `MediaEntry` fields match `expected_media`. Mock HTTP responses can be injected to avoid real network calls.
 
 For skills that are not exercised through the standard pipeline (for example, those using `PlaybackType.SKILL`), use `FakeBus` unit tests directly instead of `ovoscope`.
+
+To test a modern [MediaProvider](media-providers.md) instead of a skill, use
+ovoscope's `MediaProviderHarness` (see `ovoscope/docs/media-provider-testing.md`),
+which drives a provider's `search()` directly without the skill machinery.
 
 ## Configuration reference
 


### PR DESCRIPTION
Full accuracy + completeness pass over every `docs/` page and the README, verified against the current `ovos_media/` source (`player.py`, `media_backends/`, `mpris.py`, `service.py`, `legacy_api.py`) and the `ovos-plugin-manager` media templates. Docs-only.

## Per-page

- **media-providers.md** — rewritten to the **simplified** `MediaProvider` contract: one abstract method `search(self, signals, lang="en-us", **context) -> list[Release]`. Dropped the stale `is_available` / `matches` / `featured_media` / `search_safe` methods and the three-axis routing class attributes (`media`/`playback_type`/`genre_filter`) that no longer exist. Documents the `**context` kwargs the pipeline passes (`supported_playback_types`, `blocked_genres`, `region`, `session_id`) and the `[]`-on-cannot-serve gate.
- **architecture.md** — removed the false claims that `OCPMediaPlayer` subclasses `OVOSAbstractApplication` and that setup happens in a `bind()` method (it's a plain class wired in `__init__`). Rebuilt the handler / emitted-event tables, added `NowPlaying`, the `BUFFERED_MEDIA` / `INVALID_MEDIA` states, and the inbound `ovos.common_play.mpris.now_playing` -> `set_external_now_playing` reflection. Names `ovos-media-plugin-qt5` as the GUI render backend.
- **mpris.md** — fixed the **LoopStatus** table: the getter returns the canonical MPRIS `"None"`/`"Track"`/`"Playlist"`, not `"RepeatTrack"`/`"Repeat"` (removed the bogus asymmetry note). Added the inbound external-player reflection + `handle_MPRIS_takeover`, and cross-linked the standalone `ovos-media-plugin-mpris` watcher that emits the bus primitive.
- **backends.md** — added the dual-target story (plugins ship both `opm.media.audio`/`.video`/`.web` and the legacy `mycroft.plugin.audioservice` entry points); mapped pip package names -> entry-point `module` names; corrected `PlaybackType.WEBVIEW`.
- **configuration.md** — corrected `autoplay` (auto-advance on end/invalid, not "start on results") and `merge_search` semantics; added `dbus_type`; clarified `module` = entry-point name != pip package.
- **getting-started.md** — fixed the embedded-run snippet to match `__main__`; corrected the `ovos-workshop` dependency note.
- **ocp-skills.md** — fixed the legacy skill skeleton to use the `@ocp_search` decorator (there is no `search_ocp` method); pointed provider testing at ovoscope `MediaProviderHarness`.
- **index.md / migration-guide.md / README.md** — aligned example backend lists with the actually-published plugins, added the `mpris.now_playing` + `SEI.get` bus rows, tightened prose.

Throughout: stripped rotting `file.py:NNN` line numbers (kept symbolic `Class.method` references) and verified every intra-doc link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)