### PR TITLE
docs: first-playback payload, status reply convention, backend system deps

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,7 @@ Registered in `OCPMediaPlayer.register_bus_handlers` (`ovos_media/player.py`).
 | `ovos.common_play.player.state` | `OCPMediaPlayer.set_player_state` | `{"state": PlayerState}` |
 | `ovos.common_play.media.state` | `OCPMediaPlayer.set_media_state` | `{"state": MediaState}` |
 | `ovos.common_play.track.state` | `BaseMediaService.handle_media_state_change` (and the backend templates) | `{"state": TrackState}` |
-| `ovos.common_play.status` (response) | `OCPMediaPlayer.handle_status` | full status snapshot |
+| `ovos.common_play.status.response` | `OCPMediaPlayer.handle_status` (reply to `ovos.common_play.status`) | full status snapshot |
 | `ovos.common_play.pong` | `MediaService.handle_ping` | empty data |
 | `mycroft.audio.play_sound` | `OCPMediaPlayer.on_invalid_stream` / `handle_like` | `{"uri": "snd/…"}` |
 | `mycroft.stop.handled` | `OCPMediaPlayer.handle_mycroft_stop` | `{"by": "ovos-media"}` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,6 +29,17 @@ Install at least an audio backend so something can be heard:
 pip install ovos-media-plugin-vlc        # or -mplayer / -simple / -spotify / -chromecast
 ```
 
+`ovos-media-plugin-vlc` wraps `python-vlc`, which needs the native `libvlc`
+system library. `pip install` alone will not error if `libvlc` is missing —
+the plugin just silently fails to load, and no audio backend is available.
+Install the system package too, e.g. `apt install vlc` (Debian/Ubuntu) or
+`libvlc-dev`/`libvlc5` on distros that split the runtime from the dev headers.
+
+For a headless box, `ovos-media-plugin-ffplay` is a good default: it only
+needs `ffmpeg`/`ffplay` on the `PATH`, which most systems already have or can
+install with a single package (`apt install ffmpeg`), with no separate native
+binding to install.
+
 See [Backends](backends.md) for the full list of audio/video/web backends.
 
 ### Development / editable install
@@ -56,6 +67,35 @@ Keep `ovos-audio` running for TTS, and start `ovos-media` as its own process.
 
 A complete migration walkthrough, including configuration mapping from the old
 audio service, is in the [migration guide](migration-guide.md).
+
+Note the naming split when you list backends in config (see
+[Backends](backends.md)): the **pip package** for OCP audio/video plugins uses
+`-plugin-` (e.g. `ovos-media-plugin-vlc`), but the **`module` name you write
+in config** uses `-audio-plugin-` / `-video-plugin-` (e.g.
+`ovos-media-audio-plugin-vlc` for audio, `ovos-media-video-plugin-vlc` for
+video). Installing the pip package is not enough on its own — the `module`
+key in `media.audio_players` / `media.video_players` must match the
+entry-point name, not the pip package name.
+
+### Testing in isolation
+
+`ovos-config` resolves `mycroft.conf`/`ovos.conf` through the standard XDG
+base directories (`ovos_config/locations.py`, via
+`ovos_utils.xdg_utils.xdg_config_home`), so setting `XDG_CONFIG_HOME` to a
+throwaway directory before starting `ovos-media` runs it against an isolated
+config, without touching your real user config:
+
+```bash
+export XDG_CONFIG_HOME=/tmp/ovos-media-test/config
+mkdir -p "$XDG_CONFIG_HOME/mycroft"
+echo '{"enable_old_audioservice": false}' > "$XDG_CONFIG_HOME/mycroft/mycroft.conf"
+ovos-media
+```
+
+Model and plugin caches follow `XDG_CACHE_HOME` separately (same
+`ovos_utils.xdg_utils` module, `xdg_cache_home`). Overriding only
+`XDG_CONFIG_HOME` isolates configuration but not caches — set both env vars
+if you need a fully isolated test environment.
 
 ---
 
@@ -93,13 +133,12 @@ console entry point (`ovos_media/__main__.py`) does.
 
 ## First playback
 
-Once `ovos-media` is running and at least one backend is installed, ask OVOS to
-play something, the OCP pipeline classifies the request, queries the installed
-[media providers](media-providers.md), and routes the winning result here:
+With a full OVOS install, ask OVOS to play something and the OCP pipeline
+(in `ovos-core`) classifies the request, queries the installed
+[media providers](media-providers.md), and routes the winning result to
+`ovos-media`:
 
 > "play some jazz"
-
-To test over the bus directly:
 
 ```python
 from ovos_bus_client import MessageBusClient, Message
@@ -111,6 +150,55 @@ bus.emit(Message("recognizer_loop:utterance",
                  {"utterances": ["play some jazz"], "lang": "en-us"}))
 ```
 
+This needs `ovos-core` (or another OCP pipeline) running to turn the utterance
+into a play request. With only `ovos-media` + `ovos-messagebus` + a backend
+(no `ovos-core`, no skills), there is no pipeline to classify "play some jazz",
+so send the play request directly instead. `ovos-media` listens for
+`ovos.common_play.play` on the bus and expects a `media` dict plus an
+optional `playlist` list:
+
+```python
+from ovos_bus_client import MessageBusClient, Message
+
+bus = MessageBusClient()
+bus.run_in_thread()
+
+track = {
+    "uri": "https://example.com/song.mp3",
+    "title": "Some Jazz",
+    "media_type": 2,     # MediaType.MUSIC
+    "playback": 2        # PlaybackType.AUDIO
+}
+
+bus.emit(Message("ovos.common_play.play", {
+    "media": track,
+    "playlist": [track]
+}))
+```
+
+`media` is required (`handle_play_request` in `ovos_media/player.py` logs a
+warning and ignores the message if it is missing). `media_type` and
+`playback` are the integer values of the `ovos_utils.ocp.MediaType` and
+`ovos_utils.ocp.PlaybackType` enums; common ones are `MediaType.AUDIO` (1),
+`MediaType.MUSIC` (2), `MediaType.VIDEO` (3), `MediaType.PODCAST` (6), and
+`PlaybackType.AUDIO` (2), `PlaybackType.VIDEO` (1), `PlaybackType.AUDIO_SERVICE`
+(3). See `ovos_utils/ocp.py` for the full list. Values can also be sent as the
+enum's string name in most OCP tooling, but the handler here reads them
+straight off `message.data`, so plain integers (or the raw enum) are the
+safest choice.
+
+If `playlist` is omitted, `ovos-media` builds a single-track playlist
+containing only `media` (`playlist = message.data.get("playlist") or [media]`
+in `handle_play_request`). Either way, `play_media` then calls
+`self.playlist.replace(playlist)`, which **replaces** the player's current
+playlist outright. This means an `ovos.common_play.play` message always
+overwrites whatever was set by a previous `ovos.common_play.playlist.set`
+message, whether or not you include a `playlist` key — next/previous track
+navigation after a bare `play` (no `playlist` key) will only ever have the
+one track to work with. To play a track as part of a larger playlist, include
+the full track list under `playlist` in the same `ovos.common_play.play`
+message.
+
 To confirm the daemon is live, ping it:
 
 ```python
@@ -119,6 +207,36 @@ bus.emit(Message("ovos.common_play.ping"))
 ```
 
 (handled by `MediaService.handle_ping`).
+
+### Querying status
+
+Every reply on the bus uses the `.response` suffix convention: the reply to
+`<msg_type>` is emitted as `<msg_type>.response` (see `Message.response` in
+`ovos-bus-client`). To query full player status, send
+`ovos.common_play.status` and wait for `ovos.common_play.status.response`
+(handled by `OCPMediaPlayer.handle_status` in `ovos_media/player.py`):
+
+```python
+from ovos_bus_client import MessageBusClient, Message
+
+bus = MessageBusClient()
+bus.run_in_thread()
+
+reply = bus.wait_for_response(Message("ovos.common_play.status"),
+                               reply_type="ovos.common_play.status.response",
+                               timeout=5)
+print(reply.data)
+# {'playback_type': ..., 'media_type': ..., 'player_state': ...,
+#  'loop_state': ..., 'media_state': ..., 'shuffle': ...,
+#  'playlist_position': ..., 'playlist_size': ..., 'title': ...,
+#  'artist': ..., 'image': ...}
+```
+
+Other single-value queries follow the same pattern, for example
+`ovos.common_play.track_info` (replies on
+`ovos.common_play.track_info.response` with the current track's metadata),
+`ovos.common_play.get_track_length` / `ovos.common_play.get_track_position`,
+and `ovos.common_play.list_backends`.
 
 ---
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This fixes documentation gaps found while walking through ovos-media's getting-started flow on a clean box with just ovos-media, ovos-messagebus, and one backend installed, no ovos-core or skills. It adds a real example of the play bus message for a skills-less setup, showing the actual media and playlist fields and real enum values, checked directly against the handler code and the enum definitions. It documents that sending a play message always replaces the current playlist, even in the simple case where no playlist is given, which silently overwrites anything set by an earlier playlist-set call — this was verified against the actual play handling code. It adds a working example of querying player status and waiting for the reply, and fixes an ambiguous row in the architecture doc's event table that didn't name the actual reply topic. It notes that the VLC backend plugin needs the native libvlc system package and fails to load silently without it, while the ffplay backend only needs ffmpeg and ffplay on the system path. It clarifies that the pip package name and the config module name differ for some plugins, which was already documented per-plugin but not called out clearly. And it adds a note on testing in isolation using XDG environment variables, since config and cache resolve through separate XDG paths — this last point was checked by reading the installed package's source rather than exercised live.
