### PR TITLE
fix(deps): bump ecosystem dependency floors to current majors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 
 dependencies = [
-    "ovos-utils~=0.0, >=0.1.0a13",
-    "ovos-bus-client~=1.3, >=1.3.7",
+    "ovos-utils~=0.0, >=0.13.0a1",
+    "ovos-bus-client~=2.0, >=2.0.0a1",
     "ovos-config~=2.1,>=2.1.1",
-    "ovos-plugin-manager~=2.1, >=2.1",
+    "ovos-plugin-manager~=2.1, >=2.2.0a1",
     "ovos-workshop>=0.0.15",
     "ovos-gui-api-client>=0.0.2a1",
     "json-database>=0.9.0",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
-ovos-utils~=0.0, >=0.1.0a13
-ovos-bus-client~=1.3, >=1.3.7
+ovos-utils~=0.0, >=0.13.0a1
+ovos-bus-client~=2.0, >=2.0.0a1
 ovos-config~=2.1,>=2.1.1
-ovos-plugin-manager~=2.1, >=2.1
+ovos-plugin-manager~=2.1, >=2.2.0a1
 dbus_next

--- a/test/unittests/test_gui.py
+++ b/test/unittests/test_gui.py
@@ -7,6 +7,7 @@ pause, stop, and related state changes.
 import unittest
 from unittest.mock import MagicMock, patch, call
 
+from ovos_bus_client.message import Message
 from ovos_utils.ocp import PlayerState, LoopState, MediaState, PlaybackType
 from ovos_utils.fakebus import FakeBus
 
@@ -182,25 +183,25 @@ class TestShuffleRepeatCallsUpdateGui(unittest.TestCase):
     def test_set_shuffle_calls_update_gui(self):
         p = _make_player()
         p._update_gui = MagicMock()
-        p.handle_set_shuffle(MagicMock())
+        p.handle_set_shuffle(Message("ocp.set_shuffle"))
         p._update_gui.assert_called_once()
 
     def test_unset_shuffle_calls_update_gui(self):
         p = _make_player()
         p._update_gui = MagicMock()
-        p.handle_unset_shuffle(MagicMock())
+        p.handle_unset_shuffle(Message("ocp.unset_shuffle"))
         p._update_gui.assert_called_once()
 
     def test_set_repeat_calls_update_gui(self):
         p = _make_player()
         p._update_gui = MagicMock()
-        p.handle_set_repeat(MagicMock())
+        p.handle_set_repeat(Message("ocp.set_repeat"))
         p._update_gui.assert_called_once()
 
     def test_unset_repeat_calls_update_gui(self):
         p = _make_player()
         p._update_gui = MagicMock()
-        p.handle_unset_repeat(MagicMock())
+        p.handle_unset_repeat(Message("ocp.unset_repeat"))
         p._update_gui.assert_called_once()
 
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This bumps the dependency floors in requirements.txt and pyproject.toml to current majors, checked against PyPI: ovos-plugin-manager to >=2.2.0a1 (was >=2.1), ovos-utils to >=0.13.0a1 (was >=0.1.0a13), and ovos-bus-client to >=2.0.0a1 (was >=1.3.7). I checked every ovos_bus_client usage in the repo (Message, MessageBusClient, SessionManager) and nothing depends on APIs that were removed going into the 2.x line. No lockfile is added, per the repo's policy of always tracking latest.

This replaces the three separate dependabot PRs (#66, #67, #68), which each only bumped within the old 1.x/0.x/2.1.x ranges and would have left the repo behind again immediately.

While bumping, four tests in test_gui.py broke because they passed a bare MagicMock() as the bus Message. ovos-bus-client 2.x validates the Session more strictly and raised MalformedSession on the mock's fake context. That was a gap in the test mocking, not a real incompatibility, so those tests now use a real Message instead.

Tested in a throwaway venv built with uv and prerelease installs allowed: 582 passed, 38 warnings, in about three minutes.
