### PR TITLE
fix: legacy audio API coexistence gaps

### DIFF
--- a/ovos_media/legacy_api.py
+++ b/ovos_media/legacy_api.py
@@ -144,6 +144,7 @@ class LegacyAudioServiceCompat:
         """
         tracks: List = message.data.get("tracks", [])
         repeat: bool = message.data.get("repeat", False)
+        utterance: str = message.data.get("utterance", "")
 
         if not tracks:
             LOG.warning("mycroft.audio.service.play: no tracks provided")
@@ -159,6 +160,7 @@ class LegacyAudioServiceCompat:
             "playlist": playlist,
             "disambiguation": playlist,
             "repeat": repeat,
+            "utterance": utterance,
         }))
 
     @require_default_session()

--- a/ovos_media/media_backends/base.py
+++ b/ovos_media/media_backends/base.py
@@ -67,11 +67,20 @@ class BaseMediaService:
             LOG.info(f'New {self.namespace} track coming up!')
             self.bus.emit(Message(f'ovos.{self.namespace}.playing_track',
                                   data={'track': track}))
+            if self.namespace == "audio":
+                # legacy ovos-audio twin — some skills still block on this
+                # exact message type waiting for playback to start
+                self.bus.emit(Message('mycroft.audio.playing_track',
+                                      data={'track': track}))
         else:
             # If no track is about to start last track of the queue has been
             # played.
             LOG.debug('End of playlist!')
             self.bus.emit(Message(f'ovos.{self.namespace}.queue_end'))
+            if self.namespace == "audio":
+                # legacy ovos-audio twin — some skills block forever waiting
+                # on this exact message type at the end of playback
+                self.bus.emit(Message('mycroft.audio.queue_end'))
 
     def load_services(self):
         """Method for loading services.
@@ -336,6 +345,19 @@ class BaseMediaService:
             return
         with self.service_lock:
             tracks = message.data['tracks']
+            if not tracks:
+                LOG.warning(f"ovos.{self.namespace}.service.play: no tracks provided")
+                return
+
+            # self.play() takes a single uri, not a tracklist — mirror how
+            # ovos-audio's legacy service resolves the first playable track.
+            # 'tracks' may be a bare uri string, a list of uri strings, or a
+            # list of (uri, mime) tuples.
+            if isinstance(tracks, str):
+                uri = tracks
+            else:
+                first = tracks[0]
+                uri = first[0] if isinstance(first, (list, tuple)) else first
 
             # Find if the user wants to use a specific backend
             query = message.data.get("utterance", "").lower()
@@ -353,7 +375,7 @@ class BaseMediaService:
 
             try:
                 # Use a timer to avoid blocking the bus event loop
-                threading.Timer(0.5, self.play, args=[tracks, preferred_service]).start()
+                threading.Timer(0.5, self.play, args=[uri, preferred_service]).start()
             except Exception as e:
                 LOG.exception(e)
 

--- a/ovos_media/utils.py
+++ b/ovos_media/utils.py
@@ -48,10 +48,18 @@ def require_default_session():
         @wraps(func)
         def func_wrapper(self, message=None):
             validate = getattr(self, "validate_source", True)
-            validated = message is None or \
-                        not validate or \
-                        SessionManager.get(message).session_id == "default"
-            if validated:
+            if message is None or not validate:
+                return func(self, message)
+            try:
+                is_default = SessionManager.get(message).session_id == "default"
+            except Exception as e:
+                # malformed session context (eg. empty/non-str session_id) —
+                # a hostile or buggy peer must never be able to crash a
+                # gated handler; treat it as NOT the default/local session
+                LOG.warning(f"ignoring '{message.msg_type}' message, "
+                           f"malformed session context: {e}")
+                return None
+            if is_default:
                 return func(self, message)
             LOG.debug(f"ignoring '{message.msg_type}' message, "
                       f"not from the default/local session")

--- a/test/unittests/test_base_coverage.py
+++ b/test/unittests/test_base_coverage.py
@@ -411,5 +411,109 @@ class TestHandleSeekBackward(unittest.TestCase):
         svc.current.seek_backward.assert_called_with(10)
 
 
+class TestTrackStartLegacyTwins(unittest.TestCase):
+    """C1: track_start must emit mycroft.audio.* twins alongside ovos.audio.*
+    so legacy skills blocking on mycroft.audio.playing_track /
+    mycroft.audio.queue_end do not hang forever."""
+
+    def test_track_start_emits_ovos_and_mycroft_playing_track(self):
+        svc, bus = _make_service()
+        svc.namespace = "audio"
+
+        received = {"ovos": [], "mycroft": []}
+        bus.on("ovos.audio.playing_track", lambda m: received["ovos"].append(m))
+        bus.on("mycroft.audio.playing_track", lambda m: received["mycroft"].append(m))
+
+        svc.track_start("http://example.com/track.mp3")
+
+        self.assertEqual(len(received["ovos"]), 1)
+        self.assertEqual(len(received["mycroft"]), 1)
+        self.assertEqual(received["mycroft"][0].data["track"],
+                         "http://example.com/track.mp3")
+
+    def test_track_start_none_emits_ovos_and_mycroft_queue_end(self):
+        svc, bus = _make_service()
+        svc.namespace = "audio"
+
+        received = {"ovos": [], "mycroft": []}
+        bus.on("ovos.audio.queue_end", lambda m: received["ovos"].append(m))
+        bus.on("mycroft.audio.queue_end", lambda m: received["mycroft"].append(m))
+
+        svc.track_start(None)
+
+        self.assertEqual(len(received["ovos"]), 1)
+        self.assertEqual(len(received["mycroft"]), 1)
+
+    def test_track_start_video_namespace_does_not_emit_mycroft_twin(self):
+        """mycroft.audio.* is audio-specific legacy — video/web must not
+        emit it (there is no mycroft.video.*/mycroft.web.* legacy type)."""
+        svc, bus = _make_service()
+        svc.namespace = "video"
+
+        received = []
+        bus.on("mycroft.audio.playing_track", lambda m: received.append(m))
+
+        svc.track_start("http://example.com/movie.mp4")
+
+        self.assertEqual(len(received), 0)
+
+    def test_track_start_video_namespace_does_not_emit_mycroft_queue_end(self):
+        svc, bus = _make_service()
+        svc.namespace = "video"
+
+        received = []
+        bus.on("mycroft.audio.queue_end", lambda m: received.append(m))
+
+        svc.track_start(None)
+
+        self.assertEqual(len(received), 0)
+
+
+class TestHandlePlayUriExtraction(unittest.TestCase):
+    """C3: handle_play must pass a single uri string to self.play(), not the
+    raw tracks list — self.play() does uri.split(':') and would raise
+    AttributeError on a list, killing the Timer thread silently."""
+
+    def _run_handle_play(self, svc, data):
+        """Call handle_play with threading.Timer patched to fire synchronously
+        so we can inspect what was passed to self.play()."""
+        from ovos_bus_client.message import Message
+        with patch("threading.Timer") as mock_timer:
+            svc.handle_play(Message("ovos.audio.service.play", data))
+            self.assertTrue(mock_timer.called)
+            _args, kwargs = mock_timer.call_args
+            # threading.Timer(0.5, self.play, args=[...])
+            target = mock_timer.call_args[0][1]
+            call_args = mock_timer.call_args[1].get("args") or mock_timer.call_args[0][2]
+            return target, call_args
+
+    def test_handle_play_extracts_uri_from_string_track(self):
+        svc, bus = _make_service()
+        svc.services = []
+
+        target, call_args = self._run_handle_play(
+            svc, {"tracks": ["http://example.com/a.mp3"]})
+
+        self.assertEqual(target, svc.play)
+        self.assertEqual(call_args[0], "http://example.com/a.mp3")
+
+    def test_handle_play_extracts_uri_from_tuple_track(self):
+        svc, bus = _make_service()
+        svc.services = []
+
+        target, call_args = self._run_handle_play(
+            svc, {"tracks": [("http://example.com/b.mp3", "audio/mpeg")]})
+
+        self.assertEqual(call_args[0], "http://example.com/b.mp3")
+
+    def test_handle_play_with_no_tracks_does_not_start_timer(self):
+        svc, bus = _make_service()
+        svc.services = []
+        from ovos_bus_client.message import Message
+        with patch("threading.Timer") as mock_timer:
+            svc.handle_play(Message("ovos.audio.service.play", {"tracks": []}))
+            mock_timer.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unittests/test_legacy_api.py
+++ b/test/unittests/test_legacy_api.py
@@ -55,6 +55,37 @@ class TestLegacyPlayTranslation(unittest.TestCase):
 
         self.assertEqual(len(received[0].data["playlist"]), 2)
 
+    def test_play_carries_utterance_through(self):
+        """C2: legacy 'utterance' field (used for by-name backend selection)
+        must survive translation into ovos.common_play.play."""
+        compat, bus, player = _make_compat()
+        received = []
+        bus.on("ovos.common_play.play", lambda m: received.append(m))
+
+        from ovos_bus_client.message import Message
+        bus.emit(Message("mycroft.audio.service.play", {
+            "tracks": ["http://example.com/track.mp3"],
+            "utterance": "play track.mp3 using vlc",
+        }))
+
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0].data.get("utterance"),
+                         "play track.mp3 using vlc")
+
+    def test_play_without_utterance_forwards_empty_string(self):
+        """utterance key is always present (empty default) so downstream
+        by-name selection logic never KeyErrors."""
+        compat, bus, player = _make_compat()
+        received = []
+        bus.on("ovos.common_play.play", lambda m: received.append(m))
+
+        from ovos_bus_client.message import Message
+        bus.emit(Message("mycroft.audio.service.play", {
+            "tracks": ["http://example.com/track.mp3"],
+        }))
+
+        self.assertEqual(received[0].data.get("utterance"), "")
+
     def test_play_with_no_tracks_does_not_emit(self):
         compat, bus, player = _make_compat()
         received = []

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -121,5 +121,57 @@ class TestValidateMessageContextNativeSources(unittest.TestCase):
         self.assertTrue(result)
 
 
+class TestRequireDefaultSessionMalformedContext(unittest.TestCase):
+    """C4: a malformed session context (empty session_id, non-dict session)
+    must never crash a gated handler — it must be refused (treated as
+    NOT-default) and logged, not raised, so any peer cannot DoS a handler
+    with context={"session": {"session_id": ""}}."""
+
+    def _make_handler(self):
+        from ovos_media.utils import require_default_session
+
+        calls = []
+
+        class _Svc:
+            validate_source = True
+
+            @require_default_session()
+            def handle(self, message=None):
+                calls.append(message)
+                return "ran"
+
+        return _Svc(), calls
+
+    def test_empty_session_id_refused_no_exception(self):
+        from ovos_bus_client.message import Message
+        svc, calls = self._make_handler()
+        msg = Message("x", context={"session": {"session_id": ""}})
+
+        result = svc.handle(msg)  # must not raise
+
+        self.assertIsNone(result)
+        self.assertEqual(calls, [])
+
+    def test_str_session_refused_no_exception(self):
+        from ovos_bus_client.message import Message
+        svc, calls = self._make_handler()
+        msg = Message("x", context={"session": "not_a_dict"})
+
+        result = svc.handle(msg)  # must not raise
+
+        self.assertIsNone(result)
+        self.assertEqual(calls, [])
+
+    def test_valid_default_session_still_runs(self):
+        from ovos_bus_client.message import Message
+        svc, calls = self._make_handler()
+        msg = Message("x", context={"session": {"session_id": "default"}})
+
+        result = svc.handle(msg)
+
+        self.assertEqual(result, "ran")
+        self.assertEqual(len(calls), 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This is batch C of wave 1 of the audit loop, covering coexistence with the legacy audio stack — ovos-media needs to keep working alongside it for roughly the next six months. The legacy mycroft.audio.playing_track and mycroft.audio.queue_end events are now emitted alongside the newer ovos.audio.* ones, so legacy skills that block waiting for queue_end no longer hang forever; the payload matches what upstream ovos-audio already sends. The legacy utterance field is now carried through into the forwarded play message. The legacy service play messages no longer crash when given a list or tuple of tracks. And a handler that gates on the default session now treats a malformed session context as simply "not the default session" instead of letting the underlying error escape and take the handler down with it.

One gap is left deliberately for a follow-up: legacy track_info consumers expect backend-native metadata keys like album, which the current MediaEntry model never captures. That's a real gap in the data model, not just a naming mismatch, and it needs its own scoped change rather than being patched in here.

The twin-event and session-hardening fixes were both proven necessary by reverting them first and watching the tests fail. On the rebased result, on top of the post-#92 dev branch, 562 tests pass (550 baseline plus 12 new). The orchestrator verified this live.
