### PR TITLE
feat: only act on the default/local session (validate_source)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -293,10 +293,20 @@ device's player rather than the hub's. `ovos-media` participates by reporting it
 state through `handle_status`, which the pipeline associates with the originating
 session.
 
+`ovos-media` itself stays a **single** player bound to its own device — the
+`"default"` session. Its playback-executing handlers are gated by
+`require_default_session()` (`ovos_media/utils.py`), so a server-side daemon
+**ignores** a satellite's forwarded command (`session_id != "default"`) while
+the satellite's own embedded daemon executes it. Read-only query handlers stay
+ungated so a remote pipeline can still read state. See
+[Sessions](sessions.md) for the full topology, the gated-handler list, and the
+`validate_source` config knob.
+
 ---
 
 ## See also
 
+- [Sessions](sessions.md) — the default/local session filter (HiveMind topology)
 - [Media providers](media-providers.md) — the catalog/search layer feeding this daemon
 - [Backends](backends.md) — the audio/video/web playback plugins
 - [Configuration](configuration.md) — the `media` config block

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,6 +109,7 @@ plugin's own `config` dict. See [backends.md](backends.md) for the backend API.
 | `merge_search` | bool | `true` | Merge incoming search results into the playback queue alongside the user playlist rather than ignoring them. |
 | `force_audioservice` | bool | `false` | Force audio-only playback even when a GUI is connected; bypasses video/web backend selection. |
 | `playback_mode` | enum | unset | Set to `PlaybackMode.FORCE_AUDIO` to always use audio backends regardless of GUI availability. |
+| `validate_source` | bool | `true` | Only act on playback commands from the local/`"default"` session. Leave `true` on a server-side daemon so it ignores HiveMind satellite sessions; set `false` on a satellite not getting default-NAT'd sessions. See [Sessions](sessions.md). |
 
 ---
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -50,6 +50,8 @@ Each is a separate, swappable plugin. That separation is the whole design.
 | **deferred / deferred URI** | A `Release.uri` of the form `"{sei}//{realuri}"` resolved **at playback time** by an extractor, not at search time. |
 | **MPRIS** | The freedesktop D-Bus standard (`org.mpris.MediaPlayer2`) other Linux media apps speak. ovos-media both exposes itself over it and reacts to other players. See [mpris.md](mpris.md). |
 | **MessageBus** | The OVOS WebSocket event bus. Everything ovos-media does is observable/driveable as `ovos.common_play.*` messages. |
+| **Session** | A MessageBus conversation scope identified by `session_id`. The special id `"default"` means the local/single device. ovos-media only *acts* on the `"default"` session (a HiveMind server ignores satellite sessions); see [Sessions](sessions.md). |
+| **validate_source** | The `media` config flag (default `true`) that enables the default-session filter. Set `false` on a satellite that is not getting default-NAT'd sessions so it acts on every session. See [Sessions](sessions.md). |
 | **GUI** | The OVOS GUI client; ovos-media pushes the now-playing screen to it via `GUIInterface`. |
 | **OCP search skill** *(legacy)* | The old way to provide *searchable catalog media* (`OVOSCommonPlaybackSkill` + `@ocp_search`), now **replaced by MediaProviders**. See [ocp-skills.md](ocp-skills.md). |
 | **OCP game / interactive skill** | A skill that *is* the experience (interactive fiction, quizzes, "play a game") rather than a searchable catalog. These stay as **skills** — they are **not** deprecated and have no MediaProvider equivalent. See [ocp-skills.md](ocp-skills.md). |
@@ -62,4 +64,5 @@ Each is a separate, swappable plugin. That separation is the whole design.
 - *I'm writing a player plugin* → [Backends](backends.md)
 - *I want desktop / `playerctl` control* → [MPRIS](mpris.md)
 - *I want to understand the internals* → [Architecture](architecture.md)
+- *I'm running HiveMind satellites / a server* → [Sessions](sessions.md)
 - *I'm coming from the old stack* → [Migration guide](migration-guide.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ Apache-2.0 · Python 3.10+
 | 🎮 **writing a game / interactive skill** | [OCP skills](ocp-skills.md) (still a skill — *not* a provider) |
 | 🖥️ **wiring desktop / `playerctl`** | [MPRIS](mpris.md) |
 | 🧠 **hacking on the daemon** | [Architecture](architecture.md) |
+| 🛰️ **running HiveMind satellites / a server** | [Sessions](sessions.md) |
 | ⬆️ **migrating from the old stack** | [Migration guide](migration-guide.md) |
 
 ---
@@ -70,6 +71,7 @@ written once feeds playback, MPRIS metadata, and the GUI alike.
 | [Glossary & core concepts](glossary.md) | **Read first.** Every acronym + the mental model (provider vs. backend vs. extractor, `Signals`/`Release`) |
 | [Getting started](getting-started.md) | Install, enable the daemon, run your first playback |
 | [Architecture](architecture.md) | The daemon's layers, bus API, state machine, GUI/MPRIS integration |
+| [Sessions](sessions.md) | The default/local session filter — how a HiveMind server ignores satellite sessions (`validate_source`) |
 | [Media providers](media-providers.md) | Writing a catalog/search plugin (`opm.media.provider`) — the new search layer |
 | [Playback backends](backends.md) | Audio/video/web backend plugins, discovery, writing a custom backend |
 | [Configuration](configuration.md) | Full `mycroft.conf` reference for the `media` and `media_providers` keys |

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,101 @@
+# Sessions: the default/local session filter
+
+`ovos-media` is a **single player bound to one device**. It does not manage a
+player per remote client; conceptually it only ever drives *its own* device,
+identified by the `"default"` session.
+
+This page explains how that plays out in a HiveMind satellite/server topology
+and how to configure it.
+
+## The problem
+
+In a single-device install everything shares the `"default"` session, so there
+is nothing to think about: every playback command is local and is executed.
+
+In a **HiveMind split** the OCP pipeline (`ovos-ocp-pipeline-plugin`) runs on
+the **server**. The pipeline already tracks one player proxy per MessageBus
+session and forwards playback commands **stamped with the originating session**
+(the satellite's `session_id`). If the server-side `ovos-media` blindly acted on
+every `ovos.common_play.*` message it received, a satellite asking to play music
+would start playback on the **server's** speakers — the wrong device.
+
+## The rule
+
+`ovos-media` acts only on commands for the **local/"default"** session and
+**ignores** commands stamped with any other session id.
+
+- A **server-side** `ovos-media` ignores a satellite's playback command
+  (`session_id != "default"`). The satellite has its own embedded `ovos-media`
+  that handles it.
+- The **satellite's** embedded `ovos-media` sees the command as `"default"` and
+  executes it. hivemind-core NATs the satellite's session to `"default"` for the
+  satellite-local instance, so from that instance's point of view the request is
+  local.
+
+This mirrors how `ovos-audio` scopes TTS to native/local sources
+(`ovos_audio.utils.require_default_session`).
+
+## Implementation
+
+A `require_default_session()` decorator
+(`ovos_media/utils.py`) gates each playback-**executing** bus handler. A handler
+runs only if:
+
+- the message is internal/synthetic (`message is None`), **or**
+- `validate_source` is False (act on everything — see below), **or**
+- `SessionManager.get(message).session_id == "default"`.
+
+Otherwise it logs at debug level and returns without acting.
+
+Gated handlers (the ones that change playback or persistent state):
+
+| Layer | Handlers |
+|---|---|
+| `OCPMediaPlayer` (`player.py`) | play, pause, resume, stop, play/pause toggle, next, previous, seek, set track position, playlist set/queue/clear, shuffle set/unset/toggle, repeat set/unset/toggle, duck, cork, uncork (and unduck restore), like, unlike |
+| `NowPlaying` (`player.py`) | `handle_external_play` (so a non-default play does not bleed metadata into the local now-playing) |
+| `LegacyAudioServiceCompat` (`legacy_api.py`) | `mycroft.audio.service.*`: play, queue, pause, resume, stop, next, prev, set/seek position |
+
+**Read-only query handlers are *not* gated** — `status`, `track_info`,
+`get_track_length`, `get_track_position`, `list_backends`. These reply to the
+asker (via `message.response`), so answering a remote query is harmless and
+useful (e.g. the server-side pipeline can read state).
+
+## Configuration
+
+The filter is on by default. Set it per instance:
+
+```json
+{
+  "media": {
+    "validate_source": true
+  }
+}
+```
+
+- `validate_source: true` (default) — only act on the local/`"default"` session.
+  Correct for a **server-side** `ovos-media` and for any satellite whose sessions
+  are NAT'd to `"default"` by hivemind-core.
+- `validate_source: false` — act on **every** session. Use this on a satellite
+  that is **not** getting default-NAT'd sessions, so its embedded `ovos-media`
+  still executes the playback meant for it.
+
+`MediaService(validate_source=...)` (and `OCPMediaPlayer(validate_source=...)`)
+override the config value programmatically; when left unset the config is read.
+
+## Why not a player per session?
+
+`ovos-media` deliberately stays a single global player. Per-session playback
+*state* and routing already live in the OCP pipeline (server side) and in each
+device's own `ovos-media` (client side). Duplicating that as N virtual players
+inside one daemon would also collide on the shared, session-less feedback events
+that backend plugins emit (`ovos.common_play.media.state` / `.track.state` /
+`.player.state` are emitted as bare messages by `ovos-plugin-manager`'s
+`MediaBackend`), so per-session backend feedback cannot be disambiguated without
+changing the plugin contract. The single-player + default-session-filter model
+keeps the daemon simple and routes correctly in a split.
+
+## See also
+
+- [Architecture](architecture.md) — the daemon's layers and bus API
+- [Glossary](glossary.md) — session, OCP, provider/backend/extractor
+- [Configuration](configuration.md) — the full `media` config block

--- a/ovos_media/legacy_api.py
+++ b/ovos_media/legacy_api.py
@@ -32,6 +32,8 @@ from ovos_bus_client.message import Message
 from ovos_utils.log import LOG
 from ovos_utils.ocp import MediaEntry, PlaybackType, MediaType
 
+from ovos_media.utils import require_default_session
+
 
 def _tracks_to_entries(
     tracks: List[Union[str, Tuple[str, str]]]
@@ -89,6 +91,17 @@ class LegacyAudioServiceCompat:
         self._register_handlers()
         LOG.info("LegacyAudioServiceCompat: mycroft.audio.service.* shim active")
 
+    @property
+    def validate_source(self) -> bool:
+        """Mirror the player's session filter for ``require_default_session``.
+
+        Executing legacy handlers are gated to the local/"default" session
+        exactly like their modern ``ovos.common_play.*`` counterparts; the
+        flag is inherited from the wrapped player so a single config knob
+        controls both layers.
+        """
+        return getattr(self.player, "validate_source", True)
+
     # ------------------------------------------------------------------
     # Handler registration
     # ------------------------------------------------------------------
@@ -117,6 +130,7 @@ class LegacyAudioServiceCompat:
     # Playback control handlers
     # ------------------------------------------------------------------
 
+    @require_default_session()
     def handle_play(self, message: Message) -> None:
         """Handle ``mycroft.audio.service.play``.
 
@@ -147,6 +161,7 @@ class LegacyAudioServiceCompat:
             "repeat": repeat,
         }))
 
+    @require_default_session()
     def handle_queue(self, message: Message) -> None:
         """Handle ``mycroft.audio.service.queue``.
 
@@ -172,22 +187,27 @@ class LegacyAudioServiceCompat:
         self.bus.emit(message.forward("ovos.common_play.playlist.queue",
                                       {"tracks": entries}))
 
+    @require_default_session()
     def handle_pause(self, message: Message) -> None:
         """Handle ``mycroft.audio.service.pause``."""
         self.bus.emit(message.forward("ovos.common_play.pause"))
 
+    @require_default_session()
     def handle_resume(self, message: Message) -> None:
         """Handle ``mycroft.audio.service.resume``."""
         self.bus.emit(message.forward("ovos.common_play.resume"))
 
+    @require_default_session()
     def handle_stop(self, message: Message) -> None:
         """Handle ``mycroft.audio.service.stop``."""
         self.bus.emit(message.forward("ovos.common_play.stop"))
 
+    @require_default_session()
     def handle_next(self, message: Message) -> None:
         """Handle ``mycroft.audio.service.next``."""
         self.bus.emit(message.forward("ovos.common_play.next"))
 
+    @require_default_session()
     def handle_prev(self, message: Message) -> None:
         """Handle ``mycroft.audio.service.prev``."""
         self.bus.emit(message.forward("ovos.common_play.previous"))
@@ -228,6 +248,7 @@ class LegacyAudioServiceCompat:
     # Position / seeking handlers
     # ------------------------------------------------------------------
 
+    @require_default_session()
     def handle_set_track_position(self, message: Message) -> None:
         """Handle ``mycroft.audio.service.set_track_position``.
 
@@ -264,6 +285,7 @@ class LegacyAudioServiceCompat:
         self.bus.emit(message.reply(
             "mycroft.audio.service.get_track_length.response", data))
 
+    @require_default_session()
     def handle_seek_forward(self, message: Message) -> None:
         """Handle ``mycroft.audio.service.seek_forward``.
 
@@ -273,6 +295,7 @@ class LegacyAudioServiceCompat:
         self.bus.emit(message.forward("ovos.common_play.seek",
                                       {"seconds": seconds}))
 
+    @require_default_session()
     def handle_seek_backward(self, message: Message) -> None:
         """Handle ``mycroft.audio.service.seek_backward``.
 

--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -13,11 +13,13 @@ from ovos_config.meta import get_xdg_base
 from ovos_gui_api_client import GUIInterface
 from ovos_media.media_backends import AudioService, VideoService, WebService
 from ovos_media.mpris import OcpMprisExporter
+from ovos_media.utils import require_default_session
 from ovos_plugin_manager.ocp import load_stream_extractors
 from ovos_plugin_manager.templates.media import MediaBackend
 from ovos_utils.gui import is_gui_connected, is_gui_running
 from ovos_utils.log import LOG
 from ovos_bus_client.message import Message
+from ovos_bus_client.session import SessionManager
 from ovos_utils.ocp import MediaType, Playlist
 from ovos_utils.ocp import OCP_ID, PlayerState, LoopState, PlaybackType, PlaybackMode, TrackState, MediaState, \
     MediaEntry
@@ -255,6 +257,16 @@ class NowPlaying(MediaEntry):
         bleed into the new track
         @param message: Message associated with request
         """
+        # NowPlaying is part of the single local player; a play command from a
+        # non-default session (e.g. a HiveMind satellite, routed by the
+        # server-side OCP pipeline) must not bleed its metadata into the local
+        # now_playing. Mirror require_default_session() using the owning
+        # player's validate_source flag.
+        validate = getattr(self._player, "validate_source", True)
+        if validate and SessionManager.get(message).session_id != "default":
+            LOG.debug(f"ignoring '{message.msg_type}' now_playing update, "
+                      f"not from the default/local session")
+            return
         if message.data.get("tracks"):
             # backwards compat / old style
             playlist = message.data["tracks"]
@@ -347,9 +359,15 @@ class OCPMediaPlayer:
     "now playing" is tracked and managed by this interface
     """
 
-    def __init__(self, bus: MessageBusClient, config: Optional[dict] = None) -> None:
+    def __init__(self, bus: MessageBusClient, config: Optional[dict] = None,
+                 validate_source: bool = True) -> None:
         self.bus = bus
         self.ocp_config = config or Configuration().get("media", {})
+        # When True, playback-executing handlers act only on the local/"default"
+        # session (see ovos_media.utils.require_default_session). A satellite
+        # whose sessions are not NAT'd to "default" by hivemind-core should set
+        # this False so its embedded ovos-media acts on all sessions.
+        self.validate_source = validate_source
 
         self.state: PlayerState = PlayerState.STOPPED
         self.loop_state: LoopState = LoopState.NONE
@@ -460,6 +478,7 @@ class OCPMediaPlayer:
             "image": self.now_playing.image
         }))
 
+    @require_default_session()
     def handle_like(self, message):
         # sent from GUI or intent
         uri = message.data.get("uri") or self.now_playing.original_uri
@@ -474,6 +493,7 @@ class OCPMediaPlayer:
         self.bus.emit(message.forward("mycroft.audio.play_sound",
                                       {"uri": "snd/acknowledge.mp3"}))
 
+    @require_default_session()
     def handle_unlike(self, message):
         # sent from GUI or intent
         uri = message.data.get("uri") or self.now_playing.original_uri
@@ -1163,6 +1183,7 @@ class OCPMediaPlayer:
         self._update_gui()
 
     # ovos common play bus api requests
+    @require_default_session()
     def handle_play_request(self, message):
         LOG.debug("Received OCP playback request")
         repeat = message.data.get("repeat", False)
@@ -1178,22 +1199,27 @@ class OCPMediaPlayer:
 
         self.play_media(media, disambiguation, playlist)
 
+    @require_default_session()
     def handle_pause_request(self, message):
         self.pause()
 
+    @require_default_session()
     def handle_stop_request(self, message):
         self.stop()
         self.reset()
 
+    @require_default_session()
     def handle_resume_request(self, message):
         self.resume()
-            
+
+    @require_default_session()
     def handle_pause_toggle_request(self, message):
         if self.state == PlayerState.PAUSED:
             self.handle_resume_request(message)
         else:
             self.handle_pause_request(message)
 
+    @require_default_session()
     def handle_seek_request(self, message):
         # from bus api
         miliseconds = message.data.get("seconds", 0) * 1000
@@ -1208,29 +1234,36 @@ class OCPMediaPlayer:
             position += miliseconds
         self.seek(position)
 
+    @require_default_session()
     def handle_next_request(self, message):
         self.play_next()
 
+    @require_default_session()
     def handle_prev_request(self, message):
         self.play_prev()
 
+    @require_default_session()
     def handle_set_shuffle(self, message):
         self.shuffle = True
         self._update_gui()
 
+    @require_default_session()
     def handle_unset_shuffle(self, message):
         self.shuffle = False
         self._update_gui()
 
+    @require_default_session()
     def handle_set_repeat(self, message):
         self.loop_state = LoopState.REPEAT
         self._update_gui()
 
+    @require_default_session()
     def handle_unset_repeat(self, message):
         self.loop_state = LoopState.NONE
         self._update_gui()
 
     # playlist control bus api
+    @require_default_session()
     def handle_repeat_toggle_request(self, message):
         if self.loop_state == LoopState.REPEAT_TRACK:
             self.loop_state = LoopState.NONE
@@ -1243,6 +1276,7 @@ class OCPMediaPlayer:
             self.mpris.toggle_repeat()
         self._update_gui()
 
+    @require_default_session()
     def handle_shuffle_toggle_request(self, message):
         self.shuffle = not self.shuffle
         LOG.info(f"Shuffle: {self.shuffle}")
@@ -1250,18 +1284,22 @@ class OCPMediaPlayer:
             self.mpris.toggle_shuffle()
         self._update_gui()
 
+    @require_default_session()
     def handle_playlist_set_request(self, message):
         self.playlist.clear()
         self.handle_playlist_queue_request(message)
 
+    @require_default_session()
     def handle_playlist_queue_request(self, message):
         for track in message.data["tracks"]:
             self.playlist.add_entry(track)
 
+    @require_default_session()
     def handle_playlist_clear_request(self, message):
         self.playlist.clear()
 
     # audio ducking - NB: we distinguish ducking vs corking  (lower volume vs pause)
+    @require_default_session()
     def handle_cork_request(self, message):
         """
         Pause audio on 'recognizer_loop:record_begin'
@@ -1271,6 +1309,7 @@ class OCPMediaPlayer:
             self.pause()
             self._paused_on_duck = True
 
+    @require_default_session()
     def handle_uncork_request(self, message):
         """
         Resume paused audio on 'recognizer_loop:record_begin'
@@ -1280,6 +1319,7 @@ class OCPMediaPlayer:
             self.resume()
             self._paused_on_duck = False
 
+    @require_default_session()
     def handle_duck_request(self, message):
         """
         Lower volume on 'recognizer_loop:record_begin'
@@ -1292,6 +1332,7 @@ class OCPMediaPlayer:
                 self.audio_service.lower_volume()
             self._paused_on_duck = True
 
+    @require_default_session()
     def handle_unduck_request(self, message):
         """
         Restore volume on 'recognizer_loop:audio_output_end'.
@@ -1378,6 +1419,7 @@ class OCPMediaPlayer:
         data = {"position": pos}
         self.bus.emit(message.response(data))
 
+    @require_default_session()
     def handle_set_track_position_request(self, message):
         miliseconds = message.data.get("position")
         self.seek(miliseconds)

--- a/ovos_media/service.py
+++ b/ovos_media/service.py
@@ -33,7 +33,7 @@ class MediaService(Thread):
     def __init__(self, ready_hook=on_ready, error_hook=on_error,
                  stopping_hook=on_stopping, alive_hook=on_alive,
                  started_hook=on_started, watchdog=lambda: None,
-                 bus=None, validate_source=True):
+                 bus=None, validate_source=None):
         super(MediaService, self).__init__()
 
         LOG.info("Starting Media Service")
@@ -47,6 +47,16 @@ class MediaService(Thread):
         self.config = Configuration().get("media", {})
         self.native_sources = self.config.get("native_sources", ["debug_cli", "audio"]) or []
 
+        # Only act on playback commands from the local/"default" session.
+        # In a HiveMind split the OCP pipeline (on the server) forwards
+        # commands stamped with the originating satellite session; a
+        # server-side ovos-media must ignore those (the satellite runs its
+        # own embedded ovos-media). The constructor argument wins; otherwise
+        # read `media.validate_source` from config (default True). A satellite
+        # that is not getting default-NAT'd sessions sets this False to act on
+        # all sessions.
+        if validate_source is None:
+            validate_source = self.config.get("validate_source", True)
         self.validate_source = validate_source
 
         if not bus:
@@ -56,7 +66,7 @@ class MediaService(Thread):
         self.status.bind(self.bus)
         self.status.set_alive()
         self.init_messagebus()
-        self.ocp = OCPMediaPlayer(self.bus)
+        self.ocp = OCPMediaPlayer(self.bus, validate_source=self.validate_source)
         self.bus.on('ovos.common_play.home', self.handle_home)
         self.bus.on("ovos.common_play.ping", self.handle_ping)
         self.bus.on("ovos.common_play.search.start", self.handle_search_start)

--- a/ovos_media/utils.py
+++ b/ovos_media/utils.py
@@ -11,7 +11,55 @@
 # limitations under the License.
 #
 
+from functools import wraps
+
 from ovos_config import Configuration
+from ovos_bus_client.session import SessionManager
+from ovos_utils.log import LOG
+
+
+def require_default_session():
+    """Decorator gating a bus handler to the local/"default" session only.
+
+    ovos-media is conceptually a *single* player bound to its own device — the
+    ``"default"`` session.  In a HiveMind split the OCP pipeline runs on the
+    server and forwards playback commands stamped with the *originating*
+    session.  A server-side ovos-media must NOT act on a satellite's command
+    (``session_id != "default"``): the satellite has its own embedded
+    ovos-media that handles it.  hivemind-core NATs the satellite's session to
+    ``"default"`` for that embedded instance (or the satellite sets
+    ``validate_source: false``), so the satellite's instance sees ``"default"``
+    and executes.
+
+    Mirrors :func:`ovos_audio.utils.require_default_session`.
+
+    A decorated handler runs only if any of:
+        - ``message`` is ``None`` (internal/synthetic call), OR
+        - the owning object's ``validate_source`` is falsy (act on everything), OR
+        - the message's session id is ``"default"`` (local request).
+
+    Otherwise it logs at debug level and returns ``None`` without acting.
+
+    The decorated method's ``self`` must expose a ``validate_source``
+    attribute; if missing it defaults to ``True`` (filter enabled).
+    """
+
+    def _decorator(func):
+        @wraps(func)
+        def func_wrapper(self, message=None):
+            validate = getattr(self, "validate_source", True)
+            validated = message is None or \
+                        not validate or \
+                        SessionManager.get(message).session_id == "default"
+            if validated:
+                return func(self, message)
+            LOG.debug(f"ignoring '{message.msg_type}' message, "
+                      f"not from the default/local session")
+            return None
+
+        return func_wrapper
+
+    return _decorator
 
 
 def validate_message_context(message, native_sources=None):

--- a/test/end2end/test_session_default_filter.py
+++ b/test/end2end/test_session_default_filter.py
@@ -1,0 +1,154 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end tests for the default/local session filter.
+
+ovos-media is a single player bound to its own device — the ``"default"``
+session.  Playback-executing handlers are gated by
+``ovos_media.utils.require_default_session``: a command stamped with a
+*non-default* session id (e.g. a HiveMind satellite session forwarded by the
+server-side OCP pipeline) must be IGNORED, while a ``"default"`` (or
+session-less) command must EXECUTE.  When ``validate_source`` is False the
+player acts on every session.
+
+Uses ``ovoscope.media.OCPPlayerHarness`` (real ``OCPMediaPlayer`` on a FakeBus
+with a MagicMock AudioService) so we can assert both player state and whether
+the backend was driven.
+"""
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session, SessionManager
+from ovos_utils.ocp import MediaEntry, PlaybackType, PlayerState
+
+from ovoscope.media import OCPPlayerHarness
+
+
+def _audio_entry(uri: str, title: str = "Test Track") -> MediaEntry:
+    """Return a minimal AUDIO MediaEntry."""
+    return MediaEntry(uri=uri, playback=PlaybackType.AUDIO, title=title)
+
+
+def _play_msg(uri: str, session_id: str = None) -> Message:
+    """Build an ``ovos.common_play.play`` message, optionally session-stamped.
+
+    Args:
+        uri: track URI to play.
+        session_id: if given, stamp ``context["session"]`` with this id; if
+            None, the message carries no session (resolves to "default").
+    """
+    track = _audio_entry(uri)
+    context = {}
+    if session_id is not None:
+        context["session"] = Session(session_id).serialize()
+    return Message("ovos.common_play.play",
+                   {"media": track.as_dict, "playlist": [track.as_dict]},
+                   context)
+
+
+class TestDefaultSessionFilter(unittest.TestCase):
+    """A non-default session is ignored; default / session-less executes."""
+
+    def tearDown(self) -> None:
+        # Tests register sessions on the global SessionManager; reset so they
+        # do not leak into each other.
+        SessionManager.sessions = {"default": SessionManager.default_session}
+
+    def test_default_session_play_executes(self) -> None:
+        """A play with session_id 'default' must drive the backend and PLAY."""
+        with OCPPlayerHarness() as h:
+            h.bus.emit(_play_msg("http://example.com/song.mp3", "default"))
+            import time
+            time.sleep(0.05)
+            h.assert_player_state(PlayerState.PLAYING)
+            h.player.audio_service.play.assert_called()
+            h.assert_now_playing_uri("http://example.com/song.mp3")
+
+    def test_sessionless_play_executes(self) -> None:
+        """A play with no session context resolves to 'default' and PLAYS."""
+        with OCPPlayerHarness() as h:
+            h.bus.emit(_play_msg("http://example.com/song.mp3", None))
+            import time
+            time.sleep(0.05)
+            h.assert_player_state(PlayerState.PLAYING)
+            h.player.audio_service.play.assert_called()
+
+    def test_satellite_session_play_ignored(self) -> None:
+        """A play from a non-default session must be IGNORED (no state change,
+        no backend call)."""
+        with OCPPlayerHarness() as h:
+            self.assertTrue(h.player.validate_source)
+            h.bus.emit(_play_msg("http://example.com/song.mp3", "satellite-x"))
+            import time
+            time.sleep(0.05)
+            # player stays STOPPED, backend never driven, nothing now-playing
+            h.assert_player_state(PlayerState.STOPPED)
+            h.player.audio_service.play.assert_not_called()
+            self.assertFalse(bool(h.player.now_playing.uri))
+
+    def test_satellite_pause_stop_ignored_while_default_plays(self) -> None:
+        """A satellite pause/stop must not disturb default-session playback."""
+        with OCPPlayerHarness() as h:
+            # default session starts playing
+            h.bus.emit(_play_msg("http://example.com/song.mp3", "default"))
+            import time
+            time.sleep(0.05)
+            h.assert_player_state(PlayerState.PLAYING)
+
+            # satellite tries to pause then stop — both ignored
+            h.bus.emit(Message("ovos.common_play.pause", {},
+                               {"session": Session("satellite-x").serialize()}))
+            time.sleep(0.05)
+            h.assert_player_state(PlayerState.PLAYING)
+
+            h.bus.emit(Message("ovos.common_play.stop", {},
+                               {"session": Session("satellite-x").serialize()}))
+            time.sleep(0.05)
+            h.assert_player_state(PlayerState.PLAYING)
+
+    def test_default_pause_stop_execute(self) -> None:
+        """Default-session pause then stop must execute normally."""
+        with OCPPlayerHarness() as h:
+            import time
+            h.bus.emit(_play_msg("http://example.com/song.mp3", "default"))
+            time.sleep(0.05)
+            h.bus.emit(Message("ovos.common_play.pause", {},
+                               {"session": Session("default").serialize()}))
+            time.sleep(0.05)
+            h.assert_player_state(PlayerState.PAUSED)
+            h.bus.emit(Message("ovos.common_play.stop", {},
+                               {"session": Session("default").serialize()}))
+            time.sleep(0.05)
+            h.assert_player_state(PlayerState.STOPPED)
+
+
+class TestValidateSourceDisabled(unittest.TestCase):
+    """With validate_source=False, a non-default session also executes."""
+
+    def tearDown(self) -> None:
+        SessionManager.sessions = {"default": SessionManager.default_session}
+
+    def test_satellite_session_play_executes_when_disabled(self) -> None:
+        """A satellite who disables the filter must act on its own session."""
+        with OCPPlayerHarness() as h:
+            # simulate a satellite that is NOT getting default-NAT'd sessions
+            h.player.validate_source = False
+            import time
+            h.bus.emit(_play_msg("http://example.com/song.mp3", "satellite-x"))
+            time.sleep(0.05)
+            h.assert_player_state(PlayerState.PLAYING)
+            h.player.audio_service.play.assert_called()
+            h.assert_now_playing_uri("http://example.com/song.mp3")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation — HiveMind satellite/server topology

`ovos-media` is a **single player bound to its own device** — conceptually the
`"default"` session. In a HiveMind split the OCP pipeline
(`ovos-ocp-pipeline-plugin`) runs on the **server** and forwards playback
commands stamped with the **originating** satellite session. Today the
server-side `ovos-media` would act on those and start playback on the *server's*
speakers — the wrong device.

The fix is a small **filter**, not a redesign: `ovos-media` acts only on the
local/`"default"` session and ignores commands from any other session.

- **Server-side** daemon ignores a satellite's command (`session_id != "default"`);
  the satellite has its own embedded `ovos-media`.
- **Satellite** daemon sees its session NAT'd to `"default"` by hivemind-core (or
  sets `validate_source: false`) and executes.

Mirrors `ovos-audio`'s `require_default_session()` + `validate_source` pattern.

## What changed

- **`require_default_session()` decorator** (`ovos_media/utils.py`): a handler runs
  only if `message is None`, `validate_source` is falsy, or the session id is
  `"default"`; otherwise logs debug and returns.
- **Gated playback-executing handlers** on `OCPMediaPlayer` (play, pause, resume,
  stop, play/pause toggle, next, previous, seek, set-track-position, playlist
  set/queue/clear, shuffle set/unset/toggle, repeat set/unset/toggle, duck, cork,
  uncork/unduck, like, unlike) and on the `mycroft.audio.service.*` legacy shim
  (`legacy_api.py`).
- **Inline guard on `NowPlaying.handle_external_play`** so a non-default play does
  not bleed metadata into the local now_playing.
- **Read-only query handlers stay ungated** (`status`, `track_info`,
  `get_track_length`/`position`, `list_backends`) — they reply to the asker, so a
  remote pipeline can still read state.
- **`validate_source`** wired through `MediaService` and `OCPMediaPlayer`,
  resolved from `media.validate_source` (default `True`).

## What deliberately did NOT change

No per-session virtual players; no changes to backends, GUI, or MPRIS; the single
global player stays. Per-session backend *feedback* cannot be disambiguated
because `ovos-plugin-manager`'s `MediaBackend` emits `ovos.common_play.media.state`
/ `.track.state` / `.player.state` as bare, session-less messages — the
single-player + default-session-filter model is the correct, minimal fit.

## Tests

`test/end2end/test_session_default_filter.py` (ovoscope `OCPPlayerHarness`): a
non-default session play/pause/stop is ignored (no state change, no backend call,
no now_playing bleed) when `validate_source=True`; a `"default"` / session-less
command executes; and with `validate_source=False` a non-default session also
executes.

Verified locally (CI is org-billing-blocked): **510 unittests + 65 end2end pass**
(`PYTHONPATH=. python -m pytest test/ -q -p no:ovoscope`).

## Docs

New `docs/sessions.md` (topology, gated-handler list, `validate_source` semantics,
why not per-session players); linked from `index.md`, `glossary.md`,
`architecture.md`; `validate_source` documented in `configuration.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)