### PR TITLE
fix: playback state machine, autoplay, GUI seekbar payload, session-gated search

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,7 +141,7 @@ control-signal checks.
 
 | Key | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `native_sources` | list of strings | `["debug_cli", "audio"]` | Message sources treated as trusted native callers. Requests from these sources bypass message-context validation in the backend services. Read by `MediaService.__init__`. |
+| `native_sources` | list of strings | `["debug_cli", "audio"]` | Message sources treated as trusted native callers. Requests from these sources bypass message-context validation in the backend services. May be set at the top level (`native_sources`) or nested under `media` (`media.native_sources`, as in the example below) — both are honoured by `BaseMediaService._is_message_for_service`, with the top-level key taking precedence when both are set. |
 
 ---
 

--- a/ovos_media/media_backends/base.py
+++ b/ovos_media/media_backends/base.py
@@ -35,6 +35,12 @@ class BaseMediaService:
         self.play_start_time = 0
         self.volume_is_low = False
         self.validate_source = validate_source
+        # C6: queued-but-not-yet-loaded tracks from the last handle_play(),
+        # and whether that request asked to repeat once exhausted. Consumed
+        # incrementally from track_start() as each track finishes.
+        self._pending_playlist: list = []
+        self._pending_repeat: bool = False
+        self._last_full_playlist: list = []
 
         self._loaded = MonotonicEvent()
         if autoload:
@@ -72,6 +78,19 @@ class BaseMediaService:
                 # exact message type waiting for playback to start
                 self.bus.emit(Message('mycroft.audio.playing_track',
                                       data={'track': track}))
+        elif self._pending_playlist:
+            # C6: handle_play() was given more than one track — advance to
+            # the next queued uri instead of reporting end-of-playlist after
+            # only the first track ever played.
+            next_uri = self._pending_playlist.pop(0)
+            LOG.debug(f'Advancing to next queued {self.namespace} track')
+            self.play(next_uri)
+        elif self._pending_repeat and self._last_full_playlist:
+            # C6: the exhausted playlist was requested with repeat=True —
+            # mirrors ovos-audio's PlaybackService repeat semantics.
+            LOG.debug(f'Repeating {self.namespace} playlist')
+            self._pending_playlist = list(self._last_full_playlist[1:])
+            self.play(self._last_full_playlist[0])
         else:
             # If no track is about to start last track of the queue has been
             # played.
@@ -363,7 +382,17 @@ class BaseMediaService:
     def _is_message_for_service(self, message: Message):
         if not message or not self.validate_source:
             return True
-        return validate_message_context(message)
+        # F9: docs/configuration.md documents `media.native_sources` as the
+        # key to set, but validate_message_context() (ovos_media/utils.py)
+        # only ever reads the top-level `native_sources` config key on its
+        # own — its `native_sources` parameter was always available for a
+        # caller to override that lookup, but nothing here ever passed it,
+        # so the documented media-scoped key was silently ignored. self.config
+        # IS the media-scoped config (see __init__), so honour its
+        # `native_sources` here; the top-level key still works unchanged
+        # since we only override when the media-scoped key is actually set.
+        return validate_message_context(
+            message, native_sources=self.config.get("native_sources"))
 
     def handle_play(self, message: Message):
         """
@@ -377,20 +406,49 @@ class BaseMediaService:
         if not self._is_message_for_service(message):
             return
         with self.service_lock:
-            tracks = message.data['tracks']
+            tracks = message.data.get('tracks') or []
             if not tracks:
                 LOG.warning(f"ovos.{self.namespace}.service.play: no tracks provided")
                 return
+            repeat = message.data.get("repeat", False)
 
             # self.play() takes a single uri, not a tracklist — mirror how
             # ovos-audio's legacy service resolves the first playable track.
             # 'tracks' may be a bare uri string, a list of uri strings, or a
             # list of (uri, mime) tuples.
             if isinstance(tracks, str):
-                uri = tracks
+                track_list = [tracks]
             else:
-                first = tracks[0]
-                uri = first[0] if isinstance(first, (list, tuple)) else first
+                track_list = list(tracks)
+
+            # C6: an entry may itself be an empty list/tuple (eg.
+            # tracks=[[]]) — indexing straight into it used to raise
+            # IndexError and kill the request; skip empty entries and use
+            # the first genuinely playable one instead.
+            uris = []
+            for t in track_list:
+                if isinstance(t, (list, tuple)):
+                    if not t:
+                        continue
+                    uris.append(t[0])
+                else:
+                    uris.append(t)
+            if not uris:
+                LOG.warning(f"ovos.{self.namespace}.service.play: no playable "
+                            f"track entries in tracks={track_list!r}")
+                return
+            uri = uris[0]
+
+            # C6: hand the rest of the tracklist (and repeat) through to the
+            # backend path — mirrors ovos-audio's PlaybackService.play, which
+            # queues the whole list instead of dropping everything after the
+            # first uri. BaseMediaService/MediaBackend only load one uri at a
+            # time (no add_list()/play(repeat) on this template), so the
+            # remainder is advanced incrementally from track_start() as each
+            # track completes.
+            self._last_full_playlist = uris
+            self._pending_playlist = uris[1:]
+            self._pending_repeat = repeat
 
             # Find if the user wants to use a specific backend
             query = message.data.get("utterance", "").lower()

--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -408,6 +408,10 @@ class NowPlaying(MediaEntry):
         self.media_type = MediaType.GENERIC
         self.skill_icon = ""
         self.image = ""
+        # F4: without clearing these, a stopped/home'd player still reports
+        # the previous track's uri via now_playing.as_dict / GUI payload
+        self.uri = ""
+        self.original_uri = ""
 
     def update(self, entry: MediaEntry, skipkeys: list = None, newonly: bool = False):
         """
@@ -525,6 +529,22 @@ class NowPlaying(MediaEntry):
             raise ValueError(f"Expected int or TrackState, but got: {state}")
 
         if state == MediaState.END_OF_MEDIA:
+            # F1: NowPlaying is constructed (and subscribes to this same
+            # 'ovos.common_play.media.state' topic) BEFORE
+            # OCPMediaPlayer.register_bus_handlers runs, so this handler
+            # fires FIRST and resets playback -> PlaybackType.UNDEFINED
+            # before OCPMediaPlayer.handle_playback_ended ever gets to
+            # check what was playing. Stash the pre-reset type on the
+            # player so handle_playback_ended does not depend on a value
+            # this very reset() call is about to wipe out from under it.
+            if self._player is not None:
+                self._player._last_playback_type = self.playback
+                # F4 clears now_playing.uri in reset() below, which
+                # _queue_index() (used by play_next() to locate the track
+                # that just finished, in the merged queue) reads. Stash it
+                # too so the F1 autoplay chain can still find its place —
+                # see _queue_index()'s fallback.
+                self._player._last_playback_uri = self.uri
             # playback ended, allow next track to change metadata again
             self.reset()
 
@@ -572,6 +592,10 @@ class OCPMediaPlayer:
         self.shuffle: bool = False
         self.track_history: dict = {}  # Dict of track URI to play count
         self._paused_on_duck: bool = False
+        # F1: last known-good playback type, stashed by NowPlaying right
+        # before it resets itself on END_OF_MEDIA. See handle_playback_ended.
+        self._last_playback_type: PlaybackType = PlaybackType.UNDEFINED
+        self._last_playback_uri: str = ""
 
         self.now_playing: NowPlaying = NowPlaying(bus, player=self)
         self.media: OCPMediaCatalog = OCPMediaCatalog(bus=bus, skill_id=OCP_ID + ".favorites",
@@ -653,8 +677,15 @@ class OCPMediaPlayer:
             PlayerState.STOPPED: "stopped",
         }
         np = self.now_playing
+        now_playing = None
+        if np and np.uri:
+            # F2/C3: MediaEntry.as_dict has no 'position' field (it is a
+            # plain attribute, not a dataclass field) and reports 'length'
+            # rather than 'duration' — the GUI seekbar contract needs both
+            # 'position' and 'duration' (milliseconds), so merge them in.
+            now_playing = {**np.as_dict, "position": np.position, "duration": np.length}
         self.gui.show_media_player(
-            now_playing=np.as_dict if np and np.uri else None,
+            now_playing=now_playing,
             playlist=[e.as_dict for e in self.playlist.entries] if self.playlist else [],
             search_results=[e.as_dict for e in self.search_results],
             state=state_map.get(self.state, "stopped"),
@@ -699,6 +730,13 @@ class OCPMediaPlayer:
             self.media.liked_songs.store()
             LOG.info(f"unliked song: {uri}")
 
+    # F7/F8: this and service.py's MediaService.handle_search_start both
+    # registered on 'ovos.common_play.search.start' unconditionally, so a
+    # satellite/non-default session's search double-pushed the "loading" GUI
+    # state (once from each handler). Gate this one to the default session
+    # (mirrors every other playback-affecting handler in this class) and the
+    # redundant registration in service.py was deleted outright.
+    @require_default_session()
     def handle_search_start(self, message):
         self.gui.show_media_player(
             now_playing=None,
@@ -774,6 +812,12 @@ class OCPMediaPlayer:
     def _queue_index(self, queue: List[MediaEntry]) -> int:
         """Return the index of ``now_playing`` in *queue*, or -1 if not found."""
         uri = self.now_playing.uri if self.now_playing else None
+        if not uri:
+            # F1/F4: right after an END_OF_MEDIA reset, now_playing.uri is
+            # already cleared (F4), but play_next()/can_next/can_prev still
+            # need to know where the just-finished track was in the queue —
+            # fall back to the uri NowPlaying stashed just before resetting.
+            uri = self._last_playback_uri
         if not uri:
             return -1
         for i, entry in enumerate(queue):
@@ -1071,6 +1115,32 @@ class OCPMediaPlayer:
         if self.mpris and not self.mpris.stop_event.is_set():
             self.mpris.stop()
 
+        # C1: handle_player_media_update dedups on `state == self.media_state`
+        # (see below). Without resetting here, two unplayable tracks in a
+        # row both land on MediaState.INVALID_MEDIA, so the second INVALID_MEDIA
+        # is silently swallowed by the dedup guard and the bad-track skip
+        # chain (on_invalid_stream -> play_next -> play -> ... ) stops dead,
+        # wedging the player mid-PLAYING. Resetting to LOADING_MEDIA at the
+        # start of every play() attempt guarantees the next real state
+        # (whatever it is) always differs from the just-reset value.
+        self.media_state = MediaState.LOADING_MEDIA
+
+        # C4: switching playback types must not leave the previously active
+        # backend's BaseMediaService.current set — otherwise a later,
+        # unrelated global LOADED_MEDIA event revives the stale backend and
+        # two backends end up playing at once. Stop/clear every backend that
+        # is not the one about to be used.
+        for svc, ptype in ((self.audio_service, PlaybackType.AUDIO),
+                           (self.video_service, PlaybackType.VIDEO),
+                           (self.web_service, PlaybackType.WEBVIEW)):
+            if self.playback_type != ptype and svc.current is not None:
+                try:
+                    svc.current.stop()
+                except Exception as e:
+                    LOG.exception(f"Failed to stop inactive {svc.namespace} "
+                                  f"backend on playback-type switch: {e}")
+                svc.current = None
+
         # track play count
         if self.now_playing.uri in self.media.liked_songs:
             if "play_count" not in self.media.liked_songs[self.now_playing.uri]:
@@ -1180,6 +1250,10 @@ class OCPMediaPlayer:
             self.set_now_playing(queue[0])
         else:
             LOG.info("Requested next, but there are no more tracks in the queue")
+            # F3: end of queue with repeat off previously left the player
+            # state untouched (still PLAYING from the just-ended track) —
+            # nothing ever told the GUI/MPRIS/bus that playback stopped.
+            self.set_player_state(PlayerState.STOPPED)
             return
         self.play()
 
@@ -1319,7 +1393,14 @@ class OCPMediaPlayer:
             self.set_media_state(MediaState.NO_MEDIA)
         self.shuffle = False
         self.loop_state = LoopState.NONE
-        self.state: PlayerState = PlayerState.STOPPED
+        # F4: use the authoritative setter (emits ovos.common_play.player.state,
+        # updates MPRIS) instead of a bare attribute assignment that bypassed it.
+        self.set_player_state(PlayerState.STOPPED)
+        # F4: stop -> home (reset) previously left a zombie now_playing entry
+        # on the GUI — now_playing.reset() above already clears uri/original_uri,
+        # but set_player_state() above is a no-op (incl. no _update_gui) when
+        # the player was already STOPPED, so push explicitly here too.
+        self._update_gui()
 
     def shutdown(self):
         """
@@ -1374,8 +1455,14 @@ class OCPMediaPlayer:
         )
 
     def handle_playback_ended(self, message):
+        # F1: self.playback_type reads now_playing.playback, which
+        # NowPlaying.handle_media_state_change already reset to UNDEFINED
+        # for this very END_OF_MEDIA event (it is subscribed to the same
+        # topic and runs first — see the comment there). Use the type it
+        # stashed just before resetting instead of the now-wiped live value.
+        playback_type = self._last_playback_type
         if len(self.playlist) and self.ocp_config.get("autoplay", True) and \
-                self.playback_type not in [PlaybackType.MPRIS, PlaybackType.UNDEFINED]:
+                playback_type not in [PlaybackType.MPRIS, PlaybackType.UNDEFINED]:
             # PlaybackType.UNDEFINED -> no media loaded, eg stop called explicitly
             # PlaybackType.MPRIS -> can't load media in MPRIS players
             LOG.debug(f"Playing next track")
@@ -1429,7 +1516,10 @@ class OCPMediaPlayer:
 
         # from audio player GUI
         position = message.data.get("seekValue")
-        if not position:
+        # F5: `seekValue: 0` (seek to the very start) is falsy, so `if not
+        # position` misread it as "no seekValue given" and fell through to
+        # the relative-seek path instead of seeking to 0.
+        if position is None:
             position = self.now_playing.position or 0
             if self.playback_type in [PlaybackType.AUDIO,
                                       PlaybackType.UNDEFINED]:
@@ -1489,12 +1579,19 @@ class OCPMediaPlayer:
 
     @require_default_session()
     def handle_playlist_set_request(self, message):
+        # F6: validate (and default to []) BEFORE clearing the existing
+        # playlist — the old code cleared first and then KeyError'd on a
+        # missing 'tracks' key inside handle_playlist_queue_request, leaving
+        # the player with an empty playlist for no reason on a malformed
+        # request.
+        tracks = message.data.get("tracks") or []
         self.playlist.clear()
-        self.handle_playlist_queue_request(message)
+        for track in tracks:
+            self.playlist.add_entry(track)
 
     @require_default_session()
     def handle_playlist_queue_request(self, message):
-        for track in message.data["tracks"]:
+        for track in message.data.get("tracks") or []:
             self.playlist.add_entry(track)
 
     @require_default_session()

--- a/ovos_media/service.py
+++ b/ovos_media/service.py
@@ -45,7 +45,12 @@ class MediaService(Thread):
         self.status.set_started()
 
         self.config = Configuration().get("media", {})
-        self.native_sources = self.config.get("native_sources", ["debug_cli", "audio"]) or []
+        # F9: this attribute was dead — it read media.native_sources but was
+        # never passed anywhere; the real consumer, validate_message_context()
+        # in utils.py, only ever read the top-level `native_sources` key.
+        # validate_message_context() now also honours the documented
+        # media-scoped key directly, so this unused shadow copy is removed
+        # rather than wired through a second time.
 
         # Only act on playback commands from the local/"default" session.
         # In a HiveMind split the OCP pipeline (on the server) forwards
@@ -69,7 +74,10 @@ class MediaService(Thread):
         self.ocp = OCPMediaPlayer(self.bus, validate_source=self.validate_source)
         self.bus.on('ovos.common_play.home', self.handle_home)
         self.bus.on("ovos.common_play.ping", self.handle_ping)
-        self.bus.on("ovos.common_play.search.start", self.handle_search_start)
+        # F7/F8: 'ovos.common_play.search.start' is handled by
+        # OCPMediaPlayer.handle_search_start (player.py) — that registration
+        # duplicated it here, unconditionally (no session gating), so every
+        # search.start double-pushed the "loading" GUI state.
         self.bus.on("ovos.common_play.search.end", self.handle_search_end)
         self.legacy_compat = LegacyAudioServiceCompat(self.ocp, self.bus)
 
@@ -82,15 +90,6 @@ class MediaService(Thread):
         @param message: message associated with request
         """
         self.bus.emit(message.reply("ovos.common_play.pong"))
-
-    def handle_search_start(self, message):
-        """when OCP pipeline triggers, show search animation"""
-        self.ocp.gui.show_media_player(
-            now_playing=None,
-            playlist=[],
-            search_results=[],
-            state="loading",
-        )
 
     def handle_search_end(self, message: "Message") -> None:
         """Dismiss the search spinner and refresh the player GUI."""

--- a/test/end2end/test_media_service.py
+++ b/test/end2end/test_media_service.py
@@ -218,18 +218,16 @@ class TestMediaServicePing(unittest.TestCase):
 
 
 class TestMediaServiceSearchHandlers(unittest.TestCase):
-    """Search lifecycle handlers."""
+    """Search lifecycle handlers.
 
-    def test_search_start_shows_loading_gui(self) -> None:
-        """search.start must call gui.show_media_player with state='loading'."""
-        with MediaServiceHarness() as h:
-            h.search_start()
-            h.assert_gui_show_media_player_called(
-                now_playing=None,
-                playlist=[],
-                search_results=[],
-                state="loading",
-            )
+    F7/F8: 'ovos.common_play.search.start' -> GUI "loading" state is now
+    handled solely by OCPMediaPlayer.handle_search_start (player.py),
+    session-gated. MediaService's own (ungated, redundant, double-pushing)
+    registration/handler was deleted. This harness replaces OCPMediaPlayer
+    with a MagicMock entirely, so it cannot exercise that real handler —
+    see test_wave2_defect_fixes.py::TestF7F8SearchStartSessionGating for
+    the real-player coverage (gating behavior + exactly-one-push assertion).
+    """
 
     def test_search_end_does_not_raise(self) -> None:
         """search.end handler must not raise even when not yet implemented."""

--- a/test/unittests/test_base_coverage.py
+++ b/test/unittests/test_base_coverage.py
@@ -24,6 +24,10 @@ def _make_service():
     svc.service_lock = threading.Lock()
     svc.play_start_time = 0.0
     svc.namespace = "audio"
+    svc.config = {}
+    svc._pending_playlist = []
+    svc._pending_repeat = False
+    svc._last_full_playlist = []
     svc._loaded = threading.Event()
     svc._loaded.set()
     return svc, bus

--- a/test/unittests/test_gui.py
+++ b/test/unittests/test_gui.py
@@ -153,8 +153,13 @@ class TestSearchStartShowsLoadingState(unittest.TestCase):
     """handle_search_start must call show_media_player with state='loading'."""
 
     def test_handle_search_start_loading(self):
+        # F7/F8: handle_search_start is now gated to the default/local
+        # session (require_default_session), so a real default-session
+        # Message is needed — a bare MagicMock has no valid session context
+        # and would be (correctly) ignored.
         p = _make_player()
-        msg = MagicMock()
+        p.validate_source = True
+        msg = Message("ovos.common_play.search.start", {})
         p.handle_search_start(msg)
         p.gui.show_media_player.assert_called_once_with(
             now_playing=None,

--- a/test/unittests/test_media_backends.py
+++ b/test/unittests/test_media_backends.py
@@ -66,6 +66,9 @@ class TestBaseMediaServiceLoading(unittest.TestCase):
             svc.volume_is_low = False
             svc.validate_source = True
             svc.service_lock = __import__("threading").Lock()
+            svc._pending_playlist = []
+            svc._pending_repeat = False
+            svc._last_full_playlist = []
             from ovos_utils.process_utils import MonotonicEvent
             svc._loaded = MonotonicEvent()
         return svc
@@ -358,6 +361,9 @@ def _make_base_svc(namespace="audio", config=None, services=None, validate_sourc
     svc.volume_is_low = False
     svc.validate_source = validate_source
     svc.service_lock = threading.Lock()
+    svc._pending_playlist = []
+    svc._pending_repeat = False
+    svc._last_full_playlist = []
     svc._loaded = MonotonicEvent()
     svc._loaded.set()
     return svc, bus

--- a/test/unittests/test_player_coverage.py
+++ b/test/unittests/test_player_coverage.py
@@ -35,6 +35,7 @@ from ovos_utils.ocp import (
     TrackState,
     LoopState,
     PlaybackType,
+    MediaType,
     MediaEntry,
     Playlist,
 )
@@ -80,7 +81,7 @@ def _make_player(playback_type: PlaybackType = PlaybackType.AUDIO):
         p.now_playing.image = ""
         p.now_playing.length = 180000
         p.now_playing.position = 0
-        p.now_playing.media_type = MagicMock()
+        p.now_playing.media_type = MediaType.GENERIC
         p.now_playing.as_dict = {
             "uri": "http://example.com/track.mp3",
             "title": "Test Track",
@@ -89,14 +90,24 @@ def _make_player(playback_type: PlaybackType = PlaybackType.AUDIO):
         }
         p.playlist = MagicMock()
         p.playlist.as_list.return_value = []
+        p.playlist.entries = []
+        p.playlist.position = 0
+        p.playlist.__len__ = lambda self: 0
         p.media = MagicMock()
+        p.media.search_playlist.entries = []
         p.audio_service = MagicMock()
+        p.audio_service.current = None
         p.video_service = MagicMock()
+        p.video_service.current = None
         p.web_service = MagicMock()
+        p.web_service.current = None
         p.current = None
         p.mpris = None
         p.bus = FakeBus()
         p.gui = MagicMock()
+        # __init__ normally sets these; OCPMediaPlayer.__new__ skips __init__
+        p._last_playback_type = playback_type
+        p._last_playback_uri = p.now_playing.uri
     return p
 
 

--- a/test/unittests/test_service.py
+++ b/test/unittests/test_service.py
@@ -67,16 +67,11 @@ class TestMediaServiceHandlers(unittest.TestCase):
         svc.handle_home(MagicMock())
         svc.ocp._update_gui.assert_called_once()
 
-    def test_handle_search_start_shows_loading(self):
-        svc = self._make_service()
-        svc.ocp = MagicMock()
-        svc.handle_search_start(MagicMock())
-        svc.ocp.gui.show_media_player.assert_called_once_with(
-            now_playing=None,
-            playlist=[],
-            search_results=[],
-            state="loading",
-        )
+    # F7/F8: MediaService no longer registers its own
+    # 'ovos.common_play.search.start' handler — it was a redundant,
+    # ungated duplicate of OCPMediaPlayer.handle_search_start (player.py),
+    # which double-pushed the GUI "loading" state on every search. See
+    # test_wave2_defect_fixes.py::TestF7F8SearchStartSessionGating.
 
     def test_handle_search_end_calls_update_gui(self):
         svc = self._make_service()

--- a/test/unittests/test_wave2_defect_fixes.py
+++ b/test/unittests/test_wave2_defect_fixes.py
@@ -1,0 +1,406 @@
+"""Regression tests for defects found during the 2026-08 wave-2 audit.
+
+F1: NowPlaying (constructed BEFORE OCPMediaPlayer.register_bus_handlers)
+    resets playback -> PlaybackType.UNDEFINED on END_OF_MEDIA before
+    OCPMediaPlayer.handle_playback_ended gets to check what was playing
+    (both are subscribed to 'ovos.common_play.media.state'; NowPlaying's
+    handler fires first purely because it was registered first) — autoplay
+    never ran because the UNDEFINED check always tripped.
+C1: handle_player_media_update's `if state == self.media_state: return`
+    dedup guard swallowed the SECOND consecutive INVALID_MEDIA in a bad-track
+    skip chain, wedging the player mid-PLAYING instead of skipping through
+    every unplayable track.
+F3: end of queue (repeat off) left the player state untouched instead of
+    transitioning to STOPPED.
+F2/C3: the GUI now_playing payload was missing 'position' (a plain
+    NowPlaying attribute, not a MediaEntry dataclass field) and reported
+    'length' instead of the 'duration' key the seekbar contract expects.
+F4: NowPlaying.reset() did not clear uri/original_uri, and
+    OCPMediaPlayer.reset() used a bare `self.state = ...` assignment that
+    never reached the GUI.
+F5: handle_seek_request treated `seekValue: 0` as "no seekValue given"
+    (falsy) and fell through to the relative-seek path.
+F6: handle_playlist_set_request cleared the playlist before validating
+    'tracks', so a malformed/absent 'tracks' key KeyError'd with the
+    playlist already wiped.
+F7/F8: 'ovos.common_play.search.start' was handled by both
+    OCPMediaPlayer.handle_search_start (ungated) and
+    MediaService.handle_search_start (also ungated, now deleted), double
+    pushing the GUI "loading" state, including for non-default sessions.
+C4: switching playback type (eg. VIDEO -> AUDIO) left the previous
+    BaseMediaService's `current` set, so a later stray LOADED_MEDIA event
+    could revive it and run two backends at once.
+C6: BaseMediaService.handle_play only ever looked at tracks[0], silently
+    dropping the rest of the tracklist and `repeat`; `tracks=[[]]` raised
+    an uncaught IndexError.
+
+CRITICAL: the F1/C1 tests drive their scenario entirely through
+bus.emit()/FakeBus — calling the handler methods directly was the
+false-green mechanism that let both defects through the first audit wave.
+"""
+import threading
+import unittest
+from unittest.mock import patch
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import (
+    MediaState,
+    PlayerState,
+    PlaybackType,
+    MediaEntry,
+    Playlist,
+)
+
+
+def _track(uri, title, playback=PlaybackType.AUDIO):
+    return MediaEntry(uri=uri, title=title, playback=playback)
+
+
+class TestF1AutoplayChain(unittest.TestCase):
+    """F1: a 2-track playlist must advance to track 2 on END_OF_MEDIA,
+    driven entirely through bus.emit on a FakeBus."""
+
+    def test_end_of_media_advances_to_next_track_via_bus(self):
+        from ovos_media.player import OCPMediaPlayer
+
+        bus = FakeBus()
+        player = OCPMediaPlayer(bus, config={})
+        t1 = _track("http://example.com/a.mp3", "Track A")
+        t2 = _track("http://example.com/b.mp3", "Track B")
+        player.set_now_playing(Playlist([t1, t2], title="Q"))
+        player.set_player_state(PlayerState.PLAYING)
+        self.assertEqual(player.now_playing.uri, t1.uri)
+
+        # avoid touching a real backend for the *next* play() attempt —
+        # only the routing decision (does play_next even fire, and does it
+        # pick track 2) is under test here.
+        with patch.object(player, "play") as mock_play:
+            bus.emit(Message("ovos.common_play.media.state",
+                             {"state": MediaState.END_OF_MEDIA}))
+
+        mock_play.assert_called_once()
+        self.assertEqual(player.now_playing.uri, t2.uri)
+        self.assertEqual(player.now_playing.title, "Track B")
+
+
+class TestC1InvalidMediaSkipChain(unittest.TestCase):
+    """C1: three unplayable tracks in a row must ALL be attempted, and the
+    player must end up in a sane (not silently-wedged-PLAYING) state.
+    Driven entirely through bus.emit on a FakeBus."""
+
+    def test_three_unplayable_tracks_all_attempted_via_bus(self):
+        from ovos_media.player import OCPMediaPlayer
+
+        bus = FakeBus()
+        player = OCPMediaPlayer(bus, config={})
+        # no backend plugins loaded -> every play attempt on this uri_type
+        # synchronously emits INVALID_MEDIA (BaseMediaService.play(), "no
+        # service found for uri_type")
+        player.audio_service.services = []
+
+        tracks = [_track(f"http://example.com/t{i}.mp3", f"T{i}")
+                 for i in range(3)]
+
+        invalid_media_events = []
+        bus.on("ovos.common_play.media.state",
+              lambda m: invalid_media_events.append(m.data.get("state")))
+        player_state_events = []
+        bus.on("ovos.common_play.player.state",
+              lambda m: player_state_events.append(m.data.get("state")))
+        # start from PLAYING so F3's STOPPED transition (fired deep inside
+        # the recursive skip chain, before any frame's own trailing
+        # set_player_state(PLAYING) call has had a chance to run) is not
+        # itself a same-state no-op against the constructor's default
+        # PlayerState.STOPPED.
+        player.set_player_state(PlayerState.PLAYING)
+        player_state_events.clear()
+
+        bus.emit(Message("ovos.common_play.play", {
+            "media": tracks[0].as_dict,
+            "playlist": [t.as_dict for t in tracks],
+        }))
+
+        invalid_count = sum(1 for s in invalid_media_events
+                            if s == MediaState.INVALID_MEDIA)
+        # without the C1 fix, the SECOND consecutive INVALID_MEDIA is
+        # swallowed by the `state == self.media_state` dedup guard and the
+        # skip chain stops after only one retry (2 events, not 3).
+        self.assertEqual(invalid_count, 3,
+                         f"expected all 3 unplayable tracks to be attempted, "
+                         f"got {invalid_count} INVALID_MEDIA events: "
+                         f"{invalid_media_events}")
+        # F3: exhausting the queue (repeat off) must transition player
+        # state instead of leaving it wedged at whatever it was.
+        self.assertIn(PlayerState.STOPPED, player_state_events,
+                      "expected a STOPPED transition once the queue of "
+                      "unplayable tracks was exhausted")
+
+
+class TestF3EndOfQueueStops(unittest.TestCase):
+    def test_play_next_at_end_of_queue_sets_stopped(self):
+        from ovos_media.player import OCPMediaPlayer
+
+        bus = FakeBus()
+        player = OCPMediaPlayer(bus, config={})
+        t1 = _track("http://example.com/only.mp3", "Only")
+        player.set_now_playing(Playlist([t1], title="Q"))
+        player.set_player_state(PlayerState.PLAYING)
+
+        with patch.object(player, "play") as mock_play:
+            player.play_next()
+
+        mock_play.assert_not_called()
+        self.assertEqual(player.state, PlayerState.STOPPED)
+
+
+class TestF2GuiSeekbarPayload(unittest.TestCase):
+    def test_update_gui_includes_position_and_duration(self):
+        from ovos_media.player import OCPMediaPlayer
+
+        bus = FakeBus()
+        player = OCPMediaPlayer(bus, config={})
+        t1 = _track("http://example.com/a.mp3", "A")
+        player.set_now_playing(t1)
+        player.now_playing.position = 4200
+        player.now_playing.length = 90000
+
+        captured = {}
+        player.gui.show_media_player = lambda **kw: captured.update(kw)
+        player._update_gui()
+
+        np = captured["now_playing"]
+        self.assertIn("position", np)
+        self.assertIn("duration", np)
+        self.assertEqual(np["position"], 4200)
+        self.assertEqual(np["duration"], 90000)
+        # 'length' round-trips too since it's still a real MediaEntry field
+        self.assertEqual(np["length"], 90000)
+
+
+class TestF4ResetClearsZombieEntry(unittest.TestCase):
+    def test_stop_then_reset_clears_now_playing_uri_and_pushes_gui(self):
+        from ovos_media.player import OCPMediaPlayer
+
+        bus = FakeBus()
+        player = OCPMediaPlayer(bus, config={})
+        t1 = _track("http://example.com/a.mp3", "A")
+        player.set_now_playing(t1)
+        self.assertEqual(player.now_playing.uri, t1.uri)
+
+        captured = []
+        player.gui.show_media_player = lambda **kw: captured.append(kw)
+        player.reset()
+
+        self.assertEqual(player.now_playing.uri, "")
+        self.assertEqual(player.now_playing.original_uri, "")
+        self.assertTrue(captured, "reset() must push a GUI update")
+        self.assertIsNone(captured[-1]["now_playing"],
+                          "GUI must not keep showing the stopped track "
+                          "(zombie now_playing entry)")
+
+
+class TestF5SeekZeroIsAbsolute(unittest.TestCase):
+    def test_seek_value_zero_seeks_to_start(self):
+        from ovos_media.player import OCPMediaPlayer
+
+        bus = FakeBus()
+        player = OCPMediaPlayer(bus, config={})
+        t1 = _track("http://example.com/a.mp3", "A")
+        player.set_now_playing(t1)
+        # nonzero so the buggy relative-seek fallback path (position=this,
+        # + 0 ms from 'seconds') would compute something other than 0 too —
+        # otherwise both the buggy and fixed code paths land on seek(0) by
+        # coincidence and the test can't tell them apart.
+        player.now_playing.position = 15000
+
+        with patch.object(player, "seek") as mock_seek:
+            bus.emit(Message("ovos.common_play.seek", {"seekValue": 0}))
+
+        mock_seek.assert_called_once_with(0)
+
+
+class TestF6PlaylistSetMissingTracks(unittest.TestCase):
+    def test_playlist_set_without_tracks_key_does_not_raise_and_clears(self):
+        from ovos_media.player import OCPMediaPlayer
+
+        bus = FakeBus()
+        player = OCPMediaPlayer(bus, config={})
+        t1 = _track("http://example.com/a.mp3", "A")
+        player.playlist.add_entry(t1)
+        self.assertEqual(len(player.playlist), 1)
+
+        # call the handler directly (not F1/C1 — not exempt from that rule)
+        # so a KeyError raised inside is not silently swallowed by
+        # bus.emit()'s own try/except, which would mask the defect.
+        try:
+            player.handle_playlist_set_request(
+                Message("ovos.common_play.playlist.set", {}))
+        except KeyError:
+            self.fail("handle_playlist_set_request must not KeyError when "
+                     "'tracks' is missing")
+
+        self.assertEqual(len(player.playlist), 0)
+
+    def test_playlist_set_with_valid_tracks_replaces_playlist(self):
+        from ovos_media.player import OCPMediaPlayer
+
+        bus = FakeBus()
+        player = OCPMediaPlayer(bus, config={})
+        old = _track("http://example.com/old.mp3", "old")
+        player.playlist.add_entry(old)
+
+        new_track = _track("http://example.com/new.mp3", "new")
+        bus.emit(Message("ovos.common_play.playlist.set",
+                         {"tracks": [new_track.as_dict]}))
+
+        self.assertEqual(len(player.playlist), 1)
+        self.assertEqual(player.playlist[0].uri, new_track.uri)
+
+
+class TestF7F8SearchStartSessionGating(unittest.TestCase):
+    def test_named_session_search_start_pushes_no_gui_update(self):
+        from ovos_media.player import OCPMediaPlayer
+        from ovos_bus_client.session import Session
+
+        bus = FakeBus()
+        player = OCPMediaPlayer(bus, config={})
+        captured = []
+        player.gui.show_media_player = lambda **kw: captured.append(kw)
+
+        msg = Message("ovos.common_play.search.start", {})
+        msg.context["session"] = Session("some-satellite-session").serialize()
+        bus.emit(msg)
+
+        self.assertEqual(len(captured), 0)
+
+    def test_default_session_search_start_pushes_exactly_one_gui_update(self):
+        from ovos_media.player import OCPMediaPlayer
+
+        bus = FakeBus()
+        player = OCPMediaPlayer(bus, config={})
+        captured = []
+        player.gui.show_media_player = lambda **kw: captured.append(kw)
+
+        bus.emit(Message("ovos.common_play.search.start", {}))
+
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0]["state"], "loading")
+
+    def test_media_service_no_longer_registers_its_own_search_start_handler(self):
+        from ovos_media.service import MediaService
+
+        bus = FakeBus()
+        service = MediaService(bus=bus)
+        try:
+            self.assertFalse(hasattr(service, "handle_search_start"))
+        finally:
+            service.shutdown()
+
+
+class TestC4PlaybackTypeSwitchStopsOtherBackend(unittest.TestCase):
+    def test_switching_video_to_audio_clears_video_backend_current(self):
+        from ovos_media.player import OCPMediaPlayer
+
+        bus = FakeBus()
+        player = OCPMediaPlayer(bus, config={})
+        player.audio_service.services = []
+        player.video_service.services = []
+
+        fake_video_backend = type("FakeBackend", (), {
+            "stop": lambda self: None,
+        })()
+        player.video_service.current = fake_video_backend
+
+        audio_track = _track("http://example.com/a.mp3", "A",
+                             playback=PlaybackType.AUDIO)
+        player.set_now_playing(audio_track)
+        player.play()
+
+        self.assertIsNone(player.video_service.current,
+                          "switching to AUDIO must clear the VIDEO "
+                          "backend's `current`, not just leave it dangling")
+
+
+class TestC6TracklistAndRepeat(unittest.TestCase):
+    def _make_service(self):
+        from ovos_media.media_backends.base import BaseMediaService
+        svc = BaseMediaService.__new__(BaseMediaService)
+        svc.bus = FakeBus()
+        svc.services = []
+        svc.current = None
+        svc.validate_source = False
+        svc.volume_is_low = False
+        svc.service_lock = threading.Lock()
+        svc.play_start_time = 0.0
+        svc.namespace = "audio"
+        svc.config = {}
+        svc._pending_playlist = []
+        svc._pending_repeat = False
+        svc._last_full_playlist = []
+        svc._loaded = threading.Event()
+        svc._loaded.set()
+        return svc
+
+    def test_handle_play_with_empty_track_entry_does_not_raise(self):
+        svc = self._make_service()
+        with patch("threading.Timer") as mock_timer:
+            svc.handle_play(Message("ovos.audio.service.play",
+                                    {"tracks": [[]]}))
+            mock_timer.assert_not_called()
+
+    def test_handle_play_with_empty_entry_then_real_track_uses_the_real_one(self):
+        svc = self._make_service()
+        with patch("threading.Timer") as mock_timer:
+            svc.handle_play(Message("ovos.audio.service.play",
+                                    {"tracks": [[], "http://example.com/a.mp3"]}))
+            mock_timer.assert_called_once()
+            call_args = mock_timer.call_args[1].get("args") or mock_timer.call_args[0][2]
+            self.assertEqual(call_args[0], "http://example.com/a.mp3")
+
+    def test_handle_play_stores_remaining_tracks_and_repeat(self):
+        svc = self._make_service()
+        with patch("threading.Timer"):
+            svc.handle_play(Message("ovos.audio.service.play", {
+                "tracks": ["http://example.com/a.mp3",
+                          "http://example.com/b.mp3",
+                          "http://example.com/c.mp3"],
+                "repeat": True,
+            }))
+        self.assertEqual(svc._pending_playlist,
+                         ["http://example.com/b.mp3", "http://example.com/c.mp3"])
+        self.assertTrue(svc._pending_repeat)
+        self.assertEqual(svc._last_full_playlist,
+                         ["http://example.com/a.mp3",
+                          "http://example.com/b.mp3",
+                          "http://example.com/c.mp3"])
+
+    def test_track_start_none_advances_to_next_pending_track(self):
+        svc = self._make_service()
+        svc._pending_playlist = ["http://example.com/b.mp3"]
+        svc._last_full_playlist = ["http://example.com/a.mp3", "http://example.com/b.mp3"]
+        with patch.object(svc, "play") as mock_play:
+            svc.track_start(None)
+        mock_play.assert_called_once_with("http://example.com/b.mp3")
+        self.assertEqual(svc._pending_playlist, [])
+
+    def test_track_start_none_repeats_full_playlist_when_exhausted(self):
+        svc = self._make_service()
+        svc._pending_playlist = []
+        svc._pending_repeat = True
+        svc._last_full_playlist = ["http://example.com/a.mp3", "http://example.com/b.mp3"]
+        with patch.object(svc, "play") as mock_play:
+            svc.track_start(None)
+        mock_play.assert_called_once_with("http://example.com/a.mp3")
+        self.assertEqual(svc._pending_playlist, ["http://example.com/b.mp3"])
+
+    def test_track_start_none_emits_queue_end_when_no_repeat_and_exhausted(self):
+        svc = self._make_service()
+        received = []
+        svc.bus.on(f"ovos.{svc.namespace}.queue_end", lambda m: received.append(m))
+        svc.track_start(None)
+        self.assertEqual(len(received), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This is wave 2 of the audit loop, focused on the player and its state machine. Two independent auditors reproduced every defect below by probing the running player over the bus, not just by reading code. Autoplay never advanced past the first track, because a state reset raced with the end-of-track handler depending on which order handlers ran in; a small companion stash of the last playback type and uri keeps queue indexing working now that the reset clears the uri. Two bad tracks in a row used to wedge the player entirely, because state deduplication swallowed the second failure signal. The GUI seek bar could never move, because its payload was missing position and its length wasn't mapped to duration. Reaching the end of the queue never actually emitted a stopped state. Stopping left a stale "now playing" uri and a stale GUI behind. Seeking to position zero was treated as false and silently did a relative seek instead of an absolute one. Setting a playlist with no tracks wiped the queue and then raised a KeyError. Search requests weren't gated by session, so a satellite session could hijack the local GUI, and the handler was also registered twice, so one obsolete duplicate end-to-end test was removed and its coverage moved to the unit level. Switching playback namespace left the old backend still running, so two backends could play at once. The legacy play path dropped every track after the first and ignored repeat. And a documented config option, media.native_sources, was never actually read; it's now honored.

Reverting the fixes produced 15 failures out of 17 red-proof assertions; two weak tests were strengthened and re-proven. On the rebased result, unit tests went from 585 to 602 passing (17 new), and end-to-end tests went from 65 to 64 (one obsolete duplicate removed). The orchestrator verified this live.
