### PR TITLE
fix: remove the media.state listener in remove_listeners() (leaked handler)

### DIFF
--- a/ovos_media/media_backends/base.py
+++ b/ovos_media/media_backends/base.py
@@ -463,3 +463,4 @@ class BaseMediaService:
         self.bus.remove(f'ovos.{self.namespace}.service.list_backends', self.handle_list_backends)
         self.bus.remove(f'ovos.{self.namespace}.service.duck', self.lower_volume)
         self.bus.remove(f'ovos.{self.namespace}.service.unduck', self.restore_volume)
+        self.bus.remove("ovos.common_play.media.state", self.handle_media_state_change)


### PR DESCRIPTION
## Bug

`BaseMediaService.__init__` registers a handler on `ovos.common_play.media.state`:

```python
self.bus.on("ovos.common_play.media.state", self.handle_media_state_change)  # base.py:42
```

but `remove_listeners()` (called from `shutdown()`) mirrors every other `ovos.{namespace}.service.*` handler **except** this one. So on any in-process shutdown/reconstruct cycle — the daemon-lifecycle tests, or a supervisor restarting the service without killing the interpreter — the previous `handle_media_state_change` stays bound to the bus. Handlers accumulate across restarts, and a single `ovos.common_play.media.state` event then fires the handler N times for N restarts, potentially calling into a backend that was already torn down/replaced.

## Fix

One line — add the symmetric `bus.remove` in `remove_listeners()`:

```python
self.bus.remove("ovos.common_play.media.state", self.handle_media_state_change)
```

Found while auditing ovos-media for the OVOS Technical Manual. Draft pending maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed media service shutdown so global media-state event listeners are properly removed.
  * Prevented media state callbacks from remaining active after a service is stopped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->