### PR TITLE
test: e2e seek pins expect milliseconds per the OPM MediaBackend contract

### DIFF
--- a/test/end2end/test_daemon_lifecycle.py
+++ b/test/end2end/test_daemon_lifecycle.py
@@ -311,23 +311,24 @@ class TestSeekAndPosition(unittest.TestCase):
     """seek / set_track_position / get_track_position bus APIs."""
 
     def test_set_track_position_seeks_audio_backend(self) -> None:
-        """set_track_position must seek the audio service (ms→seconds)."""
+        """set_track_position must seek the audio service (milliseconds passthrough,
+        per the OPM MediaBackend contract)."""
         with OCPPlayerHarness() as h:
             h.play(_audio("http://example.com/song.mp3"))
             h.bus.emit(Message("ovos.common_play.set_track_position",
                                {"position": 5000}))
             time.sleep(0.05)
-            h.player.audio_service.set_track_position.assert_called_with(5.0)
+            h.player.audio_service.set_track_position.assert_called_with(5000)
 
     def test_seek_request_moves_audio_position(self) -> None:
         """A seek request must reach audio_service.set_track_position."""
         with OCPPlayerHarness() as h:
             h.play(_audio("http://example.com/song.mp3"))
             # seekValue takes the absolute-position branch (ms passed straight
-            # through to seek() -> set_track_position(seconds))
+            # through to seek() -> set_track_position(ms))
             h.bus.emit(Message("ovos.common_play.seek", {"seekValue": 8000}))
             time.sleep(0.05)
-            h.player.audio_service.set_track_position.assert_called_with(8.0)
+            h.player.audio_service.set_track_position.assert_called_with(8000)
 
     def test_get_track_position_returns_backend_position(self) -> None:
         """get_track_position must reply with the audio backend's position."""


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This is a follow-up to #96, which got merged while its coverage job was still red — my process error, and this fixes it forward. The two end-to-end tests that started failing had pinned an unrelated unit bug: they expected the player to divide milliseconds down to seconds, which is exactly the wrong behavior that #96 removed. The backend's set_track_position method actually takes milliseconds, confirmed against the installed template, and ovos-audio already passes milliseconds unconverted. So those two pre-existing test pins were changed on purpose, because they had been pinning the bug rather than the correct behavior. A separate ovoscope job failure in the same run was an unrelated source-install infrastructure error, and a rerun was triggered for that.
