### PR TITLE
fix: consistent MediaEntry representation and live GUI search results

### DIFF
--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -71,33 +71,37 @@ class OCPMediaCatalog(OVOSCommonPlaybackSkill):
                 "match_confidence": min(base_score + 35, 100),
                 "media_type": MediaType.MUSIC,
                 "playback": PlaybackType.AUDIO,
-                "playlist": self.liked_songs_playlist,  # return full playlist result
+                "playlist": [e.as_dict for e in self.liked_songs_playlist],
                 "skill_icon": self.skill_icon,
                 "title": "Liked Songs",
                 "skill_id": self.skill_id
             }
 
         if entities.get("song_name"):
-            title = entities["song_name"]
-            candidates = [song for song in self.liked_songs_playlist
-                          if title.lower() in song["title"].lower()]
-            for c in candidates:
-                c["match_confidence"] = min(base_score + 40, 100)
-                c["media_type"] = MediaType.MUSIC
-                c["playback"] = PlaybackType.AUDIO
-                c["skill_id"] = self.skill_id
-                c["skill_icon"] = self.skill_icon
-                yield c
+            title = entities["song_name"].lower()
+            for entry in self.liked_songs_playlist:
+                if title not in entry.title.lower():
+                    continue
+                result = entry.as_dict
+                result["match_confidence"] = min(base_score + 40, 100)
+                result["skill_id"] = self.skill_id
+                result["skill_icon"] = self.skill_icon
+                yield result
 
     @property
-    def liked_songs_playlist(self):
-        pl = list(self.liked_songs.values())
-        for idx, p in enumerate(pl):
-            pl[idx]["media_type"] = MediaType.MUSIC
-            pl[idx]["playback"] = PlaybackType.AUDIO
-            # HACK to allow sort_by_conf to work once this is in a Playlist object
-            pl[idx]["match_confidence"] = p.get("play_count", 0) + 50
-        return sorted(pl, key=lambda k: k.get("play_count", 0), reverse=True)
+    def liked_songs_playlist(self) -> List[MediaEntry]:
+        # canonicalize the persisted liked-songs store (raw dicts) into
+        # MediaEntry objects; match_confidence tracks play_count so the entries
+        # sort most-played-first once handed to a Playlist.
+        entries = [MediaEntry(uri=uri,
+                              title=song.get("title", ""),
+                              artist=song.get("artist", ""),
+                              image=song.get("image", ""),
+                              media_type=MediaType.MUSIC,
+                              playback=PlaybackType.AUDIO,
+                              match_confidence=song.get("play_count", 0) + 50)
+                   for uri, song in self.liked_songs.items()]
+        return sorted(entries, key=lambda e: e.match_confidence, reverse=True)
 
     def handle_skill_announce(self, message):
         skill_id = message.data.get("skill_id")
@@ -172,21 +176,9 @@ class NowPlaying(MediaEntry):
         """
         return MediaEntry(**self.as_dict)
 
-    @property
-    def as_dict(self) -> dict:
-        """
-        Return a dict representation of this MediaEntry
-        """
-        return {"uri": self.uri,
-                "title": self.title,
-                "artist": self.artist,
-                "image": self.image,
-                "playback": self.playback,
-                "status": self.status,
-                "media_type": self.media_type,
-                "length": self.length,
-                "skill_id": self.skill_id,
-                "skill_icon": self.skill_icon}
+    # as_dict is inherited from MediaEntry: it serializes every dataclass field,
+    # so fields added to MediaEntry survive the round-trip to the GUI/bus instead
+    # of being dropped by a hand-maintained key list.
 
     def shutdown(self):
         """
@@ -376,7 +368,6 @@ class OCPMediaPlayer:
         self.shuffle: bool = False
         self.track_history: dict = {}  # Dict of track URI to play count
         self._paused_on_duck: bool = False
-        self._last_search_results: list = []
 
         self.now_playing: NowPlaying = NowPlaying(bus, player=self)
         self.media: OCPMediaCatalog = OCPMediaCatalog(bus=bus, skill_id=OCP_ID + ".favorites")
@@ -459,7 +450,7 @@ class OCPMediaPlayer:
         self.gui.show_media_player(
             now_playing=np.as_dict if np and np.uri else None,
             playlist=[e.as_dict for e in self.playlist.entries] if self.playlist else [],
-            search_results=self._last_search_results or [],
+            search_results=[e.as_dict for e in self.search_results],
             state=state_map.get(self.state, "stopped"),
         )
 
@@ -823,7 +814,7 @@ class OCPMediaPlayer:
         self.gui.show_media_player(
             now_playing=None,
             playlist=[e.as_dict for e in self.playlist.entries] if self.playlist else [],
-            search_results=self._last_search_results or [],
+            search_results=[e.as_dict for e in self.search_results],
             state="error",
         )
         LOG.warning(f"Failed to play: {self.now_playing}")
@@ -1166,7 +1157,7 @@ class OCPMediaPlayer:
         self.gui.show_media_player(
             now_playing=None,
             playlist=[e.as_dict for e in self.playlist.entries] if self.playlist else [],
-            search_results=self._last_search_results or [],
+            search_results=[e.as_dict for e in self.search_results],
             state="error",
         )
 

--- a/test/unittests/test_gui.py
+++ b/test/unittests/test_gui.py
@@ -29,7 +29,6 @@ def _make_player():
         p.shuffle = False
         p.track_history = {}
         p._paused_on_duck = False
-        p._last_search_results = []
         p.now_playing = MagicMock()
         p.now_playing.uri = "http://example.com/track.mp3"
         p.playlist = MagicMock()
@@ -84,9 +83,15 @@ class TestUpdateGuiCallsShowMediaPlayer(unittest.TestCase):
         self.assertEqual(kwargs["playlist"], [{"title": "Track A"}])
 
     def test_update_gui_passes_search_results(self):
-        """_update_gui() passes _last_search_results as search_results."""
+        """_update_gui() serializes live search_playlist entries as search_results.
+
+        Regression: search_results used to read a dead `_last_search_results`
+        field that was never assigned, so the GUI always saw an empty list.
+        """
         p = _make_player()
-        p._last_search_results = [{"title": "Result 1"}]
+        entry = MagicMock()
+        entry.as_dict = {"title": "Result 1"}
+        p.media.search_playlist.entries = [entry]
         p._update_gui()
         kwargs = p.gui.show_media_player.call_args[1]
         self.assertEqual(kwargs["search_results"], [{"title": "Result 1"}])

--- a/test/unittests/test_media_entry_shape.py
+++ b/test/unittests/test_media_entry_shape.py
@@ -1,0 +1,93 @@
+"""Regression tests for MediaEntry representation consistency.
+
+Covers two defects surfaced by the ecosystem audit:
+
+* NowPlaying used to override ``as_dict`` with a hard-coded key list, so any
+  field added to MediaEntry was silently dropped from the GUI/bus payload.
+* ``OCPMediaCatalog.liked_songs_playlist`` used to return (and mutate) the raw
+  persisted store dicts, mixing plain dicts with the MediaEntry objects the
+  playback path expects and polluting the on-disk store.
+"""
+import unittest
+from unittest.mock import patch
+
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import MediaEntry, MediaType, PlaybackType
+
+
+class TestNowPlayingSerializesAllFields(unittest.TestCase):
+    """NowPlaying.as_dict must serialize the full MediaEntry field set."""
+
+    def _make_now_playing(self):
+        from ovos_media.player import NowPlaying
+        with patch("ovos_media.player.load_stream_extractors"):
+            return NowPlaying(FakeBus())
+
+    def test_as_dict_covers_every_dataclass_field(self):
+        np = self._make_now_playing()
+        expected = set(MediaEntry(uri="u").as_dict)
+        self.assertEqual(set(np.as_dict), expected)
+
+    def test_non_legacy_fields_survive_round_trip(self):
+        # match_confidence and javascript were dropped by the old hard-coded
+        # key list; they must now round-trip through as_dict.
+        np = self._make_now_playing()
+        np.match_confidence = 73
+        np.javascript = "play();"
+        self.assertEqual(np.as_dict["match_confidence"], 73)
+        self.assertEqual(np.as_dict["javascript"], "play();")
+
+
+class TestLikedSongsPlaylistShape(unittest.TestCase):
+    """liked_songs_playlist must yield canonical MediaEntry objects."""
+
+    def _make_catalog(self, liked):
+        from ovos_media.player import OCPMediaCatalog
+        cat = OCPMediaCatalog.__new__(OCPMediaCatalog)
+        cat.liked_songs = dict(liked)
+        cat.skill_icon = "icon.svg"
+        cat.skill_id = "ovos.common_play"
+        return cat
+
+    def test_returns_media_entries_with_attribute_access(self):
+        cat = self._make_catalog({
+            "file://a.mp3": {"title": "Alpha", "play_count": 2},
+            "file://b.mp3": {"title": "Beta", "play_count": 5},
+        })
+        entries = cat.liked_songs_playlist
+        self.assertTrue(all(isinstance(e, MediaEntry) for e in entries))
+        # attribute access must work on every entry (the playback path uses it)
+        self.assertEqual([e.title for e in entries], ["Beta", "Alpha"])
+        self.assertTrue(all(e.playback == PlaybackType.AUDIO for e in entries))
+        self.assertTrue(all(e.media_type == MediaType.MUSIC for e in entries))
+
+    def test_does_not_mutate_persisted_store(self):
+        stored = {"file://a.mp3": {"title": "Alpha", "play_count": 1}}
+        cat = self._make_catalog(stored)
+        _ = cat.liked_songs_playlist
+        # the raw store dict must not gain search-only keys
+        self.assertEqual(stored["file://a.mp3"],
+                         {"title": "Alpha", "play_count": 1})
+
+    def test_search_song_branch_yields_serializable_dicts(self):
+        cat = self._make_catalog(
+            {"file://a.mp3": {"title": "Alpha", "play_count": 1}})
+
+        def fake_voc_match(phrase):
+            return {"song_name": "alpha"}
+
+        with patch.object(cat, "ocp_voc_match", side_effect=fake_voc_match):
+            results = list(cat.search_db("alpha", MediaType.MUSIC))
+
+        self.assertEqual(len(results), 1)
+        r = results[0]
+        # yielded results are dicts (OCP search contract) but carry the same
+        # data the MediaEntry path exposes as attributes
+        self.assertEqual(r["uri"], "file://a.mp3")
+        self.assertEqual(r["title"], "Alpha")
+        self.assertEqual(r["playback"], PlaybackType.AUDIO)
+        self.assertEqual(MediaEntry.from_dict(r).title, "Alpha")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_player.py
+++ b/test/unittests/test_player.py
@@ -29,7 +29,6 @@ def _make_player():
         p.shuffle = False
         p.track_history = {}
         p._paused_on_duck = False
-        p._last_search_results = []
         p.now_playing = MagicMock()
         p.playlist = MagicMock()
         p.playlist.as_list.return_value = []

--- a/test/unittests/test_player_coverage.py
+++ b/test/unittests/test_player_coverage.py
@@ -70,7 +70,6 @@ def _make_player(playback_type: PlaybackType = PlaybackType.AUDIO):
         p.shuffle = False
         p.track_history = {}
         p._paused_on_duck = False
-        p._last_search_results = []
         p.now_playing = MagicMock()
         p.now_playing.playback = playback_type
         p.now_playing.skill_id = "test.skill"

--- a/test/unittests/test_player_coverage2.py
+++ b/test/unittests/test_player_coverage2.py
@@ -32,7 +32,6 @@ def _make_player(playback_type=PlaybackType.AUDIO):
         p.shuffle = False
         p.track_history = {}
         p._paused_on_duck = False
-        p._last_search_results = []
         p.now_playing = MagicMock()
         p.now_playing.playback = playback_type
         p.now_playing.skill_id = "test.skill"

--- a/test/unittests/test_player_handlers.py
+++ b/test/unittests/test_player_handlers.py
@@ -68,7 +68,6 @@ def _make_player(playback_type: PlaybackType = PlaybackType.AUDIO):
         p.shuffle = False
         p.track_history = {}
         p._paused_on_duck = False
-        p._last_search_results = []
         p.now_playing = MagicMock()
         p.now_playing.playback = playback_type
         p.now_playing.skill_id = "test.skill"

--- a/test/unittests/test_player_state.py
+++ b/test/unittests/test_player_state.py
@@ -31,7 +31,6 @@ def _make_player():
         p.shuffle = False
         p.track_history = {}
         p._paused_on_duck = False
-        p._last_search_results = []
         p.now_playing = MagicMock()
         p.now_playing.playback = PlaybackType.AUDIO
         p.now_playing.skill_id = "test.skill"


### PR DESCRIPTION
Fixes three related defects in `player.py`, all rooted in inconsistent `MediaEntry` handling.

### 1. GUI never shows search results
`_update_gui` / `on_invalid_stream` / `handle_invalid_media` read `search_results` from `self._last_search_results` — a field that was initialized (`player.py`) but never assigned anywhere, so the GUI always received `[]`. The real results live in `search_playlist`, exposed via the `search_results` property. Now the three GUI pushes serialize the live `search_results`, and the dead field is removed.

### 2. NowPlaying silently drops new fields on serialize
`NowPlaying` overrode `as_dict` with a hard-coded key list, so any field added to `MediaEntry` (e.g. `match_confidence`, `javascript`) was dropped from the GUI/bus payload. The override is removed so serialization delegates to the base dataclass and covers the full field set. This also makes `now_playing` enum serialization consistent with the playlist entries (both now emit ints).

### 3. liked_songs represented as both dict and MediaEntry
`liked_songs_playlist` returned the raw persisted store dicts and mutated them in place (adding `match_confidence`/`media_type`/`playback`), polluting the on-disk store and mixing plain dicts into the MediaEntry-based playback path. It now builds canonical `MediaEntry` objects at the seam; the `@ocp_search` generator serializes to dicts only at the yield boundary (the OCP contract), and the store is left untouched.

### Tests
- New `test/unittests/test_media_entry_shape.py` — NowPlaying serializes every dataclass field, non-legacy fields round-trip, `liked_songs_playlist` yields typed entries with attribute access, the store is not mutated, and the search generator yields serializable dicts.
- `test_gui.py` search-results test rewritten to assert live serialization.
- All six regression tests fail on the pre-fix code and pass after.

Full suite green in a fresh venv: 515 unit + 65 end2end passed.