### PR TITLE
docs: 10/10 pass — glossary, audience routing, game-skill carve-out

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,65 @@
+# Glossary & core concepts
+
+New to the OVOS media stack? Read this once and the rest of the docs click into
+place. It defines every acronym and — more importantly — the handful of concepts
+people most often mix up.
+
+## The 30-second mental model
+
+You say *"play some jazz"*. Four kinds of plugin cooperate to make sound come out:
+
+1. a **provider** *finds* candidate tracks (searches catalogs),
+2. **ovos-media** (this daemon) *decides* what to play and *tracks* what's playing,
+3. a **backend** *plays* it (hands the URL to VLC, mpv, a Chromecast, …),
+4. an **extractor** *resolves* a deferred link (e.g. a `youtube//…` placeholder)
+   into a real stream URL at the moment of playback.
+
+Each is a separate, swappable plugin. That separation is the whole design.
+
+## The four plugin roles (don't mix these up)
+
+| Role | Entry-point group | Answers the question | Example |
+|------|-------------------|----------------------|---------|
+| **MediaProvider** | `opm.media.provider` | *"where can I find this?"* | youtube, bandcamp, tunein |
+| **Playback backend** | `opm.media.audio` / `.video` / `.web` | *"how do I play this?"* | vlc, mpv, chromecast |
+| **Stream extractor** | `opm.ocp.extractor` | *"what's the real URL?"* | youtube, m3u, rss |
+| **MPRIS plugin** | (see [mpris.md](mpris.md)) | *"what are other apps playing?"* | the mpris watcher |
+
+> **Provider vs. backend** is the #1 point of confusion. A *provider* is a search
+> engine (returns a list of results). A *backend* is a player (turns one result
+> into sound/video). "youtube" exists as both a provider (searches YouTube) and is
+> played by a backend (vlc/mpv) after the youtube *extractor* resolves the stream.
+
+## Terms
+
+| Term | Meaning |
+|------|---------|
+| **OCP** | *OpenVoiceOS Common Play* — the framework/protocol for voice-driven media ("play X"). The **OCP pipeline** is the ovos-core stage that classifies a "play …" utterance and asks providers to search. |
+| **ovos-media** | This daemon — the OCP-native player. Manages the queue, now-playing state, and playback backends. Runs **alongside `ovos-audio`** (which does TTS). |
+| **ovos-audio** | The separate daemon that handles **TTS** (and the *legacy* audio service). Not a replacement for ovos-media; they coexist. |
+| **OPM** | *ovos-plugin-manager* — discovers plugins via Python entry points. The `opm.*` groups above are OPM groups. |
+| **Signals** | A [`mediavocab.Signals`](https://github.com/TigreGotico/mediavocab) object — the *parsed request* a provider receives: `title`, `artist`, `medium` (a `MediaType`), `content_genres`, … |
+| **Release** | A [`mediavocab.Release`](https://github.com/TigreGotico/mediavocab) — a *typed, playable catalog entry* a provider returns. The shared currency between search, playback, MPRIS metadata, and the GUI. |
+| **Work** | The creative work a `Release` manifests (`Release.work.title`, `.media_type`, …). |
+| **MediaType** | What *kind* of content it is (music, movie, podcast, radio, audiobook, …). |
+| **PlaybackType** | What *surface* renders it: `AUDIO`, `VIDEO`, `WEBVIEW`, `MPRIS`. Determines which backend group plays it. |
+| **PlayerState** | The player's transport state: `PLAYING`, `PAUSED`, `STOPPED`. (A *paused* track is still `PLAYING_*` at the track level — pause lives only in `PlayerState`.) |
+| **MediaState** | The media's lifecycle: buffering, loaded, end-of-media, invalid, … |
+| **now_playing** | The single currently-playing `Release` the daemon tracks (`NowPlaying`), mirrored to the bus / MPRIS / GUI. |
+| **SEI** | *Stream Extractor Identifier* — the prefix in a deferred URI (`youtube//…`, `rss//…`) that names which extractor resolves it. |
+| **deferred / deferred URI** | A `Release.uri` of the form `"{sei}//{realuri}"` resolved **at playback time** by an extractor, not at search time. |
+| **MPRIS** | The freedesktop D-Bus standard (`org.mpris.MediaPlayer2`) other Linux media apps speak. ovos-media both exposes itself over it and reacts to other players. See [mpris.md](mpris.md). |
+| **MessageBus** | The OVOS WebSocket event bus. Everything ovos-media does is observable/driveable as `ovos.common_play.*` messages. |
+| **GUI** | The OVOS GUI client; ovos-media pushes the now-playing screen to it via `GUIInterface`. |
+| **OCP search skill** *(legacy)* | The old way to provide *searchable catalog media* (`OVOSCommonPlaybackSkill` + `@ocp_search`), now **replaced by MediaProviders**. See [ocp-skills.md](ocp-skills.md). |
+| **OCP game / interactive skill** | A skill that *is* the experience (interactive fiction, quizzes, "play a game") rather than a searchable catalog. These stay as **skills** — they are **not** deprecated and have no MediaProvider equivalent. See [ocp-skills.md](ocp-skills.md). |
+
+## Which doc do I want?
+
+- *I just want it running* → [Getting started](getting-started.md)
+- *I want to tune it* → [Configuration](configuration.md)
+- *I'm writing a search plugin* → [Media providers](media-providers.md)
+- *I'm writing a player plugin* → [Backends](backends.md)
+- *I want desktop / `playerctl` control* → [MPRIS](mpris.md)
+- *I want to understand the internals* → [Architecture](architecture.md)
+- *I'm coming from the old stack* → [Migration guide](migration-guide.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,23 @@ handle TTS.
 
 Apache-2.0 · Python 3.10+
 
+> **New here?** Read the [Glossary & core concepts](glossary.md) first (5 min) —
+> it explains OCP, providers vs. backends vs. extractors, `Signals`/`Release`, and
+> the mental model the rest of these docs assume.
+
+## Start here
+
+| You are… | Go to |
+|----------|-------|
+| 🆕 **new to the media stack** | [Glossary](glossary.md) → [Getting started](getting-started.md) |
+| 🎛️ **running / tuning a device** | [Getting started](getting-started.md) → [Configuration](configuration.md) |
+| 🔌 **writing a search plugin** | [Glossary](glossary.md) → [Media providers](media-providers.md) |
+| 🎚️ **writing a player plugin** | [Backends](backends.md) |
+| 🎮 **writing a game / interactive skill** | [OCP skills](ocp-skills.md) (still a skill — *not* a provider) |
+| 🖥️ **wiring desktop / `playerctl`** | [MPRIS](mpris.md) |
+| 🧠 **hacking on the daemon** | [Architecture](architecture.md) |
+| ⬆️ **migrating from the old stack** | [Migration guide](migration-guide.md) |
+
 ---
 
 ## How it fits together
@@ -50,6 +67,7 @@ written once feeds playback, MPRIS metadata, and the GUI alike.
 
 | Document | What it covers |
 |---|---|
+| [Glossary & core concepts](glossary.md) | **Read first.** Every acronym + the mental model (provider vs. backend vs. extractor, `Signals`/`Release`) |
 | [Getting started](getting-started.md) | Install, enable the daemon, run your first playback |
 | [Architecture](architecture.md) | The daemon's layers, bus API, state machine, GUI/MPRIS integration |
 | [Media providers](media-providers.md) | Writing a catalog/search plugin (`opm.media.provider`) — the new search layer |
@@ -57,7 +75,7 @@ written once feeds playback, MPRIS metadata, and the GUI alike.
 | [Configuration](configuration.md) | Full `mycroft.conf` reference for the `media` and `media_providers` keys |
 | [MPRIS integration](mpris.md) | D-Bus MPRIS support, external player control, `playerctl` |
 | [Migration guide](migration-guide.md) | Moving from the legacy audio service to `ovos-media` |
-| [OCP skills (legacy)](ocp-skills.md) | The superseded search-skill approach — see [media providers](media-providers.md) instead |
+| [OCP skills](ocp-skills.md) | Media *search* skills are superseded by [media providers](media-providers.md); **game / interactive skills stay here** |
 
 ---
 

--- a/docs/media-providers.md
+++ b/docs/media-providers.md
@@ -34,8 +34,11 @@ downstream, and its per-instance config key under `media_providers`.
 `MediaProvider` has a **single abstract method**:
 
 ```python
-def search(self, signals: Signals, lang: str = "en-us",
-           **context) -> list[Release]:
+def search(self, signals: Signals, lang: str = "en-us", *,
+           supported_playback_types: set[str] | None = None,
+           blocked_genres: set[str] | None = None,
+           region: str | None = None,
+           session_id: str | None = None) -> list[Release]:
     ...
 ```
 
@@ -52,7 +55,7 @@ class MediaProvider(metaclass=ABCMeta):
         self.config = config or {}
 
     @abstractmethod
-    def search(self, signals, lang="en-us", **context) -> list[Release]: ...
+    def search(self, signals, lang="en-us", *, supported_playback_types=None, blocked_genres=None, region=None, session_id=None) -> list[Release]: ...
 
     def shutdown(self) -> None:     # optional — release resources
         ...
@@ -65,9 +68,9 @@ class MediaProvider(metaclass=ABCMeta):
   `signals.artist` (artist, or director for video). `signals.medium` carries the
   classified `MediaType` and `signals.content_genres` the requested genres.
 - **`lang`** is the BCP-47 language tag for the request (default `"en-us"`).
-- **`**context`** carries whatever the pipeline knows about the request
-  environment. A provider reads the kwargs it cares about and ignores the rest.
-  Recognised keys include:
+- the remaining **keyword-only arguments** carry what the pipeline knows about
+  the request environment (explicitly named, not `**kwargs`); a provider reads the
+  ones it cares about and ignores the rest:
 
   | Context kwarg | Meaning |
   |---|---|
@@ -126,9 +129,9 @@ skipping any whose config sets `"enabled": false`.
 At query time the pipeline:
 
 1. Classifies the utterance into a `Signals` (media type, title, artist, genres).
-2. Builds the `**context` (supported playback types, blocked genres, region,
+2. Builds the context kwargs (supported playback types, blocked genres, region,
    session) from the requesting session's state.
-3. Calls `search(signals, lang, **context)` on each loaded provider
+3. Calls `search(signals, lang, *, ...)` on each loaded provider
    **concurrently** (thread pool). A provider that cannot serve the request
    returns `[]`; a misbehaving provider that raises is caught and treated as `[]`
    so it cannot abort a multi-provider dispatch.
@@ -163,8 +166,11 @@ class BandcampMediaProvider(MediaProvider):
         super().__init__(config)
         self.max_pages = self.config.get("max_pages", 1)
 
-    def search(self, signals: Signals, lang: str = "en-us",
-               **context) -> List[Release]:
+    def search(self, signals: Signals, lang: str = "en-us", *,
+               supported_playback_types: set[str] | None = None,
+               blocked_genres: set[str] | None = None,
+               region: str | None = None,
+               session_id: str | None = None) -> List[Release]:
         title = (signals.title or "").strip()
         artist = (signals.artist or "").strip()
         query = " ".join(p for p in (artist, title) if p).strip()
@@ -252,7 +258,7 @@ playback halves are unchanged — those live in the OCP pipeline and the
 | Old (OCP search skill) | New (MediaProvider) |
 |---|---|
 | Subclass `OVOSCommonPlaybackSkill` | Subclass `MediaProvider` |
-| `@ocp_search` method returning `MediaEntry`/`Playlist` | `search(signals, lang, **context)` returning `list[Release]` |
+| `@ocp_search` method returning `MediaEntry`/`Playlist` | `search(signals, lang, *, ...)` returning `list[Release]` |
 | Registered as a skill; replies to `ovos.common_play.query` over the bus | Registered under `opm.media.provider`; called in-process |
 | Routing implied by the skill's vocab and per-result `media_type` | The provider decides per call and returns `[]` when it can't serve |
 | Match score `0`–`100` on each `MediaEntry` | `match_confidence` `0.0`–`1.0` on each `Release` |

--- a/docs/ocp-skills.md
+++ b/docs/ocp-skills.md
@@ -1,10 +1,20 @@
-# OCP Skills and the Media Pipeline (legacy)
+# OCP Skills and the Media Pipeline
 
-> **Superseded.** OCP *search skills* (`OVOSCommonPlaybackSkill` + `@ocp_search`)
-> are the legacy catalog/search approach. New catalog integrations should be
-> written as [MediaProvider plugins](media-providers.md), which the OCP pipeline
-> loads in-process instead of broadcasting bus queries to skills. This page
-> documents the legacy flow, which still works during the transition.
+There are **two kinds** of OCP skill, and only one of them is deprecated:
+
+| Kind | Base class | Status |
+|------|-----------|--------|
+| **Search skill** — returns catalog results for *"play X"* | `OVOSCommonPlaybackSkill` + `@ocp_search` | ⛔ **deprecated** → write a [MediaProvider](media-providers.md) instead |
+| **Game / interactive skill** — *is* the experience (a game, quiz, interactive story) | `OVOSGameSkill` / `ConversationalGameSkill` | ✅ **fully supported** — stays a skill; see [Game & interactive skills](#game--interactive-skills) |
+
+> **Why the split?** A *search* skill is a catalog: it just answers "where can I
+> find this?", which is exactly what an in-process [MediaProvider](media-providers.md)
+> does better (no bus round-trip, typed `Release` results). A *game* skill, by
+> contrast, owns an interactive session — there is no catalog to extract, so it
+> remains a skill. MediaProviders do **not** replace games.
+
+The rest of this page documents the legacy **search-skill** flow (still functional
+during the transition), then the **game-skill** path which is current.
 
 ## What is OCP?
 
@@ -96,6 +106,51 @@ class MyMusicSkill(OVOSCommonPlaybackSkill):
 ```
 
 OCP skills are regular OVOS skills: they announce themselves on the bus with `ovos.common_play.announce` when they load, and the OCP pipeline tracks the available skills from those announcements.
+
+## Game & interactive skills
+
+**These are not deprecated.** A game skill *is* the media experience rather than a
+catalog of it, so there is nothing for a MediaProvider to replace. Game skills
+subclass `OVOSGameSkill` (or `ConversationalGameSkill` for turn-by-turn
+voice games) from `ovos_workshop.skills.game_skill`, and OCP routes the session
+to them via `PlaybackType.SKILL` — the daemon hands control to the skill instead
+of streaming a URI through an audio/video backend.
+
+`ConversationalGameSkill` gives a game a managed lifecycle (start/stop/pause/
+resume, idle timeout) plus **intent layers** — sets of intents you enable/disable
+as the game advances, so the same utterance means different things in different
+game states.
+
+```python
+from ovos_workshop.skills.game_skill import ConversationalGameSkill
+from ovos_workshop.decorators import layer_intent, enables_layer
+
+class MyGameSkill(ConversationalGameSkill):
+    def __init__(self, *args, **kwargs):
+        super().__init__(skill_voc_filename="MyGameKeyword", *args, **kwargs)
+
+    def initialize(self):
+        self.intent_layers.disable()      # start with game intents off
+
+    def on_play_game(self):
+        """Called when OCP launches the game."""
+        self.speak_dialog("intro")
+        self.enable_intent_layer("main")
+
+    def on_stop_game(self):
+        """Clean up when the session ends."""
+
+    @layer_intent(intent_name="guess.intent", layer_name="main")
+    def handle_guess(self, message):
+        ...
+```
+
+The reference implementation is
+[`ovos-skill-moon-game`](https://github.com/OpenVoiceOS/ovos-skill-moon-game) — an
+Apollo-11 escape-room game built on `ConversationalGameSkill` with intent layers,
+and the canonical end-to-end test that the game-skill integration still works on
+the modern stack. Game skills register under the normal `ovos.plugin.skill`
+entry-point group, not any `opm.media.*` group.
 
 ## Backend selection
 


### PR DESCRIPTION
Raises `/docs` to a 10/10 onboarding for both newcomers and advanced devs:

- **New `glossary.md`** — every acronym (OCP/OPM/SEI/Signals/Release/PlaybackType/…) and the mental model, including the #1 confusion (provider vs. backend vs. extractor). The noob on-ramp.
- **`index.md`** — a 'Start here' audience-routing table; glossary listed first.
- **`ocp-skills.md`** — splits the two OCP-skill kinds: *search* skills are deprecated (→ MediaProviders); **game/interactive skills (`OVOSGameSkill`/`ConversationalGameSkill`, e.g. ovos-skill-moon-game) are fully supported and stay**.
- **`media-providers.md`** — `search()` documented with the final explicit keyword-only context args (supersedes #55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)