### PR TITLE
fix: bound mpris retry loop, tolerate real-world metadata shapes, deliver mpris config

### DIFF
--- a/ovos_media/mpris.py
+++ b/ovos_media/mpris.py
@@ -397,6 +397,10 @@ class OcpMprisExporter(Thread):
         if name not in self.players:
             LOG.error(f"Invalid player: {name}")
             return
+        if name not in self.player_meta:
+            # not yet queried (race with scan_players), nothing to stop
+            LOG.debug(f"player {name} has no metadata yet, skipping stop")
+            return
         try:
             if self.player_meta[name]["state"] == "Playing":
                 LOG.info(f"Stopping MPRIS player: {name}")
@@ -512,7 +516,12 @@ class OcpMprisExporter(Thread):
             if k == "xesam:title":
                 ocp_data["title"] = v.value
             elif k == "xesam:artist":
-                ocp_data["artist"] = v.value[0]
+                artist = v.value
+                if isinstance(artist, (list, tuple)):
+                    if artist:
+                        ocp_data["artist"] = artist[0]
+                elif isinstance(artist, str):
+                    ocp_data["artist"] = artist
             elif k == "xesam:album":
                 ocp_data["album"] = v.value
             elif k == "mpris:artUrl":
@@ -647,17 +656,20 @@ class OcpMprisExporter(Thread):
     def run(self):
         count = 0
         max_count = 5
-        try:
-            self.loop.run_until_complete(self.event_loop())
-        except Exception as e:
-            if not self.shutdown_event.is_set():
+        while True:
+            try:
+                self.loop.run_until_complete(self.event_loop())
+                return
+            except Exception as e:
+                if self.shutdown_event.is_set():
+                    return
                 LOG.exception(e)
                 count += 1
                 if count <= max_count:
                     LOG.warning(f"MPRIS daemon crashed, restarting: retry {count} out of {max_count}")
-                    self.run()
-                else:
-                    LOG.error("MPRIS exited")
+                    continue
+                LOG.error("MPRIS exited")
+                return
 
     def play_prev(self):
         self.prev_event.set()

--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -519,7 +519,8 @@ class OCPMediaPlayer:
         if self.ocp_config.get("enable_mpris", False) is False:
             LOG.info("MPRIS integration is disabled")
         else:
-            self.mpris = OcpMprisExporter(self, manage_players=manage_players)
+            self.mpris = OcpMprisExporter(self, config=self.ocp_config,
+                                          manage_players=manage_players)
 
         self.gui = GUIInterface("ovos.common_play", bus=bus)
         self.register_bus_handlers()

--- a/test/unittests/test_mpris.py
+++ b/test/unittests/test_mpris.py
@@ -486,6 +486,68 @@ class TestMeta2Dict(unittest.TestCase):
         # no title and no state → state remains None (falsy) and not overridden
         self.assertIsNone(result["state"])
 
+    def test_artist_empty_list_does_not_raise_and_is_skipped(self):
+        # browsers/podcast apps send an empty xesam:artist list
+        result = self._call({"xesam:artist": self._make_variant([])})
+        self.assertNotIn("artist", result)
+
+    def test_artist_plain_string_kept_whole(self):
+        # a plain string must not be truncated to its first character
+        result = self._call({"xesam:artist": self._make_variant("Solo")})
+        self.assertEqual(result["artist"], "Solo")
+
+    def test_artist_normal_list_takes_first_element(self):
+        result = self._call({"xesam:artist": self._make_variant(["A", "B"])})
+        self.assertEqual(result["artist"], "A")
+
+    def test_artist_none_is_skipped(self):
+        result = self._call({"xesam:artist": self._make_variant(None)})
+        self.assertNotIn("artist", result)
+
+
+class TestRunRetryBound(unittest.TestCase):
+    """run() must bound its retry loop and never recurse unboundedly."""
+
+    def test_run_retries_bounded_and_does_not_recurse(self):
+        ctl, _ = _make_exporter()
+        ctl.shutdown_event = MagicMock()
+        ctl.shutdown_event.is_set.return_value = False
+
+        loop = MagicMock()
+        loop.run_until_complete = MagicMock(side_effect=RuntimeError("boom"))
+        ctl.loop = loop
+
+        with patch("ovos_media.mpris.LOG") as mock_log:
+            ctl.run()  # must return, not raise RecursionError
+            mock_log.error.assert_called_with("MPRIS exited")
+
+        # initial attempt + 5 retries = 6 calls
+        self.assertEqual(loop.run_until_complete.call_count, 6)
+
+    def test_run_stops_immediately_once_shutdown_event_is_set(self):
+        ctl, _ = _make_exporter()
+        ctl.shutdown_event = MagicMock()
+        ctl.shutdown_event.is_set.return_value = True
+
+        loop = MagicMock()
+        loop.run_until_complete = MagicMock(side_effect=RuntimeError("boom"))
+        ctl.loop = loop
+
+        ctl.run()
+        loop.run_until_complete.assert_called_once()
+
+    def test_run_returns_cleanly_on_success(self):
+        ctl, _ = _make_exporter()
+        ctl.shutdown_event = MagicMock()
+        ctl.shutdown_event.is_set.return_value = False
+
+        loop = MagicMock()
+        loop.run_until_complete = MagicMock(return_value=None)
+        ctl.loop = loop
+
+        ctl.run()
+        loop.run_until_complete.assert_called_once()
+
 
 class TestHandleLostPlayer(unittest.IsolatedAsyncioTestCase):
     """handle_lost_player must remove player from players and player_meta."""

--- a/test/unittests/test_mpris_coverage.py
+++ b/test/unittests/test_mpris_coverage.py
@@ -622,6 +622,16 @@ class TestInternalPlayerControl(unittest.IsolatedAsyncioTestCase):
         # Should not raise
         await ctl._stop_player("nonexistent")
 
+    async def test_stop_player_skips_when_in_players_but_not_yet_in_player_meta(self):
+        # race window: scan_players() adds to self.players before query_player()
+        # has populated player_meta for that name
+        ctl, _ = _make_exporter()
+        proxy, iface = self._make_player_proxy()
+        ctl.players["new_player"] = proxy
+        # deliberately NOT setting ctl.player_meta["new_player"]
+        await ctl._stop_player("new_player")  # must not raise KeyError
+        iface.call_stop.assert_not_awaited()
+
     async def test_shuffle_enable_calls_set_shuffle_true(self):
         ctl, iface, name = self._make_ctl_with_player()
         await ctl._shuffle_enable(name)

--- a/test/unittests/test_player_mpris_config.py
+++ b/test/unittests/test_player_mpris_config.py
@@ -1,0 +1,58 @@
+"""Regression test: OCPMediaPlayer must forward its media config block to
+OcpMprisExporter, so config keys like mpris_poll_interval, ignored_players
+and dbus_type actually reach the exporter instead of being dead config.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ovos_utils.fakebus import FakeBus
+
+
+class TestMprisConfigForwarded(unittest.TestCase):
+    """__init__ must pass config=self.ocp_config to OcpMprisExporter."""
+
+    def _make_player(self, media_config):
+        from ovos_media.player import OCPMediaPlayer
+        with patch("ovos_media.player.AudioService"), \
+             patch("ovos_media.player.VideoService"), \
+             patch("ovos_media.player.WebService"), \
+             patch("ovos_media.player.OcpMprisExporter") as mock_exporter, \
+             patch("ovos_media.player.GUIInterface"), \
+             patch("ovos_media.player.NowPlaying"), \
+             patch("ovos_media.player.Playlist"), \
+             patch("ovos_media.player.OCPMediaCatalog"), \
+             patch.object(OCPMediaPlayer, "register_bus_handlers"):
+            p = OCPMediaPlayer(bus=FakeBus(), config=media_config)
+        return p, mock_exporter
+
+    def test_custom_poll_interval_reaches_exporter_config(self):
+        media_config = {"enable_mpris": True,
+                        "manage_external_players": True,
+                        "mpris_poll_interval": 42}
+        p, mock_exporter = self._make_player(media_config)
+
+        mock_exporter.assert_called_once()
+        _, kwargs = mock_exporter.call_args
+        self.assertIn("config", kwargs)
+        self.assertEqual(kwargs["config"].get("mpris_poll_interval"), 42)
+        self.assertIs(kwargs["config"], p.ocp_config)
+
+    def test_ignored_players_and_dbus_type_reach_exporter_config(self):
+        media_config = {"enable_mpris": True,
+                        "ignored_players": ["org.mpris.MediaPlayer2.foo"],
+                        "dbus_type": "system"}
+        p, mock_exporter = self._make_player(media_config)
+
+        _, kwargs = mock_exporter.call_args
+        self.assertEqual(kwargs["config"].get("ignored_players"),
+                         ["org.mpris.MediaPlayer2.foo"])
+        self.assertEqual(kwargs["config"].get("dbus_type"), "system")
+
+    def test_mpris_disabled_does_not_construct_exporter(self):
+        media_config = {"enable_mpris": False}
+        p, mock_exporter = self._make_player(media_config)
+        mock_exporter.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This is batch B of wave 1 of the ongoing audit loop, covering MPRIS. Four real bugs got fixed. The retry loop recursed into itself on every failed attempt with no cap, so a persistent failure caused unbounded recursion — reproduced directly, it threw a RecursionError after 281 retries. It's now a bounded loop capped at five retries. Metadata parsing crashed with an IndexError whenever a track had an empty artist list, which happens with some browsers and podcast apps, and it also truncated plain-string artist names down to a single character. The MPRIS exporter never actually received its config, so the dbus_type, ignored_players, and poll-interval settings were dead and had no effect. And a race window between player registration and the first status query could throw a KeyError when stopping a player — found and fixed while working through this batch.

Before these fixes were applied, reverting them produced 7 failures out of 543 tests, proving the fixes are load-bearing. After the fixes, on the rebased result, 550 tests pass. The orchestrator verified this live.
