### PR TITLE
ci: fire alpha release on merged PRs, publish to PyPI

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -1,11 +1,21 @@
 name: Publish Alpha
 on:
-  push:
-    branches:
-      - dev
   workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches: [dev]
 
 jobs:
   publish_alpha:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     uses: OpenVoiceOS/gh-automations/.github/workflows/publish-alpha.yml@dev
     secrets: inherit
+    with:
+      branch: 'dev'
+      version_file: 'ovos_media/version.py'
+      update_changelog: true
+      publish_prerelease: true
+      propose_release: true
+      changelog_max_issues: 100
+      publish_pypi: true
+      notify_matrix: true


### PR DESCRIPTION
## Summary

- The `publish-alpha` caller triggered on `push` to `dev`, but the shared `gh-automations` workflow only runs its bump job when `github.event.pull_request.merged == true` or on `workflow_dispatch` — so every merge to dev skipped the alpha release.
- It also passed no inputs, so `publish_pypi` stayed at its `false` default and even a manual dispatch would not have published.
- Switch the trigger to `pull_request: [closed]` on `dev` (plus dispatch) and pass the standard org inputs (`version_file`, `publish_pypi: true`, changelog, release proposal, Matrix notify), matching `release_workflow.yml` in other OVOS repos.

## Test plan

- [ ] After merge, the Publish Alpha run for this PR's close event bumps `ovos_media/version.py` and publishes an alpha to PyPI

## AI Usage Disclaimer

Claude Fable. Human reviewed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated alpha publishing to run manually or after pull requests targeting the development branch are merged.
  * Added publishing and notification options to improve release workflow control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->