### PR TITLE
fix: single-writer end-of-track path, stop semantics, bounded retries

### DIFF
--- a/ovos_media/media_backends/base.py
+++ b/ovos_media/media_backends/base.py
@@ -18,10 +18,18 @@ from ovos_utils.process_utils import MonotonicEvent
 class BaseMediaService:
 
     def __init__(self, bus, namespace: str, plugin_loader: Callable,
-                 config=None, autoload=True, validate_source=True):
+                 config=None, autoload=True, validate_source=True,
+                 on_stop: Callable = None):
         """
             Args:
                 bus: OVOS messagebus
+                on_stop: optional callback invoked at the start of stop(), in
+                    the calling thread, before the backend is asked to stop.
+                    OCPMediaPlayer uses it to flag that the END_OF_MEDIA the
+                    backend's ocp_stop() is about to emit was caused by a stop
+                    request and must not advance the queue. A callback rather
+                    than a second bus subscription because only a direct call
+                    is ordered before the event it needs to annotate.
         """
         self.bus = bus
         self.namespace = namespace
@@ -35,17 +43,32 @@ class BaseMediaService:
         self.play_start_time = 0
         self.volume_is_low = False
         self.validate_source = validate_source
+        self._init_runtime_state(on_stop=on_stop)
+
+        self._loaded = MonotonicEvent()
+        if autoload:
+            self.load_services()
+        self.bus.on("ovos.common_play.media.state", self.handle_media_state_change)
+
+    def _init_runtime_state(self, on_stop: Callable = None) -> None:
+        """Initialise the plain in-memory playback bookkeeping.
+
+        Split out of __init__ so it can be applied on its own to a service
+        whose backends and bus wiring are supplied by other means.
+        """
+        self.on_stop = on_stop
         # C6: queued-but-not-yet-loaded tracks from the last handle_play(),
         # and whether that request asked to repeat once exhausted. Consumed
         # incrementally from track_start() as each track finishes.
         self._pending_playlist: list = []
         self._pending_repeat: bool = False
         self._last_full_playlist: list = []
-
-        self._loaded = MonotonicEvent()
-        if autoload:
-            self.load_services()
-        self.bus.on("ovos.common_play.media.state", self.handle_media_state_change)
+        # W3: handles for the deferred work started by handle_play()/stop().
+        # Both are cancellable and daemonic — an orphaned timer used to load a
+        # second backend behind the first, survive a stop, and fire into an
+        # already shut-down service.
+        self._play_timer: Optional[threading.Timer] = None
+        self._deferred_stop_timer: Optional[threading.Timer] = None
 
     def available_backends(self):
         """Return available media backends.
@@ -84,13 +107,13 @@ class BaseMediaService:
             # only the first track ever played.
             next_uri = self._pending_playlist.pop(0)
             LOG.debug(f'Advancing to next queued {self.namespace} track')
-            self.play(next_uri)
+            self._play(next_uri)
         elif self._pending_repeat and self._last_full_playlist:
             # C6: the exhausted playlist was requested with repeat=True —
             # mirrors ovos-audio's PlaybackService repeat semantics.
             LOG.debug(f'Repeating {self.namespace} playlist')
             self._pending_playlist = list(self._last_full_playlist[1:])
-            self.play(self._last_full_playlist[0])
+            self._play(self._last_full_playlist[0])
         else:
             # If no track is about to start last track of the queue has been
             # played.
@@ -276,10 +299,32 @@ class BaseMediaService:
             self.current.resume()
             self.current.ocp_resume()
 
+    def _cancel_timers(self):
+        """Cancel any pending deferred play/stop so they cannot fire late."""
+        for attr in ("_play_timer", "_deferred_stop_timer"):
+            timer = getattr(self, attr, None)
+            if timer is not None:
+                timer.cancel()
+                setattr(self, attr, None)
+
+    def _clear_pending_playlist(self):
+        """Forget the legacy-request tracklist queued by handle_play().
+
+        W3: without this, a legacy 'ovos.{ns}.service.play' tracklist that was
+        never exhausted stayed queued and hijacked a later, unrelated OCP
+        playback — track_start() advanced into the stale uris, interleaving
+        them with the OCP queue.
+        """
+        self._pending_playlist = []
+        self._pending_repeat = False
+        self._last_full_playlist = []
+
     def _perform_stop(self, message: Message = None):
         """Stop mediaservice if active."""
         if not self._is_message_for_service(message):
             return
+        self._cancel_timers()
+        self._clear_pending_playlist()
         if self.current:
             LOG.debug(f'stopping playing service: {self.current}')
             if self.current.stop():
@@ -303,13 +348,53 @@ class BaseMediaService:
         """
         if not self._is_message_for_service(message):
             return
-        if time.monotonic() - self.play_start_time > 1:
+        if self.on_stop is not None:
+            # W3: tell the owning player this end-of-playback is a stop, before
+            # the backend's ocp_stop() emits END_OF_MEDIA.
+            try:
+                self.on_stop()
+            except Exception as e:
+                LOG.exception(f"on_stop callback failed: {e}")
+        # W3: a stop must also cancel playback that has been scheduled but has
+        # not started yet — otherwise a stop inside handle_play()'s 0.5s window
+        # was simply ignored and the track started playing anyway.
+        if self._play_timer is not None:
+            self._play_timer.cancel()
+            self._play_timer = None
+        elapsed = time.monotonic() - self.play_start_time
+        if elapsed > 1:
             with self.service_lock:
                 try:
                     self._perform_stop(message)
                 except Exception as e:
                     LOG.exception(e)
                     LOG.error("failed to stop!")
+        elif message is None:
+            # W3: the <1s guard exists to swallow the stop that ovos-core fires
+            # right as playback begins. Dropping it outright meant the internal
+            # caller (OCPMediaPlayer.stop) reported STOPPED while audio kept
+            # playing forever. Defer the stop past the guard window instead.
+            LOG.debug(f"{self.namespace}: stop within the start guard window — "
+                      f"deferring it")
+            self._schedule_deferred_stop(1.0 - elapsed + 0.05)
+
+    def _schedule_deferred_stop(self, delay: float):
+        """Run _perform_stop once the post-play-start guard window closes."""
+        if self._deferred_stop_timer is not None:
+            self._deferred_stop_timer.cancel()
+        timer = threading.Timer(max(delay, 0.0), self._deferred_stop)
+        timer.daemon = True
+        self._deferred_stop_timer = timer
+        timer.start()
+
+    def _deferred_stop(self):
+        self._deferred_stop_timer = None
+        with self.service_lock:
+            try:
+                self._perform_stop(None)
+            except Exception as e:
+                LOG.exception(e)
+                LOG.error("failed to stop!")
 
     def lower_volume(self, message: Message = None):
         """
@@ -343,6 +428,23 @@ class BaseMediaService:
                 uri: uri of track to play.
                 preferred_service: indicates the service the user prefer to play
                                   the tracks.
+        """
+        # W3: a new playback request supersedes whatever the last legacy
+        # 'service.play' tracklist left queued, and any deferred stop aimed at
+        # the previous track. The internal advance path (_play) deliberately
+        # keeps the pending playlist, since that is what it is consuming.
+        self._clear_pending_playlist()
+        if self._deferred_stop_timer is not None:
+            self._deferred_stop_timer.cancel()
+            self._deferred_stop_timer = None
+        self._play(uri, preferred_service)
+
+    def _play(self, uri, preferred_service: MediaBackend = None):
+        """Select a backend and load *uri* on it.
+
+        Internal entry point: unlike play(), it preserves the queued
+        legacy-request tracklist, because track_start() drives the queue
+        through here as each track finishes.
         """
         uri_type = uri.split(':')[0]
 
@@ -406,6 +508,10 @@ class BaseMediaService:
         if not self._is_message_for_service(message):
             return
         with self.service_lock:
+            # W3: a second play request supersedes the first. Without cancelling
+            # the pending timer both fired, loading two backends at once and
+            # orphaning the first.
+            self._cancel_timers()
             tracks = message.data.get('tracks') or []
             if not tracks:
                 LOG.warning(f"ovos.{self.namespace}.service.play: no tracks provided")
@@ -465,8 +571,15 @@ class BaseMediaService:
                 preferred_service = None
 
             try:
-                # Use a timer to avoid blocking the bus event loop
-                threading.Timer(0.5, self.play, args=[uri, preferred_service]).start()
+                # Use a timer to avoid blocking the bus event loop. Daemonic so
+                # a pending start never outlives shutdown, and kept on the
+                # service so stop()/handle_play()/shutdown() can cancel it.
+                # Targets _play so the tracklist queued just above survives.
+                timer = threading.Timer(0.5, self._play,
+                                        args=[uri, preferred_service])
+                timer.daemon = True
+                self._play_timer = timer
+                timer.start()
             except Exception as e:
                 LOG.exception(e)
 
@@ -601,6 +714,9 @@ class BaseMediaService:
         self.current.set_track_position(milliseconds)
 
     def shutdown(self):
+        # W3: a pending deferred play/stop must not fire into a shut-down backend
+        self._cancel_timers()
+        self._clear_pending_playlist()
         for s in self.services:
             try:
                 LOG.info('shutting down ' + s.name)

--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -44,7 +44,6 @@ class OCPMediaCatalog(OVOSCommonPlaybackSkill):
         self.search_playlist = Playlist()
         self.ocp_skills = {}
         self.featured_skills = {}
-        self.search_lock = RLock()
         self.add_event("ovos.common_play.skills.detach", self.handle_ocp_skill_detach)
         self.add_event("ovos.common_play.announce", self.handle_skill_announce)
 
@@ -353,7 +352,14 @@ class NowPlaying(MediaEntry):
         super().__init__(*args, **kwargs)
         self.original_uri = self.uri
         self.bus.on("ovos.common_play.track.state", self.handle_track_state_change)
-        self.bus.on("ovos.common_play.media.state", self.handle_media_state_change)
+        # NOTE: NowPlaying deliberately does NOT subscribe to
+        # 'ovos.common_play.media.state'. OCPMediaPlayer.handle_player_media_update
+        # is the SINGLE subscriber to that topic and calls
+        # NowPlaying.on_end_of_media() as a plain method call, in order, after it
+        # has captured the pre-reset playback type / uri. Two independent
+        # subscribers had no ordering guarantee (pyee's ExecutorEventEmitter
+        # submits every handler to a thread pool independently), which raced the
+        # end-of-track reset against the autoplay decision that reads it.
         self.bus.on("ovos.common_play.play", self.handle_external_play)
         self.bus.on("ovos.common_play.playback_time", self.handle_sync_seekbar)
 
@@ -389,7 +395,6 @@ class NowPlaying(MediaEntry):
         Remove NowPlaying events from the MessageBusClient
         """
         self.bus.remove("ovos.common_play.track.state", self.handle_track_state_change)
-        self.bus.remove("ovos.common_play.media.state", self.handle_media_state_change)
         self.bus.remove('ovos.common_play.play', self.handle_external_play)
         self.bus.remove('ovos.common_play.playback_time', self.handle_sync_seekbar)
 
@@ -514,9 +519,22 @@ class NowPlaying(MediaEntry):
         # NOTE: pause is a PlayerState/MediaState concern, never a TrackState —
         # there is no TrackState.PAUSED_* member, so no pause branch belongs here.
 
+    def on_end_of_media(self):
+        """
+        End-of-media reset, invoked as a plain method call by
+        OCPMediaPlayer.handle_player_media_update (the single subscriber to
+        'ovos.common_play.media.state') AFTER it has captured the pre-reset
+        playback type and uri. Playback ended, so allow the next track to
+        change metadata again.
+        """
+        self.reset()
+
     def handle_media_state_change(self, message):
         """
         Handle 'ovos.common_play.media.state' Messages. If ended, reset.
+
+        NOT registered on the bus (see __init__): kept as a callable entry
+        point for out-of-tree callers that drive NowPlaying directly.
         @param message: Message with updated MediaState
         """
         state = message.data.get("state")
@@ -529,24 +547,7 @@ class NowPlaying(MediaEntry):
             raise ValueError(f"Expected int or TrackState, but got: {state}")
 
         if state == MediaState.END_OF_MEDIA:
-            # F1: NowPlaying is constructed (and subscribes to this same
-            # 'ovos.common_play.media.state' topic) BEFORE
-            # OCPMediaPlayer.register_bus_handlers runs, so this handler
-            # fires FIRST and resets playback -> PlaybackType.UNDEFINED
-            # before OCPMediaPlayer.handle_playback_ended ever gets to
-            # check what was playing. Stash the pre-reset type on the
-            # player so handle_playback_ended does not depend on a value
-            # this very reset() call is about to wipe out from under it.
-            if self._player is not None:
-                self._player._last_playback_type = self.playback
-                # F4 clears now_playing.uri in reset() below, which
-                # _queue_index() (used by play_next() to locate the track
-                # that just finished, in the merged queue) reads. Stash it
-                # too so the F1 autoplay chain can still find its place —
-                # see _queue_index()'s fallback.
-                self._player._last_playback_uri = self.uri
-            # playback ended, allow next track to change metadata again
-            self.reset()
+            self.on_end_of_media()
 
     def handle_sync_seekbar(self, message):
         """
@@ -591,18 +592,19 @@ class OCPMediaPlayer:
         self.playlist: Playlist = Playlist(title="Search Results")
         self.shuffle: bool = False
         self.track_history: dict = {}  # Dict of track URI to play count
-        self._paused_on_duck: bool = False
-        # F1: last known-good playback type, stashed by NowPlaying right
-        # before it resets itself on END_OF_MEDIA. See handle_playback_ended.
-        self._last_playback_type: PlaybackType = PlaybackType.UNDEFINED
-        self._last_playback_uri: str = ""
+        self._init_runtime_state()
 
         self.now_playing: NowPlaying = NowPlaying(bus, player=self)
         self.media: OCPMediaCatalog = OCPMediaCatalog(bus=bus, skill_id=OCP_ID + ".favorites",
                                                        validate_source=self.validate_source)
-        self.audio_service = AudioService(bus)
-        self.video_service = VideoService(bus)
-        self.web_service = WebService(bus)
+        # W3: the per-namespace 'ovos.{ns}.service.stop' bus handler lives on
+        # BaseMediaService; this callback lets it flag the stop on the player
+        # BEFORE the backend's ocp_stop() emits END_OF_MEDIA, in the same
+        # thread. A second bus subscription would have had no such ordering
+        # guarantee against the END_OF_MEDIA it causes.
+        self.audio_service = AudioService(bus, on_stop=self._mark_stop_requested)
+        self.video_service = VideoService(bus, on_stop=self._mark_stop_requested)
+        self.web_service = WebService(bus, on_stop=self._mark_stop_requested)
         self.current: Optional[MediaBackend] = None
         self.mpris: Optional[OcpMprisExporter] = None
 
@@ -616,6 +618,37 @@ class OCPMediaPlayer:
 
         self.gui = GUIInterface("ovos.common_play", bus=bus)
         self.register_bus_handlers()
+
+    def _init_runtime_state(self) -> None:
+        """Initialise the plain in-memory playback bookkeeping.
+
+        Split out of __init__ so it can be applied on its own to a player whose
+        heavyweight collaborators (services, GUI, MPRIS) are supplied by other
+        means.
+        """
+        self._paused_on_duck: bool = False
+        # W3: guards every read-modify-write of media_state/player_state so the
+        # END_OF_MEDIA compare-and-set cannot be executed twice concurrently
+        # (two racing END_OF_MEDIA events used to double-advance the queue).
+        # Reentrant because play() -> on_invalid_stream() re-enters.
+        self._state_lock = RLock()
+        # W3: True between a stop request and the next play(). An explicit stop
+        # must NOT advance the queue, but OPM backends emit END_OF_MEDIA from
+        # ocp_stop(), so a stop is indistinguishable from a natural track end at
+        # the media.state level without this flag.
+        self._stop_requested: bool = False
+        # W3: the exact MediaEntry object currently selected. Located by
+        # identity in _queue_index(), which makes duplicate uris in a playlist
+        # (eg. [a, b, a]) advance correctly instead of ping-ponging, and
+        # survives the END_OF_MEDIA reset that clears now_playing.uri.
+        self._current_entry: Optional[MediaEntry] = None
+        # W3: uris that failed to load since the last successful load. Used to
+        # stop LoopState.REPEAT from restarting a queue in which every track is
+        # broken (unbounded hot loop).
+        self._failed_uris: set = set()
+        self._invalid_timer: Optional[threading.Timer] = None
+        # retry delay after an invalid stream, seconds (overridable in tests)
+        self.invalid_stream_delay: float = 3.0
 
     def register_bus_handlers(self) -> None:
         """Register all OCP bus event handlers."""
@@ -809,17 +842,43 @@ class OCPMediaPlayer:
         extra = [e for e in self.media.search_playlist.entries if e.uri not in seen]
         return user_entries + extra
 
-    def _queue_index(self, queue: List[MediaEntry]) -> int:
-        """Return the index of ``now_playing`` in *queue*, or -1 if not found."""
-        uri = self.now_playing.uri if self.now_playing else None
-        if not uri:
-            # F1/F4: right after an END_OF_MEDIA reset, now_playing.uri is
-            # already cleared (F4), but play_next()/can_next/can_prev still
-            # need to know where the just-finished track was in the queue —
-            # fall back to the uri NowPlaying stashed just before resetting.
-            uri = self._last_playback_uri
+    def _mark_stop_requested(self):
+        """Flag that the current playback is ending because it was stopped.
+
+        Called from OCPMediaPlayer.stop() and, via the ``on_stop`` callback,
+        from BaseMediaService.stop() (the 'ovos.{ns}.service.stop' bus handler)
+        before the backend's ocp_stop() emits END_OF_MEDIA.
+        """
+        self._stop_requested = True
+
+    def _queue_index(self, queue: List[MediaEntry], uri: str = None) -> int:
+        """Return the index of the currently selected track in *queue*, or -1.
+
+        Resolution order:
+
+        1. **Entry identity** — the exact MediaEntry object last handed to
+           ``set_now_playing``. This is the only reliable locator when the same
+           uri appears more than once in a queue (``[a, b, a]``), and it
+           survives the END_OF_MEDIA reset that clears ``now_playing.uri``.
+        2. **Playlist position** — ``self.playlist.position``, accepted only if
+           it points at an entry whose uri matches the one we are looking for.
+        3. **URI lookup** — first entry with a matching uri.
+        """
+        cur = self._current_entry
+        if cur is not None:
+            for i, entry in enumerate(queue):
+                if entry is cur:
+                    return i
+
+        uri = uri or (self.now_playing.uri if self.now_playing else None) or \
+              (cur.uri if cur is not None else None)
         if not uri:
             return -1
+
+        pos = getattr(self.playlist, "position", None)
+        if isinstance(pos, int) and 0 <= pos < len(queue) and queue[pos].uri == uri:
+            return pos
+
         for i, entry in enumerate(queue):
             if entry.uri == uri:
                 return i
@@ -903,6 +962,10 @@ class OCPMediaPlayer:
             self.playlist.clear()
 
         self.now_playing.reset()  # reset now_playing to remove old metadata
+        # W3: remember the exact entry object so _queue_index() can locate it by
+        # identity even when its uri is duplicated in the queue or cleared by
+        # the END_OF_MEDIA reset.
+        self._current_entry = track if isinstance(track, MediaEntry) else None
         if isinstance(track, MediaEntry):
             # single track entry (MediaEntry)
             self.now_playing.update(track)
@@ -914,6 +977,7 @@ class OCPMediaPlayer:
             for entry in track:
                 self.playlist.add_entry(entry)
             self.now_playing.update(self.playlist[0])
+            self._current_entry = self.playlist[0]
 
         if track.playback == PlaybackType.MPRIS:
             self.playlist.clear()
@@ -1068,8 +1132,29 @@ class OCPMediaPlayer:
             state="error",
         )
         LOG.warning(f"Failed to play: {self.now_playing}")
+        # W3: remember this uri as broken so LoopState.REPEAT cannot restart a
+        # queue whose every track has failed (that was an unbounded hot loop:
+        # 1-track repeat playlist + a backend that always reports INVALID_MEDIA).
+        uri = self.now_playing.uri if self.now_playing else None
+        if uri:
+            self._failed_uris.add(uri)
         # Use a timer so the bus event loop is not blocked during the pause
-        threading.Timer(3.0, self.play_next).start()
+        self._schedule_play_next()
+
+    def _schedule_play_next(self):
+        """Schedule the delayed skip-to-next-track used after a bad stream.
+
+        Replaces any still-pending retry so a burst of INVALID_MEDIA events
+        cannot pile up overlapping timers, and uses a daemon thread so a
+        pending retry never keeps the process alive past shutdown.
+        """
+        with self._state_lock:
+            if self._invalid_timer is not None:
+                self._invalid_timer.cancel()
+            timer = threading.Timer(self.invalid_stream_delay, self.play_next)
+            timer.daemon = True
+            self._invalid_timer = timer
+        timer.start()
 
     # media controls
     def play_media(self, track: Union[dict, MediaEntry],
@@ -1123,7 +1208,10 @@ class OCPMediaPlayer:
         # wedging the player mid-PLAYING. Resetting to LOADING_MEDIA at the
         # start of every play() attempt guarantees the next real state
         # (whatever it is) always differs from the just-reset value.
-        self.media_state = MediaState.LOADING_MEDIA
+        with self._state_lock:
+            self.media_state = MediaState.LOADING_MEDIA
+            # W3: a new play attempt supersedes any earlier stop request
+            self._stop_requested = False
 
         # C4: switching playback types must not leave the previously active
         # backend's BaseMediaService.current set — otherwise a later,
@@ -1210,12 +1298,21 @@ class OCPMediaPlayer:
         LOG.debug(f"Shuffle pick: {pick.title!r}")
         self.set_now_playing(pick)
 
-    def play_next(self):
+    def _all_tracks_failed(self, queue: List[MediaEntry]) -> bool:
+        """True if every track in *queue* has failed to load since the last
+        successful load. Used to break the repeat cycle instead of retrying a
+        wholly broken queue forever."""
+        return bool(queue) and all(e.uri in self._failed_uris for e in queue)
+
+    def play_next(self, finished_uri: str = None):
         """
         Play the next track in the merged queue (user playlist + search results).
 
         Uses ``_merged_queue()`` for O(n) deduplication — no O(n²) scanning.
         Respects repeat, shuffle, loop state, and ``merge_search`` config.
+
+        @param finished_uri: uri of the track that just finished, captured
+            before the end-of-media reset; used only as a locator fallback.
         """
         if self.playback_type in [PlaybackType.MPRIS]:
             if self.mpris and self.mpris.manage_players:
@@ -1229,6 +1326,14 @@ class OCPMediaPlayer:
             return
 
         if self.loop_state == LoopState.REPEAT_TRACK:
+            uri = self.now_playing.uri if self.now_playing else None
+            uri = uri or finished_uri or \
+                  (self._current_entry.uri if self._current_entry else None)
+            if uri and uri in self._failed_uris:
+                LOG.warning("Repeat-track requested, but the track has failed "
+                            "to load — stopping instead of retrying forever")
+                self.set_player_state(PlayerState.STOPPED)
+                return
             LOG.debug("Repeating single track")
             self.play()
             return
@@ -1239,13 +1344,21 @@ class OCPMediaPlayer:
             return
 
         queue = self._merged_queue()
-        idx = self._queue_index(queue)
+        idx = self._queue_index(queue, uri=finished_uri)
 
         if idx >= 0 and idx + 1 < len(queue):
             next_track = queue[idx + 1]
             LOG.info(f"Next track: {next_track.title!r} (queue index {idx + 1}/{len(queue) - 1})")
             self.set_now_playing(next_track)
         elif self.loop_state == LoopState.REPEAT and queue:
+            # W3: never restart a queue in which every track has already failed
+            # to load since the last successful one — that is an unbounded hot
+            # loop, not a repeat.
+            if self._all_tracks_failed(queue):
+                LOG.warning("End of queue with repeat == True, but every track "
+                            "failed to load — stopping instead of looping")
+                self.set_player_state(PlayerState.STOPPED)
+                return
             LOG.info("End of queue, repeat == True — restarting from beginning")
             self.set_now_playing(queue[0])
         else:
@@ -1347,6 +1460,12 @@ class OCPMediaPlayer:
         """
         Request stopping current playback and searching
         """
+        # W3: flag BEFORE asking the backends to stop. OPM backends emit
+        # END_OF_MEDIA from ocp_stop(), which is indistinguishable from a track
+        # ending naturally; without this flag an explicit stop advanced the
+        # queue, contradicting the documented "stop must not advance" semantics.
+        self._mark_stop_requested()
+
         # stop any search still happening
         self.bus.emit(Message("ovos.common_play.search.stop"))
 
@@ -1387,6 +1506,12 @@ class OCPMediaPlayer:
         Reset this instance to clear any media or settings
         """
         self.now_playing.reset()
+        self._current_entry = None
+        self._failed_uris.clear()
+        with self._state_lock:
+            if self._invalid_timer is not None:
+                self._invalid_timer.cancel()
+                self._invalid_timer = None
         self.playlist.clear()
         self.media.clear()
         if self.playback_type != PlaybackType.MPRIS:
@@ -1407,6 +1532,10 @@ class OCPMediaPlayer:
         Shutdown this instance and its spawned objects. Remove events.
         """
         self.stop()
+        with self._state_lock:
+            if self._invalid_timer is not None:
+                self._invalid_timer.cancel()
+                self._invalid_timer = None
         if self.mpris:
             self.mpris.shutdown()
         self.now_playing.shutdown()
@@ -1428,25 +1557,51 @@ class OCPMediaPlayer:
             state = MediaState(state)
         if not isinstance(state, MediaState):
             raise ValueError(f"Expected int or MediaState, but got: {state}")
-        if state == self.media_state:
-            return
-        LOG.info(f"MediaState changed: {repr(self.media_state)} -> {repr(state)}")
-        self.media_state = state
-        if state == MediaState.END_OF_MEDIA:
+
+        # W3: this is the SOLE subscriber to 'ovos.common_play.media.state'.
+        # The compare-and-set below plus the end-of-media capture happen under
+        # one lock, so two concurrent END_OF_MEDIA events can only ever advance
+        # the queue once. Nothing that can re-enter the player (autoplay, GUI
+        # pushes) runs while the lock is held.
+        with self._state_lock:
+            if state == self.media_state:
+                return
+            LOG.info(f"MediaState changed: {repr(self.media_state)} -> {repr(state)}")
+            self.media_state = state
+            ended = state == MediaState.END_OF_MEDIA
+            invalid = state == MediaState.INVALID_MEDIA
+            playback_type = playback_uri = None
+            stop_requested = False
+            if ended:
+                # capture BEFORE the reset that clears both values
+                playback_type = self.now_playing.playback
+                playback_uri = self.now_playing.uri
+                stop_requested = self._stop_requested
+                self.now_playing.on_end_of_media()
+            elif state in (MediaState.LOADED_MEDIA, MediaState.BUFFERED_MEDIA):
+                # a track loaded successfully: the queue is not wholly broken
+                self._failed_uris.clear()
+
+        if ended:
             # handle_playback_ended manages its own _update_gui() call
-            self.handle_playback_ended(message)
-        elif state == MediaState.INVALID_MEDIA:
+            self.handle_playback_ended(message, playback_type=playback_type,
+                                       playback_uri=playback_uri,
+                                       stop_requested=stop_requested)
+        elif invalid:
             self.handle_invalid_media(message)
             if self.ocp_config.get("autoplay", True):
-                self.play_next()
-            # play_next → play → set_player_state → _update_gui; call explicitly
-            # only if autoplay is disabled (no play() fired)
+                # W3: go through the delayed on_invalid_stream() path rather
+                # than calling play_next() inline — an inline call recursed
+                # straight back into play() and, with a permanently failing
+                # backend, spun without bound.
+                self.on_invalid_stream()
+            # on_invalid_stream defers; nothing else pushed the GUI
             else:
                 self._update_gui()
         else:
             self._update_gui()
 
-    def handle_invalid_media(self, message):
+    def handle_invalid_media(self, message=None):
         self.gui.show_media_player(
             now_playing=None,
             playlist=[e.as_dict for e in self.playlist.entries] if self.playlist else [],
@@ -1454,19 +1609,38 @@ class OCPMediaPlayer:
             state="error",
         )
 
-    def handle_playback_ended(self, message):
-        # F1: self.playback_type reads now_playing.playback, which
-        # NowPlaying.handle_media_state_change already reset to UNDEFINED
-        # for this very END_OF_MEDIA event (it is subscribed to the same
-        # topic and runs first — see the comment there). Use the type it
-        # stashed just before resetting instead of the now-wiped live value.
-        playback_type = self._last_playback_type
+    def handle_playback_ended(self, message, playback_type: PlaybackType = None,
+                              playback_uri: str = None,
+                              stop_requested: bool = None):
+        """Decide whether the end of a track should advance the queue.
+
+        @param playback_type: the PlaybackType captured by
+            handle_player_media_update BEFORE the end-of-media reset wiped it.
+            Defaults to the live value for direct callers.
+        @param playback_uri: likewise for the finished track's uri.
+        @param stop_requested: whether this end-of-media was caused by an
+            explicit stop request rather than a track finishing.
+        """
+        if playback_type is None:
+            playback_type = self.playback_type
+        if stop_requested is None:
+            stop_requested = self._stop_requested
+
+        if stop_requested:
+            # W3: an explicit stop must never advance the queue. OPM backends
+            # emit END_OF_MEDIA from ocp_stop(), so both the API path
+            # (OCPMediaPlayer.stop) and the external path
+            # ('ovos.{ns}.service.stop') land here.
+            LOG.debug("Playback ended by an explicit stop request; not advancing")
+            self._update_gui()
+            return
+
         if len(self.playlist) and self.ocp_config.get("autoplay", True) and \
                 playback_type not in [PlaybackType.MPRIS, PlaybackType.UNDEFINED]:
             # PlaybackType.UNDEFINED -> no media loaded, eg stop called explicitly
             # PlaybackType.MPRIS -> can't load media in MPRIS players
             LOG.debug(f"Playing next track")
-            self.play_next()
+            self.play_next(finished_uri=playback_uri)
             return
 
         LOG.info("Playback ended")

--- a/test/end2end/test_ocp_player.py
+++ b/test/end2end/test_ocp_player.py
@@ -167,7 +167,14 @@ class TestInvalidStream(unittest.TestCase):
             time.sleep(0.05)
             # Enable autoplay so the player auto-skips
             h.player.ocp_config["autoplay"] = True
+            # W3: the skip is deferred (on_invalid_stream) rather than inline
+            h.player.invalid_stream_delay = 0.01
             h.simulate_invalid_stream()
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                if h.player.now_playing.uri == "http://example.com/2.mp3":
+                    break
+                time.sleep(0.02)
             # Player should have skipped to track 2
             h.assert_now_playing_uri("http://example.com/2.mp3")
 

--- a/test/unittests/test_base_coverage.py
+++ b/test/unittests/test_base_coverage.py
@@ -16,6 +16,7 @@ def _make_service():
     from ovos_media.media_backends.base import BaseMediaService
     bus = FakeBus()
     svc = BaseMediaService.__new__(BaseMediaService)
+    svc._init_runtime_state()
     svc.bus = bus
     svc.services = []
     svc.current = None
@@ -498,7 +499,9 @@ class TestHandlePlayUriExtraction(unittest.TestCase):
         target, call_args = self._run_handle_play(
             svc, {"tracks": ["http://example.com/a.mp3"]})
 
-        self.assertEqual(target, svc.play)
+        # W3: handle_play defers to _play so the tracklist it just queued
+        # is not cleared by the public play() entry point.
+        self.assertEqual(target, svc._play)
         self.assertEqual(call_args[0], "http://example.com/a.mp3")
 
     def test_handle_play_extracts_uri_from_tuple_track(self):

--- a/test/unittests/test_catalog_now_playing_intents.py
+++ b/test/unittests/test_catalog_now_playing_intents.py
@@ -236,6 +236,7 @@ def _make_real_player(bus, title="Bohemian Rhapsody", artist="Queen"):
          patch("ovos_media.player.Configuration", return_value={"media": {}}), \
          patch("ovos_media.player.OCPMediaCatalog"):
         p = OCPMediaPlayer.__new__(OCPMediaPlayer)
+        p._init_runtime_state()
         p.ocp_config = {}
         p.validate_source = True
         p.state = PlayerState.STOPPED

--- a/test/unittests/test_defect_fixes.py
+++ b/test/unittests/test_defect_fixes.py
@@ -59,6 +59,7 @@ class TestA1DaemonStartup(unittest.TestCase):
 def _make_base_service(current=None):
     from ovos_media.media_backends.base import BaseMediaService
     svc = BaseMediaService.__new__(BaseMediaService)
+    svc._init_runtime_state()
     svc.bus = FakeBus()
     svc.services = []
     svc.current = current
@@ -172,6 +173,7 @@ class TestA4ConfigRobustness(unittest.TestCase):
     def _make_service_for_load(self, players_cfg):
         from ovos_media.media_backends.base import BaseMediaService
         svc = BaseMediaService.__new__(BaseMediaService)
+        svc._init_runtime_state()
         svc.bus = FakeBus()
         svc.namespace = "audio"
         svc.config = {"audio_players": players_cfg}

--- a/test/unittests/test_gui.py
+++ b/test/unittests/test_gui.py
@@ -23,6 +23,7 @@ def _make_player():
          patch("ovos_media.player.Configuration", return_value={"media": {}}), \
          patch("ovos_media.player.OCPMediaCatalog"):
         p = OCPMediaPlayer.__new__(OCPMediaPlayer)
+        p._init_runtime_state()
         p.ocp_config = {}
         p.state = PlayerState.STOPPED
         p.loop_state = LoopState.NONE

--- a/test/unittests/test_media_backends.py
+++ b/test/unittests/test_media_backends.py
@@ -55,6 +55,7 @@ class TestBaseMediaServiceLoading(unittest.TestCase):
 
         with patch("ovos_media.media_backends.base.Configuration", return_value={"media": config}):
             svc = BaseMediaService.__new__(BaseMediaService)
+            svc._init_runtime_state()
             svc.bus = bus
             svc.namespace = "audio"
             svc.config = config
@@ -350,6 +351,7 @@ def _make_base_svc(namespace="audio", config=None, services=None, validate_sourc
 
     bus = FakeBus()
     svc = BaseMediaService.__new__(BaseMediaService)
+    svc._init_runtime_state()
     svc.bus = bus
     svc.namespace = namespace
     svc.config = config or {}

--- a/test/unittests/test_player.py
+++ b/test/unittests/test_player.py
@@ -22,6 +22,7 @@ def _make_player():
          patch("ovos_media.player.Configuration", return_value={"media": {}}), \
          patch("ovos_media.player.OCPMediaCatalog"):
         p = OCPMediaPlayer.__new__(OCPMediaPlayer)
+        p._init_runtime_state()
         p.ocp_config = {}
         p.state = PlayerState.STOPPED
         p.loop_state = LoopState.NONE

--- a/test/unittests/test_player_coverage.py
+++ b/test/unittests/test_player_coverage.py
@@ -24,6 +24,7 @@ Targets uncovered regions:
   stop_skill, handle_MPRIS_takeover, reset
 """
 import asyncio
+import time
 import unittest
 from unittest.mock import MagicMock, patch, call
 
@@ -64,6 +65,7 @@ def _make_player(playback_type: PlaybackType = PlaybackType.AUDIO):
          patch("ovos_media.player.Configuration", return_value={"media": {}}), \
          patch("ovos_media.player.OCPMediaCatalog"):
         p = OCPMediaPlayer.__new__(OCPMediaPlayer)
+        p._init_runtime_state()
         p.ocp_config = {}
         p.state = PlayerState.STOPPED
         p.loop_state = LoopState.NONE
@@ -730,10 +732,16 @@ class TestHandlePlayerMediaUpdateEndOfMedia(unittest.TestCase):
         p.play_next = MagicMock()
         p._update_gui = MagicMock()
         p.ocp_config = {"autoplay": True}
+        # W3: the skip is scheduled through on_invalid_stream() rather than
+        # called inline, so it lands on the next tick, not this one.
+        p.invalid_stream_delay = 0.01
         msg = Message("ovos.common_play.media.state",
                       {"state": int(MediaState.INVALID_MEDIA)})
         p.handle_player_media_update(msg)
         p.handle_invalid_media.assert_called_once()
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not p.play_next.called:
+            time.sleep(0.01)
         p.play_next.assert_called_once()
 
 

--- a/test/unittests/test_player_coverage2.py
+++ b/test/unittests/test_player_coverage2.py
@@ -25,6 +25,7 @@ def _make_player(playback_type=PlaybackType.AUDIO):
          patch("ovos_media.player.Configuration", return_value={"media": {}}), \
          patch("ovos_media.player.OCPMediaCatalog"):
         p = OCPMediaPlayer.__new__(OCPMediaPlayer)
+        p._init_runtime_state()
         p.ocp_config = {}
         p.state = PlayerState.STOPPED
         p.loop_state = LoopState.NONE

--- a/test/unittests/test_player_handlers.py
+++ b/test/unittests/test_player_handlers.py
@@ -61,6 +61,7 @@ def _make_player(playback_type: PlaybackType = PlaybackType.AUDIO):
          patch("ovos_media.player.Configuration", return_value={"media": {}}), \
          patch("ovos_media.player.OCPMediaCatalog"):
         p = OCPMediaPlayer.__new__(OCPMediaPlayer)
+        p._init_runtime_state()
         p.ocp_config = {}
         p.state = PlayerState.STOPPED
         p.loop_state = LoopState.NONE

--- a/test/unittests/test_player_state.py
+++ b/test/unittests/test_player_state.py
@@ -24,6 +24,7 @@ def _make_player():
          patch("ovos_media.player.Configuration", return_value={"media": {}}), \
          patch("ovos_media.player.OCPMediaCatalog"):
         p = OCPMediaPlayer.__new__(OCPMediaPlayer)
+        p._init_runtime_state()
         p.ocp_config = {}
         p.state = PlayerState.STOPPED
         p.loop_state = MagicMock()

--- a/test/unittests/test_wave2_defect_fixes.py
+++ b/test/unittests/test_wave2_defect_fixes.py
@@ -39,6 +39,7 @@ bus.emit()/FakeBus — calling the handler methods directly was the
 false-green mechanism that let both defects through the first audit wave.
 """
 import threading
+import time
 import unittest
 from unittest.mock import patch
 
@@ -98,6 +99,10 @@ class TestC1InvalidMediaSkipChain(unittest.TestCase):
         # synchronously emits INVALID_MEDIA (BaseMediaService.play(), "no
         # service found for uri_type")
         player.audio_service.services = []
+        # W3: the skip-to-next-track retry is now deferred (on_invalid_stream)
+        # instead of recursing inline, so shorten the delay and wait for the
+        # chain rather than expecting it to complete inside bus.emit().
+        player.invalid_stream_delay = 0.01
 
         tracks = [_track(f"http://example.com/t{i}.mp3", f"T{i}")
                  for i in range(3)]
@@ -120,6 +125,14 @@ class TestC1InvalidMediaSkipChain(unittest.TestCase):
             "media": tracks[0].as_dict,
             "playlist": [t.as_dict for t in tracks],
         }))
+
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if sum(1 for s in invalid_media_events
+                   if s == MediaState.INVALID_MEDIA) >= 3:
+                break
+            time.sleep(0.02)
+        time.sleep(0.2)  # let the chain settle past the last track
 
         invalid_count = sum(1 for s in invalid_media_events
                             if s == MediaState.INVALID_MEDIA)
@@ -326,6 +339,7 @@ class TestC6TracklistAndRepeat(unittest.TestCase):
     def _make_service(self):
         from ovos_media.media_backends.base import BaseMediaService
         svc = BaseMediaService.__new__(BaseMediaService)
+        svc._init_runtime_state()
         svc.bus = FakeBus()
         svc.services = []
         svc.current = None
@@ -379,7 +393,9 @@ class TestC6TracklistAndRepeat(unittest.TestCase):
         svc = self._make_service()
         svc._pending_playlist = ["http://example.com/b.mp3"]
         svc._last_full_playlist = ["http://example.com/a.mp3", "http://example.com/b.mp3"]
-        with patch.object(svc, "play") as mock_play:
+        # W3: the internal advance goes through _play, which (unlike the
+        # public play()) preserves the pending tracklist it is consuming.
+        with patch.object(svc, "_play") as mock_play:
             svc.track_start(None)
         mock_play.assert_called_once_with("http://example.com/b.mp3")
         self.assertEqual(svc._pending_playlist, [])
@@ -389,7 +405,7 @@ class TestC6TracklistAndRepeat(unittest.TestCase):
         svc._pending_playlist = []
         svc._pending_repeat = True
         svc._last_full_playlist = ["http://example.com/a.mp3", "http://example.com/b.mp3"]
-        with patch.object(svc, "play") as mock_play:
+        with patch.object(svc, "_play") as mock_play:
             svc.track_start(None)
         mock_play.assert_called_once_with("http://example.com/a.mp3")
         self.assertEqual(svc._pending_playlist, ["http://example.com/b.mp3"])

--- a/test/unittests/test_wave3_end_of_track.py
+++ b/test/unittests/test_wave3_end_of_track.py
@@ -1,0 +1,528 @@
+"""Regression tests for the 2026-08 wave-3 end-of-track redesign.
+
+The end-of-track path used to have TWO independent subscribers to
+'ovos.common_play.media.state' — NowPlaying.handle_media_state_change and
+OCPMediaPlayer.handle_player_media_update — with no ordering guarantee between
+them (pyee's ExecutorEventEmitter submits every handler to a thread pool
+independently). They coordinated through a stash on the player, which meant:
+
+W3-1  under contention the autoplay decision read a half-reset NowPlaying and
+      silently dropped the advance;
+W3-2  two END_OF_MEDIA events could both pass the compare-and-set and advance
+      the queue twice;
+W3-3  an explicit stop advanced the queue, because OPM backends emit
+      END_OF_MEDIA from ocp_stop() and nothing distinguished that from a track
+      ending naturally;
+W3-4  a playlist with a repeated uri ([a, b, a]) ping-ponged forever, because
+      the current track was located by uri alone;
+W3-5  a 1-track repeat playlist on a permanently failing backend spun without
+      bound, because INVALID_MEDIA called play_next() inline;
+W3-6  two rapid legacy 'service.play' requests each armed a 0.5s Timer, loading
+      two backends at once and orphaning the first; a stop inside that window
+      was ignored entirely;
+W3-7  a stop within 1s of playback starting was dropped silently — the player
+      reported STOPPED while audio kept playing forever;
+W3-8  a legacy tracklist that was never exhausted stayed queued on the service
+      and hijacked later, unrelated OCP playback.
+
+Every test drives the scenario through the real objects (FakeBus + a stub
+backend), never by hand-calling the handler under test in isolation.
+"""
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import (
+    LoopState,
+    MediaEntry,
+    MediaState,
+    PlaybackType,
+    PlayerState,
+)
+
+
+def _track(uri, title, playback=PlaybackType.AUDIO):
+    return MediaEntry(uri=uri, title=title, playback=playback)
+
+
+def _make_player(bus=None, config=None):
+    """Real OCPMediaPlayer on a FakeBus, with stream extraction stubbed out."""
+    from ovos_media.player import OCPMediaPlayer
+    bus = bus or FakeBus()
+    player = OCPMediaPlayer(bus, config=config if config is not None else {})
+    # extract_stream() would hit the network; the uris here are already streams
+    player.now_playing.extract_stream = lambda: None
+    return player
+
+
+def _load(player, entries):
+    """Load *entries* as the player's playlist and select the first one."""
+    player.playlist.clear()
+    for e in entries:
+        player.playlist.add_entry(e)
+    player.set_now_playing(player.playlist[0])
+
+
+class _StubBackend:
+    """Minimal MediaBackend stand-in mirroring the OPM template's stop path.
+
+    ``ocp_stop()`` emits PlayerState.STOPPED then MediaState.END_OF_MEDIA,
+    exactly as ovos_plugin_manager.templates.media.MediaBackend does — which is
+    what makes an external stop indistinguishable from a track ending.
+    """
+
+    def __init__(self, bus, name="stub", uris=("http", "https", "file")):
+        self.bus = bus
+        self.name = name
+        self.aliases = [name]
+        self._uris = list(uris)
+        self.loaded = []
+        self.stopped = 0
+        self._playing = False
+
+    def supported_uris(self):
+        return self._uris
+
+    def set_track_start_callback(self, cb):
+        self._cb = cb
+
+    def load_track(self, uri):
+        self.loaded.append(uri)
+        self._playing = True
+
+    def play(self, repeat=False):
+        pass
+
+    def stop(self):
+        self.stopped += 1
+        was = self._playing
+        self._playing = False
+        return was
+
+    def ocp_stop(self):
+        self.bus.emit(Message("ovos.common_play.player.state",
+                              {"state": PlayerState.STOPPED}))
+        self.bus.emit(Message("ovos.common_play.media.state",
+                              {"state": MediaState.END_OF_MEDIA}))
+
+    def shutdown(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# W3-1 / W3-2: single writer, deterministic advance
+# ---------------------------------------------------------------------------
+
+class TestSingleWriterEndOfMedia(unittest.TestCase):
+
+    def test_raced_end_of_media_handlers_still_advance(self):
+        """END_OF_MEDIA delivered while other media.state subscribers run
+        concurrently must still advance the queue, every time.
+
+        Pre-fix this lost roughly 15% of advances (29/200 with barriers): the
+        NowPlaying subscriber reset now_playing.playback to UNDEFINED before
+        the player's handler read it, and the UNDEFINED guard suppressed the
+        autoplay.
+        """
+        for attempt in range(40):
+            bus = FakeBus()
+            player = _make_player(bus)
+            a = _track("http://example.com/a.mp3", "A")
+            b = _track("http://example.com/b.mp3", "B")
+            _load(player, [a, b])
+            player.set_player_state(PlayerState.PLAYING)
+            player.media_state = MediaState.BUFFERED_MEDIA
+
+            barrier = threading.Barrier(2)
+
+            def racer(_msg):
+                # a competing media.state subscriber, released simultaneously
+                barrier.wait(timeout=5)
+
+            bus.on("ovos.common_play.media.state", racer)
+
+            with patch.object(player, "play"):
+                t = threading.Thread(target=barrier.wait, kwargs={"timeout": 5})
+                t.start()
+                bus.emit(Message("ovos.common_play.media.state",
+                                 {"state": MediaState.END_OF_MEDIA}))
+                t.join(timeout=5)
+
+            self.assertEqual(player.now_playing.uri, b.uri,
+                             f"attempt {attempt}: end of track A did not "
+                             f"advance to B")
+            player.shutdown()
+
+    def test_late_now_playing_reset_cannot_wipe_the_next_track(self):
+        """The adverse interleaving, simulated directly.
+
+        Pre-fix, the two media.state subscribers had no ordering guarantee. If
+        the player's handler won the race it advanced to track B — and then the
+        OTHER subscriber (NowPlaying) ran and reset now_playing, wiping the
+        track that had just been selected. Post-fix the player is the sole
+        subscriber, so no late handler exists that can undo the advance.
+        """
+        bus = FakeBus()
+        player = _make_player(bus)
+        a = _track("http://example.com/a.mp3", "A")
+        b = _track("http://example.com/b.mp3", "B")
+        _load(player, [a, b])
+        player.set_player_state(PlayerState.PLAYING)
+        player.media_state = MediaState.BUFFERED_MEDIA
+
+        msg = Message("ovos.common_play.media.state",
+                      {"state": MediaState.END_OF_MEDIA})
+        with patch.object(player, "play"):
+            bus.emit(msg)
+            self.assertEqual(player.now_playing.uri, b.uri)
+            # now let every OTHER media.state subscriber process the same
+            # event, as a losing thread would have done
+            for fn in bus.ee.listeners("ovos.common_play.media.state"):
+                if getattr(fn, "__self__", None) is not player:
+                    fn(msg)
+
+        self.assertEqual(player.now_playing.uri, b.uri,
+                         "a late media.state subscriber wiped the track the "
+                         "player had just advanced to")
+        player.shutdown()
+
+    def test_two_concurrent_end_of_media_advance_exactly_once(self):
+        """Two END_OF_MEDIA events racing must advance the queue ONCE.
+
+        Pre-fix this double-advanced in 263/300 runs: both threads passed the
+        unsynchronised `state == self.media_state` compare-and-set.
+        """
+        for attempt in range(40):
+            bus = FakeBus()
+            player = _make_player(bus)
+            tracks = [_track(f"http://example.com/{n}.mp3", n)
+                      for n in ("a", "b", "c")]
+            _load(player, tracks)
+            player.set_player_state(PlayerState.PLAYING)
+            player.media_state = MediaState.BUFFERED_MEDIA
+
+            with patch.object(player, "play"):
+                start = threading.Barrier(2)
+
+                def fire():
+                    start.wait(timeout=5)
+                    bus.emit(Message("ovos.common_play.media.state",
+                                     {"state": MediaState.END_OF_MEDIA}))
+
+                threads = [threading.Thread(target=fire) for _ in range(2)]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join(timeout=5)
+
+            self.assertEqual(player.now_playing.uri, tracks[1].uri,
+                             f"attempt {attempt}: two concurrent END_OF_MEDIA "
+                             f"events advanced past track b")
+            player.shutdown()
+
+    def test_now_playing_no_longer_subscribes_to_media_state(self):
+        """NowPlaying must not be a second subscriber to the topic."""
+        bus = FakeBus()
+        player = _make_player(bus)
+        listeners = bus.ee.listeners("ovos.common_play.media.state")
+        owners = [getattr(fn, "__self__", None) for fn in listeners]
+        self.assertNotIn(player.now_playing, owners)
+        self.assertIn(player, owners)
+        player.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# W3-3: stop must not advance
+# ---------------------------------------------------------------------------
+
+class TestStopDoesNotAdvance(unittest.TestCase):
+
+    def _player_with_backend(self):
+        bus = FakeBus()
+        player = _make_player(bus)
+        backend = _StubBackend(bus)
+        player.audio_service.services = [backend]
+        player.audio_service.current = backend
+        backend._playing = True  # so stop() reports a real stop -> ocp_stop()
+        a = _track("http://example.com/a.mp3", "A")
+        b = _track("http://example.com/b.mp3", "B")
+        _load(player, [a, b])
+        player.set_player_state(PlayerState.PLAYING)
+        player.media_state = MediaState.BUFFERED_MEDIA
+        # pretend playback started long enough ago to clear the stop guard
+        player.audio_service.play_start_time = time.monotonic() - 5
+        return bus, player, backend, a, b
+
+    def test_api_stop_does_not_advance(self):
+        bus, player, backend, a, b = self._player_with_backend()
+        player.stop()
+        time.sleep(0.1)
+        self.assertNotEqual(player.now_playing.uri, b.uri,
+                            "stop() advanced now_playing to the next track")
+        self.assertEqual(player.state, PlayerState.STOPPED)
+        # the END_OF_MEDIA emitted by ocp_stop() was consumed as a stop
+        self.assertEqual(backend.stopped, 1)
+        player.shutdown()
+
+    def test_external_service_stop_does_not_advance(self):
+        """'ovos.audio.service.stop' from outside must not advance either."""
+        bus, player, backend, a, b = self._player_with_backend()
+        bus.emit(Message("ovos.audio.service.stop"))
+        time.sleep(0.1)
+        self.assertNotEqual(player.now_playing.uri, b.uri,
+                            "external stop advanced to the next track")
+        player.shutdown()
+
+    def test_play_clears_the_stop_flag(self):
+        bus, player, backend, a, b = self._player_with_backend()
+        player.stop()
+        self.assertTrue(player._stop_requested)
+        _load(player, [a, b])
+        player.play()
+        self.assertFalse(player._stop_requested)
+        player.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# W3-4: duplicate uris in a playlist
+# ---------------------------------------------------------------------------
+
+class TestDuplicateUriPlaylist(unittest.TestCase):
+
+    def test_playlist_a_b_a_advances_then_stops(self):
+        """[a, b, a] must play b, then a (index 2), then STOP.
+
+        Pre-fix _queue_index() matched on uri and always returned 0 for the
+        third entry, so the queue ping-ponged a -> b -> a -> b forever.
+        """
+        bus = FakeBus()
+        player = _make_player(bus)
+        a1 = _track("http://example.com/a.mp3", "A")
+        b = _track("http://example.com/b.mp3", "B")
+        a2 = _track("http://example.com/a.mp3", "A again")
+        _load(player, [a1, b, a2])
+        player.set_player_state(PlayerState.PLAYING)
+
+        seen = []
+        with patch.object(player, "play",
+                          side_effect=lambda: seen.append(player.now_playing.uri)):
+            for _ in range(3):
+                player.media_state = MediaState.BUFFERED_MEDIA
+                bus.emit(Message("ovos.common_play.media.state",
+                                 {"state": MediaState.END_OF_MEDIA}))
+
+        self.assertEqual(seen, [b.uri, a2.uri],
+                         "expected a -> b -> a(index 2) -> end of queue")
+        self.assertEqual(player.state, PlayerState.STOPPED)
+        player.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# W3-5: bounded retries on a permanently broken queue
+# ---------------------------------------------------------------------------
+
+class TestBoundedInvalidRetries(unittest.TestCase):
+
+    def test_repeat_with_always_invalid_backend_stops(self):
+        """1 track + LoopState.REPEAT + a backend that always fails must make a
+        bounded number of attempts and end STOPPED — not spin.
+
+        Pre-fix the INVALID_MEDIA bus handler called play_next() inline, which
+        re-entered play() immediately: an unbounded hot loop (in-process it
+        blew the recursion limit).
+        """
+        bus = FakeBus()
+        player = _make_player(bus)
+        player.invalid_stream_delay = 0.05
+        player.loop_state = LoopState.REPEAT
+        broken = _track("http://example.com/broken.mp3", "Broken")
+        _load(player, [broken])
+
+        calls = []
+        real_play = player.play
+
+        def counting_play():
+            calls.append(time.monotonic())
+            return real_play()
+
+        player.play = counting_play
+        # no backend supports this uri -> BaseMediaService.play emits INVALID_MEDIA
+        player.audio_service.services = []
+
+        player.play()
+        time.sleep(2.0)
+
+        self.assertLessEqual(len(calls), 4,
+                             f"unbounded retry loop: play() ran {len(calls)} "
+                             f"times in 2s")
+        self.assertEqual(player.state, PlayerState.STOPPED)
+        player.shutdown()
+
+    def test_successful_load_clears_the_failed_uri_memory(self):
+        bus = FakeBus()
+        player = _make_player(bus)
+        player._failed_uris.add("http://example.com/a.mp3")
+        player.media_state = MediaState.LOADING_MEDIA
+        bus.emit(Message("ovos.common_play.media.state",
+                         {"state": MediaState.LOADED_MEDIA}))
+        self.assertEqual(player._failed_uris, set())
+        player.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# W3-6 / W3-7 / W3-8: BaseMediaService deferred play & stop
+# ---------------------------------------------------------------------------
+
+def _make_service(bus=None, backends=None):
+    from ovos_media.media_backends.base import BaseMediaService
+    bus = bus or FakeBus()
+    svc = BaseMediaService.__new__(BaseMediaService)
+    # set the bookkeeping fields explicitly rather than via
+    # _init_runtime_state(), so this fixture also builds against the
+    # pre-fix source when proving these tests fail before the fix
+    svc.on_stop = None
+    svc._pending_playlist = []
+    svc._pending_repeat = False
+    svc._last_full_playlist = []
+    svc._play_timer = None
+    svc._deferred_stop_timer = None
+    svc.bus = bus
+    svc.namespace = "audio"
+    svc.config = {}
+    svc.service_lock = threading.Lock()
+    svc.validate_source = False
+    svc.current = None
+    svc.play_start_time = 0
+    svc.volume_is_low = False
+    svc.services = backends if backends is not None else [_StubBackend(bus)]
+    return svc, bus
+
+
+class TestDeferredPlayTimer(unittest.TestCase):
+
+    def test_rapid_double_legacy_play_loads_one_backend(self):
+        """Two rapid 'service.play' requests must leave exactly one load.
+
+        Pre-fix each request armed its own un-cancellable 0.5s Timer, so both
+        fired: two backends loaded, the first orphaned.
+        """
+        svc, bus = _make_service()
+        backend = svc.services[0]
+        svc.handle_play(Message("ovos.audio.service.play",
+                                {"tracks": ["http://example.com/1.mp3"]}))
+        first_timer = svc._play_timer
+        svc.handle_play(Message("ovos.audio.service.play",
+                                {"tracks": ["http://example.com/2.mp3"]}))
+        time.sleep(1.0)
+
+        self.assertFalse(first_timer.is_alive(),
+                         "the superseded play timer was not cancelled")
+        self.assertEqual(backend.loaded, ["http://example.com/2.mp3"],
+                         f"expected only the second request to load, got "
+                         f"{backend.loaded}")
+
+    def test_stop_before_timer_fires_prevents_playback(self):
+        """A stop inside the 0.5s scheduling window must cancel the start."""
+        svc, bus = _make_service()
+        backend = svc.services[0]
+        svc.handle_play(Message("ovos.audio.service.play",
+                                {"tracks": ["http://example.com/1.mp3"]}))
+        svc.stop(Message("ovos.audio.service.stop"))
+        time.sleep(1.0)
+        self.assertEqual(backend.loaded, [],
+                         "playback started despite being stopped first")
+
+    def test_play_timer_is_daemonic(self):
+        svc, bus = _make_service()
+        svc.handle_play(Message("ovos.audio.service.play",
+                                {"tracks": ["http://example.com/1.mp3"]}))
+        self.assertTrue(svc._play_timer.daemon)
+        svc._play_timer.cancel()
+
+
+class TestDeferredStop(unittest.TestCase):
+
+    def test_internal_stop_within_guard_window_is_deferred_not_dropped(self):
+        """stop() 0.3s after playback starts must still reach the backend.
+
+        Pre-fix the <1s guard dropped the stop silently: the player reported
+        STOPPED while the backend kept playing forever.
+        """
+        svc, bus = _make_service()
+        backend = svc.services[0]
+        svc.play("http://example.com/1.mp3")
+        self.assertIs(svc.current, backend)
+        time.sleep(0.3)
+
+        svc.stop()  # message=None -> internal path
+        self.assertEqual(backend.stopped, 0,
+                         "stop should be deferred, not immediate")
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and backend.stopped == 0:
+            time.sleep(0.02)
+        self.assertEqual(backend.stopped, 1,
+                         "the deferred stop never reached the backend")
+        time.sleep(0.1)  # let _perform_stop finish clearing `current`
+        self.assertIsNone(svc.current)
+
+    def test_deferred_stop_is_cancelled_by_a_new_play(self):
+        svc, bus = _make_service()
+        backend = svc.services[0]
+        svc.play("http://example.com/1.mp3")
+        svc.stop()
+        svc.play("http://example.com/2.mp3")
+        time.sleep(1.5)
+        self.assertEqual(backend.stopped, 0,
+                         "a superseded deferred stop killed the new playback")
+
+
+class TestPendingPlaylistIsolation(unittest.TestCase):
+
+    def test_legacy_tracklist_does_not_hijack_later_ocp_playback(self):
+        """A stale legacy tracklist must not interleave into later playback.
+
+        Pre-fix the queued remainder of a legacy 'service.play' survived and
+        track_start() advanced into it, producing the loaded sequence
+        x, a, y, b instead of x, y.
+        """
+        svc, bus = _make_service()
+        backend = svc.services[0]
+
+        # legacy request queues x + the leftovers a, b
+        svc.handle_play(Message("ovos.audio.service.play", {
+            "tracks": ["http://legacy/x.mp3",
+                       "http://legacy/a.mp3",
+                       "http://legacy/b.mp3"]}))
+        time.sleep(0.8)
+        self.assertEqual(backend.loaded, ["http://legacy/x.mp3"])
+
+        # now OCP plays something else entirely
+        svc.play("http://ocp/y.mp3")
+        svc.track_start(None)   # y finishes
+        time.sleep(0.1)
+
+        leftovers = [u for u in backend.loaded if u.startswith("http://legacy/a")
+                     or u.startswith("http://legacy/b")]
+        self.assertEqual(leftovers, [],
+                         f"stale legacy tracks hijacked OCP playback: "
+                         f"{backend.loaded}")
+        self.assertEqual(svc._pending_playlist, [])
+        self.assertEqual(svc._last_full_playlist, [])
+
+    def test_internal_advance_still_consumes_the_pending_tracklist(self):
+        """The C6 legacy-tracklist advance must keep working."""
+        svc, bus = _make_service()
+        backend = svc.services[0]
+        svc.handle_play(Message("ovos.audio.service.play", {
+            "tracks": ["http://legacy/x.mp3", "http://legacy/a.mp3"]}))
+        time.sleep(0.8)
+        svc.track_start(None)
+        self.assertEqual(backend.loaded,
+                         ["http://legacy/x.mp3", "http://legacy/a.mp3"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This is wave 3 of the audit loop: a redesign of the end-of-track path around a single writer, since several of the wave 2 fixes turned out to interact badly with each other. Nine verified defects came out of this. The core problem is that handler ordering on the media-state event is not guaranteed — the underlying event library dispatches each handler to its own thread pool slot — so the wave 2 fix lost autoplay in 29 out of 200 stress runs. Now exactly one subscriber, the player itself, captures the state, resets the "now playing" info inline, and only then decides what to do next. Saying "stop" used to advance to the next track, because the backend's own stop call emits an end-of-media event that re-armed autoplay; there's now an explicit stop-requested signal that runs ahead of the event it causes. An unsynchronized read-modify-write on the state could double-advance the queue, happening in 263 out of 300 runs; that's now protected by a lock. A playlist like [a, b, a] could ping-pong forever because track lookup matched by uri position; it now matches by identity first. A single track set to repeat with a failing backend could retry forever; invalid media now routes through the existing delayed retry path with a cap that eventually stops it. A stop issued within one second of starting used to get silently dropped, so the GUI said stopped while audio kept playing; stops are now deferred and cancellable instead of dropped. A playback timer wasn't tracked anywhere, so two backends could end up live at once, including timers firing after shutdown on non-daemon threads; it's now stored, cancelled properly, and marked daemon. A stale legacy pending-playlist value could hijack playback started later through the normal OCP path; it's now cleared on public play and stop calls, while still being preserved for the legacy code path that needs it. And a dead search lock that did nothing was removed.

Four deliberate design choices were reviewed against the orchestrator's ruling and accepted: using a direct in-thread stop callback instead of a bus subscription, to avoid reintroducing the race; matching tracks by identity rather than position; using a reentrant lock, since the retry path can re-enter it; and splitting play into a public and private method to preserve an existing behavior contract.

Thirteen of sixteen behavioral tests were proven to fail before the fix by reverting it, plus one more test added specifically to expose a race condition, with two tests labeled as guards rather than red proofs. On the rebased result: 619 unit tests pass (602 plus 17 new), and 64 end-to-end tests pass.
