### PR TITLE
fix: daemon startup crash, backend seek API, silent play failures, config robustness

### DIFF
--- a/ovos_media/media_backends/base.py
+++ b/ovos_media/media_backends/base.py
@@ -2,7 +2,7 @@ import abc
 import threading
 import time
 from threading import Lock
-from typing import Callable
+from typing import Callable, Optional
 
 from ovos_plugin_manager.templates.media import MediaBackend, RemoteAudioPlayerBackend, RemoteVideoPlayerBackend, \
     RemoteWebPlayerBackend
@@ -92,7 +92,23 @@ class BaseMediaService:
         remote = []
 
         plugs = self.plugin_loader()
-        for player_name, plug_cfg in self.config.get(f"{self.namespace}_players", {}).items():
+        players_cfg = self.config.get(f"{self.namespace}_players", {})
+        if not isinstance(players_cfg, dict):
+            LOG.error(f"Expected a dict for '{self.namespace}_players' "
+                      f"config, got {type(players_cfg).__name__}: "
+                      f"{players_cfg!r} - ignoring")
+            players_cfg = {}
+        for player_name, plug_cfg in players_cfg.items():
+            if not isinstance(plug_cfg, dict):
+                LOG.error(f"Expected a dict for '{self.namespace}_players' "
+                          f"entry '{player_name}', got "
+                          f"{type(plug_cfg).__name__}: {plug_cfg!r} - "
+                          f"ignoring")
+                continue
+            if "module" not in plug_cfg:
+                LOG.error(f"'{self.namespace}_players' entry '{player_name}' "
+                          f"is missing the required 'module' key - ignoring")
+                continue
             plug_name = plug_cfg["module"]
             if plug_name not in plugs:
                 LOG.error(f"{plug_name} configured but not installed")
@@ -175,7 +191,15 @@ class BaseMediaService:
         """
         state = message.data["state"]
         if self.current and state == MediaState.LOADED_MEDIA:
-            self.current.play()
+            try:
+                self.current.play()
+            except Exception as e:
+                LOG.exception(f"Failed to start playback on "
+                              f"{self.current.__class__.__name__}: {e}")
+                self.bus.emit(Message("ovos.common_play.media.state",
+                                      {"state": MediaState.INVALID_MEDIA}))
+                self.current = None
+                return
             track_state = {
                 "audio": TrackState.PLAYING_AUDIO,
                 "video": TrackState.PLAYING_VIDEO,
@@ -319,13 +343,22 @@ class BaseMediaService:
                     break
             else:
                 LOG.info('No service found for uri_type: ' + uri_type)
+                self.bus.emit(Message("ovos.common_play.media.state",
+                                      {"state": MediaState.INVALID_MEDIA}))
                 return
 
         LOG.debug(f"Using {selected_service.__class__.__name__}")
         self.current = selected_service
         self.play_start_time = time.monotonic()
-        # once loaded self.handle_media_state_change is called
-        selected_service.load_track(uri)
+        try:
+            # once loaded self.handle_media_state_change is called
+            selected_service.load_track(uri)
+        except Exception as e:
+            LOG.exception(f"Failed to load track '{uri}' on "
+                          f"{selected_service.__class__.__name__}: {e}")
+            self.bus.emit(Message("ovos.common_play.media.state",
+                                  {"state": MediaState.INVALID_MEDIA}))
+            self.current = None
 
     def _is_message_for_service(self, message: Message):
         if not message or not self.validate_source:
@@ -461,6 +494,53 @@ class BaseMediaService:
         seconds = message.data.get("seconds", 1)
         if self.current:
             self.current.seek_backward(seconds)
+
+    def get_track_length(self) -> Optional[int]:
+        """
+        Get the duration of the currently loaded track, in milliseconds.
+
+        Mirrors the backend contract defined by
+        ``ovos_plugin_manager.templates.media.MediaBackend.get_track_length``,
+        which reports/consumes milliseconds throughout.
+
+        Returns:
+            (int) duration of the current track in milliseconds, or None if
+            no backend is currently active.
+        """
+        if self.current is None:
+            return None
+        return self.current.get_track_length()
+
+    def get_track_position(self) -> Optional[int]:
+        """
+        Get the current playback position, in milliseconds.
+
+        Mirrors the backend contract defined by
+        ``ovos_plugin_manager.templates.media.MediaBackend.get_track_position``,
+        which reports/consumes milliseconds throughout.
+
+        Returns:
+            (int) current position in milliseconds, or None if no backend is
+            currently active.
+        """
+        if self.current is None:
+            return None
+        return self.current.get_track_position()
+
+    def set_track_position(self, milliseconds: int) -> None:
+        """
+        Seek to a specific position in the currently loaded track.
+
+        Mirrors the backend contract defined by
+        ``ovos_plugin_manager.templates.media.MediaBackend.set_track_position``,
+        which reports/consumes milliseconds throughout.
+
+        Args:
+            milliseconds (int): position, in milliseconds, to seek to.
+        """
+        if self.current is None:
+            return
+        self.current.set_track_position(milliseconds)
 
     def shutdown(self):
         for s in self.services:

--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -54,10 +54,24 @@ class OCPMediaCatalog(OVOSCommonPlaybackSkill):
         def norm_name(n):
             return n.split("|")[0].split("(")[0].split("[")[0].split("{")[0].split("-")[0].strip()
 
-        # ahocorasick_ner is an OPTIONAL speed optimization (only useful for
-        # huge liked-songs catalogs) - install the "ner" extra to enable it.
-        # Its absence must not break skill startup or any of the five voice
-        # intents registered below, which do not depend on OCP NER matching.
+        # ahocorasick_ner ("ner" extra) is OPTIONAL, but its absence is not
+        # a pure speed optimization: OVOSCommonPlaybackSkill.ocp_voc_match
+        # (used by search_db, see below) hard-depends on it, so without it
+        # "play my liked songs" / "play my favorites" style searches never
+        # match anything. It is still true that the five WhatSong/WhatAlbum/
+        # WhatArtist/ShuffleOn/ShuffleOff intents registered below do not
+        # depend on it and keep working.
+        #
+        # register_ocp_keyword() itself does two things: it registers the
+        # samples with the local Aho-Corasick NER matcher (raises
+        # ImportError without the "ner" extra), and it emits
+        # 'ovos.common_play.register_keyword' on the bus so the OCP pipeline
+        # classifier learns the keywords too - that emit does not need local
+        # NER. In the installed ovos-workshop, the emit happens *after* the
+        # per-language NER registration loop inside the same method, so an
+        # ImportError there prevents the emit from ever running. We
+        # replicate the (NER-independent) emit here directly so the
+        # classifier still learns the keywords even without the "ner" extra.
         try:
             self.register_ocp_keyword(MediaType.MUSIC, "song_name",
                                       [norm_name(n["title"]) for n in self.liked_songs.values()])
@@ -69,8 +83,24 @@ class OCPMediaCatalog(OVOSCommonPlaybackSkill):
                                        "liked songs", "liked tracks", "liked music",
                                        "my liked songs", "my liked tracks", "my liked music"])
         except ImportError:
-            LOG.info("ahocorasick_ner not installed - OCP keyword matching "
-                     "disabled (optional, only useful for huge catalogs)")
+            LOG.warning("ahocorasick_ner not installed - OCP local keyword "
+                       "NER matching disabled, and 'search_db' (eg. 'play "
+                       "my liked songs') will find nothing until it is "
+                       "installed. Install the 'ner' extra to fix this. "
+                       "The classifier is still informed of the keywords "
+                       "via the bus so media-type disambiguation still "
+                       "works.")
+            self._emit_ocp_keyword_registration(
+                MediaType.MUSIC, "song_name",
+                [norm_name(n["title"]) for n in self.liked_songs.values()])
+            self._emit_ocp_keyword_registration(
+                MediaType.MUSIC, "playlist_name",
+                ["favorite", "liked", "favorites",
+                 "favorite songs", "favorite tracks",
+                 "favorite music", "my favorite songs",
+                 "my favorite tracks", "my favorite music",
+                 "liked songs", "liked tracks", "liked music",
+                 "my liked songs", "my liked tracks", "my liked music"])
 
         # intents about the currently playing media, see issue #23
         self.register_intent_file("WhatSong.intent", self.handle_what_song)
@@ -78,6 +108,44 @@ class OCPMediaCatalog(OVOSCommonPlaybackSkill):
         self.register_intent_file("WhatArtist.intent", self.handle_what_artist)
         self.register_intent_file("ShuffleOn.intent", self.handle_shuffle_on)
         self.register_intent_file("ShuffleOff.intent", self.handle_shuffle_off)
+
+    def _emit_ocp_keyword_registration(self, media_type: MediaType, label: str,
+                                       samples: List[str]) -> None:
+        """
+        Emit the 'ovos.common_play.register_keyword' bus message that
+        informs the OCP pipeline classifier about a set of keyword samples,
+        WITHOUT going through OVOSCommonPlaybackSkill.register_ocp_keyword
+        (which also registers the samples with the local Aho-Corasick NER
+        matcher and requires the optional "ner" extra to be installed).
+
+        This mirrors the (NER-independent) tail half of
+        OVOSCommonPlaybackSkill.register_ocp_keyword: same message name and
+        same payload shape, so the classifier cannot tell the difference.
+        Used as a fallback when ahocorasick_ner is not installed.
+        """
+        samples = list(set(samples))
+        if not samples:
+            return
+        for lang in self.native_langs:
+            if len(samples) >= 20:
+                csv_path = f"{self.ocp_cache_dir}/{self.skill_id}_{label}_{lang}.csv"
+                with open(csv_path, "w") as f:
+                    f.write("label,sample")
+                    for s in samples:
+                        f.write(f"\n{label},{s}")
+                self.bus.emit(
+                    Message('ovos.common_play.register_keyword',
+                            {"skill_id": self.skill_id,
+                             "label": label,
+                             "csv": csv_path,
+                             "media_type": media_type}))
+            else:
+                self.bus.emit(
+                    Message('ovos.common_play.register_keyword',
+                            {"skill_id": self.skill_id,
+                             "label": label,
+                             "samples": samples,
+                             "media_type": media_type}))
 
     def _get_status(self, message: Message) -> Optional[dict]:
         """Query current player status via the existing status bus API.
@@ -500,7 +568,7 @@ class OCPMediaPlayer:
         self.state: PlayerState = PlayerState.STOPPED
         self.loop_state: LoopState = LoopState.NONE
         self.media_state: MediaState = MediaState.NO_MEDIA
-        self.playlist: Playlist = Playlist("Search Results")
+        self.playlist: Playlist = Playlist(title="Search Results")
         self.shuffle: bool = False
         self.track_history: dict = {}  # Dict of track URI to play count
         self._paused_on_duck: bool = False
@@ -1196,7 +1264,10 @@ class OCPMediaPlayer:
         """
         if self.playback_type in [PlaybackType.AUDIO,
                                   PlaybackType.UNDEFINED]:
-            self.audio_service.set_track_position(position / 1000)
+            # audio_service.set_track_position expects milliseconds,
+            # matching the milliseconds contract documented on this
+            # method and on MediaBackend.set_track_position
+            self.audio_service.set_track_position(position)
 
     def stop(self):
         """
@@ -1259,6 +1330,9 @@ class OCPMediaPlayer:
             self.mpris.shutdown()
         self.now_playing.shutdown()
         self.media.shutdown()
+        self.audio_service.shutdown()
+        self.video_service.shutdown()
+        self.web_service.shutdown()
 
     def handle_player_media_update(self, message):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/test/unittests/test_catalog_now_playing_intents.py
+++ b/test/unittests/test_catalog_now_playing_intents.py
@@ -29,7 +29,7 @@ from unittest.mock import MagicMock, patch
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session, SessionManager
 from ovos_utils.fakebus import FakeBus
-from ovos_utils.ocp import LoopState, MediaState, PlaybackType, PlayerState
+from ovos_utils.ocp import LoopState, MediaState, MediaType, PlaybackType, PlayerState
 
 from ovos_media.player import OCPMediaCatalog, OCPMediaPlayer
 
@@ -371,13 +371,20 @@ class TestShuffleSessionGate(unittest.TestCase):
 
 
 class TestConstructsWithoutAhocorasickNer(unittest.TestCase):
-    """ahocorasick_ner is an OPTIONAL dependency (only a matching-speed
-    optimization for huge catalogs, see the "ner" extra in pyproject.toml).
-    Simulates its absence by patching ovos_workshop's already-imported
-    AhocorasickNER symbol to None (the same state ovos_workshop.skills.
-    common_play ends up in when the real import fails), then constructs
-    OCPMediaCatalog and asserts no exception and that the five voice intents
-    still register normally."""
+    """ahocorasick_ner ("ner" extra) is OPTIONAL, but it is NOT a pure
+    matching-speed optimization: OVOSCommonPlaybackSkill.ocp_voc_match hard
+    -depends on the local NER matcher it builds, so without it search_db
+    ("play my liked songs" / "play my favorites") finds nothing. The five
+    WhatSong/WhatAlbum/WhatArtist/ShuffleOn/ShuffleOff voice intents do not
+    depend on it and must keep registering normally. The OCP pipeline
+    classifier should still learn the keywords via the
+    'ovos.common_play.register_keyword' bus message even without local NER
+    (see OCPMediaCatalog._emit_ocp_keyword_registration).
+
+    Simulates ahocorasick_ner's absence by patching ovos_workshop's already-
+    imported AhocorasickNER symbol to None (the same state
+    ovos_workshop.skills.common_play ends up in when the real import
+    fails), then constructs OCPMediaCatalog."""
 
     def test_catalog_constructs_and_registers_intents_without_ner(self):
         with patch("ovos_workshop.skills.common_play.AhocorasickNER", None):
@@ -392,6 +399,30 @@ class TestConstructsWithoutAhocorasickNer(unittest.TestCase):
             names = {r.get("name", "").split(":")[-1] for r in registrations}
             self.assertIn("WhatSong.intent", names)
             self.assertIn("ShuffleOn.intent", names)
+
+    def test_search_db_finds_nothing_without_ner(self):
+        """search_db depends on the local NER matcher; without ahocorasick
+        it must not crash, but it also must not find liked-songs matches."""
+        with patch("ovos_workshop.skills.common_play.AhocorasickNER", None):
+            bus = FakeBus()
+            catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+            results = list(catalog.search_db("play my liked songs", MediaType.MUSIC))
+            self.assertEqual(results, [])
+
+    def test_classifier_still_learns_keywords_without_ner(self):
+        """Even without local NER, the OCP pipeline classifier must still
+        be informed of the keywords via the bus, so media-type
+        disambiguation keeps working."""
+        with patch("ovos_workshop.skills.common_play.AhocorasickNER", None):
+            bus = FakeBus()
+            registered = []
+            bus.on("ovos.common_play.register_keyword",
+                  lambda m: registered.append(m.data))
+
+            OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+
+            labels = {r["label"] for r in registered}
+            self.assertIn("playlist_name", labels)
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_defect_fixes.py
+++ b/test/unittests/test_defect_fixes.py
@@ -1,0 +1,246 @@
+"""Regression tests for defects found during the 2026-08 ecosystem audit.
+
+A1: OCPMediaPlayer/MediaService failed to construct at all because
+    ``Playlist("Search Results")`` passed the title as a positional entry
+    instead of the ``title`` keyword, tripping an assertion inside
+    ``Playlist.add_entry``.
+A2: BaseMediaService did not implement get_track_length/get_track_position/
+    set_track_position, so player.py's calls to
+    ``self.audio_service.{get,set}_track_position``/``get_track_length``
+    raised AttributeError.
+A3: Exceptions raised inside BaseMediaService.play() (via
+    ``selected_service.load_track``) or inside
+    ``handle_media_state_change`` (via ``self.current.play()``) propagated
+    out of a ``threading.Timer`` thread and were silently swallowed by the
+    interpreter, leaving the player permanently stuck without ever emitting
+    an error state. An unsupported uri_type also silently logged and
+    returned without informing the bus.
+A4: ``load_services`` crashed on malformed ``*_players`` config blocks
+    (non-dict values, missing "module" key).
+"""
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import MediaState
+
+
+class TestA1DaemonStartup(unittest.TestCase):
+    """A1: construct a REAL OCPMediaPlayer / MediaService on a FakeBus,
+    with no Playlist patching and no __new__ bypass, and confirm startup
+    survives."""
+
+    def test_ocp_media_player_constructs_on_fakebus(self):
+        from ovos_media.player import OCPMediaPlayer
+        bus = FakeBus()
+        # plugin loading talks to entrypoints on the real system; keep that
+        # minimal external surface mocked out but construct everything else
+        # (Playlist, NowPlaying, OCPMediaCatalog, the three BaseMediaService
+        # subclasses...) for real.
+        player = OCPMediaPlayer(bus, config={})
+        self.assertEqual(player.playlist.title, "Search Results")
+        self.assertEqual(len(player.playlist), 0)
+        # validate_source must be plumbed through to the catalog (#90);
+        # this was dead code prior to the A1 fix since construction never
+        # completed far enough to exercise it
+        self.assertIs(player.media.validate_source, player.validate_source)
+
+    def test_media_service_constructs_on_fakebus(self):
+        from ovos_media.service import MediaService
+        bus = FakeBus()
+        service = MediaService(bus=bus)
+        self.assertIsNotNone(service.ocp)
+        self.assertEqual(service.ocp.playlist.title, "Search Results")
+        service.shutdown()
+
+
+def _make_base_service(current=None):
+    from ovos_media.media_backends.base import BaseMediaService
+    svc = BaseMediaService.__new__(BaseMediaService)
+    svc.bus = FakeBus()
+    svc.services = []
+    svc.current = current
+    svc.validate_source = False
+    svc.volume_is_low = False
+    svc.service_lock = threading.Lock()
+    svc.play_start_time = 0.0
+    svc.namespace = "audio"
+    svc._loaded = threading.Event()
+    svc._loaded.set()
+    return svc
+
+
+class TestA2SeekApi(unittest.TestCase):
+    """A2: BaseMediaService.{get_track_length,get_track_position,
+    set_track_position} delegate to self.current, in milliseconds, and are
+    safe when there is no current backend."""
+
+    def test_get_track_length_delegates_to_current(self):
+        current = MagicMock()
+        current.get_track_length.return_value = 123456
+        svc = _make_base_service(current)
+        self.assertEqual(svc.get_track_length(), 123456)
+        current.get_track_length.assert_called_once_with()
+
+    def test_get_track_length_no_current_returns_none(self):
+        svc = _make_base_service(None)
+        self.assertIsNone(svc.get_track_length())
+
+    def test_get_track_position_delegates_to_current(self):
+        current = MagicMock()
+        current.get_track_position.return_value = 42000
+        svc = _make_base_service(current)
+        self.assertEqual(svc.get_track_position(), 42000)
+        current.get_track_position.assert_called_once_with()
+
+    def test_get_track_position_no_current_returns_none(self):
+        svc = _make_base_service(None)
+        self.assertIsNone(svc.get_track_position())
+
+    def test_set_track_position_delegates_to_current(self):
+        current = MagicMock()
+        svc = _make_base_service(current)
+        svc.set_track_position(5000)
+        current.set_track_position.assert_called_once_with(5000)
+
+    def test_set_track_position_no_current_is_noop(self):
+        svc = _make_base_service(None)
+        # must not raise
+        svc.set_track_position(5000)
+
+
+class TestA3SilentPlayFailures(unittest.TestCase):
+    """A3: exceptions raised by a crashing backend during play() or during
+    handle_media_state_change() must emit MediaState.INVALID_MEDIA and clear
+    self.current, rather than dying silently."""
+
+    def test_play_load_track_exception_emits_invalid_media_and_clears_current(self):
+        crashing = MagicMock()
+        crashing.supported_uris.return_value = ["file"]
+        crashing.load_track.side_effect = RuntimeError("boom")
+        crashing.__class__.__name__ = "CrashingBackend"
+
+        svc = _make_base_service(None)
+        svc.services = [crashing]
+
+        received = []
+        svc.bus.on("ovos.common_play.media.state", lambda m: received.append(m))
+
+        svc.play("file:///tmp/track.mp3")
+
+        self.assertIsNone(svc.current)
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0].data["state"], MediaState.INVALID_MEDIA)
+
+    def test_play_unsupported_uri_emits_invalid_media(self):
+        svc = _make_base_service(None)
+        svc.services = []
+
+        received = []
+        svc.bus.on("ovos.common_play.media.state", lambda m: received.append(m))
+
+        svc.play("weirdscheme://nope")
+
+        self.assertIsNone(svc.current)
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0].data["state"], MediaState.INVALID_MEDIA)
+
+    def test_handle_media_state_change_play_exception_emits_invalid_media_and_clears_current(self):
+        crashing = MagicMock()
+        crashing.play.side_effect = RuntimeError("boom")
+
+        svc = _make_base_service(crashing)
+
+        received = []
+        svc.bus.on("ovos.common_play.media.state", lambda m: received.append(m))
+
+        svc.handle_media_state_change(Message("ovos.common_play.media.state",
+                                             {"state": MediaState.LOADED_MEDIA}))
+
+        self.assertIsNone(svc.current)
+        # first call is the incoming LOADED_MEDIA-triggering message is not
+        # re-emitted by us; only the INVALID_MEDIA emission we make matters
+        invalid = [m for m in received if m.data.get("state") == MediaState.INVALID_MEDIA]
+        self.assertEqual(len(invalid), 1)
+
+
+class TestA4ConfigRobustness(unittest.TestCase):
+    """A4: load_services must survive malformed *_players config blocks."""
+
+    def _make_service_for_load(self, players_cfg):
+        from ovos_media.media_backends.base import BaseMediaService
+        svc = BaseMediaService.__new__(BaseMediaService)
+        svc.bus = FakeBus()
+        svc.namespace = "audio"
+        svc.config = {"audio_players": players_cfg}
+        svc.plugin_loader = lambda: {}
+        svc.service_lock = threading.Lock()
+        svc.current = None
+        svc.play_start_time = 0.0
+        svc.volume_is_low = False
+        svc.validate_source = False
+        svc._loaded = threading.Event()
+        return svc
+
+    def test_players_cfg_none_survives(self):
+        svc = self._make_service_for_load(None)
+        services = svc.load_services()
+        self.assertEqual(services, [])
+
+    def test_players_cfg_list_survives(self):
+        svc = self._make_service_for_load(["not", "a", "dict"])
+        services = svc.load_services()
+        self.assertEqual(services, [])
+
+    def test_players_cfg_string_survives(self):
+        svc = self._make_service_for_load("oops")
+        services = svc.load_services()
+        self.assertEqual(services, [])
+
+    def test_players_entry_missing_module_survives(self):
+        svc = self._make_service_for_load({"myplayer": {"active": True}})
+        services = svc.load_services()
+        self.assertEqual(services, [])
+
+    def test_players_entry_non_dict_value_survives(self):
+        svc = self._make_service_for_load({"myplayer": "not-a-dict"})
+        services = svc.load_services()
+        self.assertEqual(services, [])
+
+    def test_valid_entry_still_loads(self):
+        plug = MagicMock()
+        instance = MagicMock()
+        instance.supported_uris.return_value = ["file"]
+        plug.return_value = instance
+        svc = self._make_service_for_load(
+            {"myplayer": {"module": "ovos-fake-plugin", "active": True}})
+        svc.plugin_loader = lambda: {"ovos-fake-plugin": plug}
+        services = svc.load_services()
+        self.assertEqual(len(services), 1)
+
+
+class TestA5Shutdown(unittest.TestCase):
+    """A5: OCPMediaPlayer.shutdown() shuts down the audio/video/web
+    BaseMediaService instances, not just the higher-level objects."""
+
+    def test_shutdown_calls_service_shutdown(self):
+        from ovos_media.player import OCPMediaPlayer
+        bus = FakeBus()
+        player = OCPMediaPlayer(bus, config={})
+        player.audio_service.shutdown = MagicMock()
+        player.video_service.shutdown = MagicMock()
+        player.web_service.shutdown = MagicMock()
+        player.now_playing.shutdown = MagicMock()
+        player.media.shutdown = MagicMock()
+
+        player.shutdown()
+
+        player.audio_service.shutdown.assert_called_once_with()
+        player.video_service.shutdown.assert_called_once_with()
+        player.web_service.shutdown.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_player_handlers.py
+++ b/test/unittests/test_player_handlers.py
@@ -273,10 +273,13 @@ class TestHandleSeekRequest(unittest.TestCase):
         p.seek.assert_called_once_with(30000)
 
     def test_seek_audio_calls_audio_service(self):
-        """seek() with AUDIO type calls audio_service.set_track_position."""
+        """seek() with AUDIO type calls audio_service.set_track_position
+        with the position in milliseconds, unconverted (matching the
+        milliseconds contract documented on seek() and on
+        MediaBackend.set_track_position)."""
         p = _make_player(PlaybackType.AUDIO)
         p.seek(60000)
-        p.audio_service.set_track_position.assert_called_once_with(60.0)
+        p.audio_service.set_track_position.assert_called_once_with(60000)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This is batch A of wave 1 of the audit loop, covering startup, backends, and packaging. The most serious finding: constructing the player's default playlist crashed with every allowed version of ovos-utils, meaning the daemon could not even start. This has apparently been broken since March 2024, hidden because no existing test actually constructed the real player, and the test harness shimmed around it. This is now fixed, with new tests that construct the real player and media service with no patching involved.

The player also called three seek/position methods that the base media service never defined, and a separate seek bug double-converted units — an old test had actually locked in that wrong behavior, so the test was deliberately updated along with the fix. Exceptions during track loading used to die silently inside a background timer thread; they're now logged properly and the player moves to an explicit invalid-media state instead of just going quiet. Malformed media configuration — None, a list, a string, or a missing module key where a players block was expected — used to crash startup; it's now skipped with a logged error instead. Backend services are now properly shut down when the player shuts down. And the keyword-classifier bus emission was made to work without the optional local NER dependency, with an honest warning logged when the search database is disabled because that dependency isn't installed, which is the intended behavior.

Separately, the build system's setuptools floor was raised, since older versions hard-fail on the license string format now required by packaging rules.

The three most serious fixes were proven necessary by reverting them and watching the tests fail. On the rebased result, on top of post-#92/#93 dev, 582 tests pass (562 baseline plus 20 new), and the daemon actually starting was verified live by the orchestrator. Two independent auditors confirmed the findings separately.
