### PR TITLE
fix: mpris Position unit (ms->us) and honest _stop_player failure handling

### DIFF
--- a/ovos_media/mpris.py
+++ b/ovos_media/mpris.py
@@ -393,7 +393,7 @@ class OcpMprisExporter(Thread):
             else:
                 LOG.warning(f"player {name} can not be resumed")
 
-    async def _stop_player(self, name, max_tries=1):
+    async def _stop_player(self, name, max_tries=2):
         if name not in self.players:
             LOG.error(f"Invalid player: {name}")
             return
@@ -407,12 +407,15 @@ class OcpMprisExporter(Thread):
                 player = self.players[name].get_interface(
                     'org.mpris.MediaPlayer2.Player')
                 await player.call_stop()
-        except:
+        except Exception:
             max_tries -= 1
             if max_tries > 0:
                 await self._stop_player(name, max_tries)
             else:
+                # stop failed - leave state untouched so a later _stop_all
+                # pass retries it instead of silently treating it as stopped
                 LOG.warning(f"player {name} can not be stopped")
+            return
         if name == self.main_player:
             self.main_player = None
         self.player_meta[name]["state"] = "Stopped"
@@ -835,7 +838,11 @@ class _MediaPlayer2PlayerInterface(ServiceInterface):
     @dbus_property(access=PropertyAccess.READ)
     def Position(self) -> 'd':
         if self._ocp_player.now_playing:
-            return self._ocp_player.now_playing.position * 1e6
+            # now_playing.position is in milliseconds (repo-wide ms contract,
+            # produced by ovos-plugin-manager templates); MPRIS Position is
+            # in microseconds, hence * 1000 (not * 1e6, which would treat
+            # position as seconds).
+            return self._ocp_player.now_playing.position * 1000
         return 0
 
     @dbus_property(access=PropertyAccess.READ)

--- a/test/unittests/test_mpris.py
+++ b/test/unittests/test_mpris.py
@@ -40,13 +40,18 @@ def _make_exporter(config=None):
 
 
 class TestPosition(unittest.TestCase):
-    """Position property must return microseconds (position * 1e6)."""
+    """Position property must return microseconds (position * 1000).
+
+    now_playing.position is milliseconds (repo-wide ms contract, produced by
+    ovos-plugin-manager templates' playback_time), NOT seconds. MPRIS wants
+    microseconds, so the conversion factor is *1000, not *1e6.
+    """
 
     def test_position_microseconds(self):
         iface, player = _make_interface()
-        player.now_playing.position = 30  # seconds
+        player.now_playing.position = 30_000  # milliseconds
         result = iface.Position
-        self.assertAlmostEqual(result, 30 * 1e6)
+        self.assertAlmostEqual(result, 30_000 * 1000)
 
     def test_position_zero_when_no_now_playing(self):
         iface, player = _make_interface()
@@ -140,6 +145,50 @@ class TestSetMainPlayer(unittest.IsolatedAsyncioTestCase):
         with patch("ovos_media.mpris.LOG") as mock_log:
             await ctl._set_main_player("same_player")
             mock_log.info.assert_not_called()
+
+
+class TestStopPlayer(unittest.IsolatedAsyncioTestCase):
+    """_stop_player must only mark a player Stopped on a successful call_stop.
+
+    A failed stop must leave player_meta state untouched (not "Stopped") so
+    _stop_all retries it later instead of silently skipping it forever.
+    """
+
+    def _setup(self):
+        ctl, player = _make_exporter()
+        mock_iface = MagicMock()
+        mock_iface.call_stop = AsyncMock()
+        mock_player_proxy = MagicMock()
+        mock_player_proxy.get_interface.return_value = mock_iface
+        ctl.players = {"p1": mock_player_proxy}
+        ctl.player_meta = {"p1": {"state": "Playing"}}
+        ctl.main_player = "p1"
+        return ctl, mock_iface
+
+    async def test_successful_stop_marks_stopped_and_clears_main_player(self):
+        ctl, mock_iface = self._setup()
+        await ctl._stop_player("p1")
+        self.assertEqual(ctl.player_meta["p1"]["state"], "Stopped")
+        self.assertIsNone(ctl.main_player)
+        mock_iface.call_stop.assert_awaited_once()
+
+    async def test_failed_stop_leaves_state_untouched(self):
+        ctl, mock_iface = self._setup()
+        mock_iface.call_stop.side_effect = Exception("dbus call failed")
+        await ctl._stop_player("p1", max_tries=1)
+        self.assertEqual(ctl.player_meta["p1"]["state"], "Playing")
+        self.assertEqual(ctl.main_player, "p1")
+
+    async def test_failed_stop_is_retried_on_next_call(self):
+        ctl, mock_iface = self._setup()
+        mock_iface.call_stop.side_effect = Exception("dbus call failed")
+        await ctl._stop_player("p1", max_tries=1)
+        self.assertEqual(mock_iface.call_stop.await_count, 1)
+        # state stayed "Playing" so a subsequent _stop_all pass retries it
+        self.assertEqual(ctl.player_meta["p1"]["state"], "Playing")
+        mock_iface.call_stop.side_effect = None  # next attempt succeeds
+        await ctl._stop_player("p1", max_tries=1)
+        self.assertEqual(ctl.player_meta["p1"]["state"], "Stopped")
 
 
 class TestDbusGracefulDegradation(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This is wave 2 of the audit loop, another MPRIS batch, with two real bugs. The Position value was being multiplied by a million as if the internal value were already in seconds, when it's actually milliseconds — so every MPRIS consumer saw positions a thousand times too large. It now multiplies by a thousand instead, converting milliseconds to microseconds correctly. The old test had been feeding it seconds and locking in the wrong answer, so it now feeds milliseconds instead, per the rule that a test pinning a defect gets corrected along with the fix.

Separately, stopping a player marked it "Stopped" and cleared it as the main player even when the stop call itself failed, which meant a still-playing player could get permanently skipped by the takeover logic. It's now success-only: a failed stop leaves the state alone and retries. The retry cap was also raised from one try to two, since one try meant no retries actually happened.

Reverting these fixes produced 3 failing tests, confirming they're needed. On the rebased result, 585 tests pass (582 baseline plus 3 new). The orchestrator verified this twice, once in randomized order and once in fixed order, after ruling out an earlier 13-failure run as resource contention rather than a real problem.
