### PR TITLE
fix: a new play request cancels the pending invalid-stream retry

### DIFF
--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -1233,6 +1233,12 @@ class OCPMediaPlayer:
             self.media_state = MediaState.LOADING_MEDIA
             # W3: a new play attempt supersedes any earlier stop request
             self._stop_requested = False
+            # a new play attempt supersedes any pending invalid-stream retry;
+            # otherwise the stale timer fires play_next() against this NEW
+            # track once the retry window elapses
+            if self._invalid_timer is not None:
+                self._invalid_timer.cancel()
+                self._invalid_timer = None
 
         # C4: switching playback types must not leave the previously active
         # backend's BaseMediaService.current set — otherwise a later,
@@ -1707,7 +1713,12 @@ class OCPMediaPlayer:
     @require_default_session()
     def handle_seek_request(self, message):
         # from bus api
-        miliseconds = message.data.get("seconds", 0) * 1000
+        seconds = message.data.get("seconds", 0)
+        if not isinstance(seconds, (int, float)) or isinstance(seconds, bool):
+            LOG.warning(f"Ignoring seek request with non-numeric 'seconds': "
+                        f"{seconds!r}")
+            return
+        miliseconds = seconds * 1000
 
         # from audio player GUI
         position = message.data.get("seekValue")
@@ -1917,7 +1928,11 @@ class OCPMediaPlayer:
     @require_default_session()
     def handle_set_track_position_request(self, message):
         miliseconds = message.data.get("position")
-        self.seek(miliseconds)
+        if isinstance(miliseconds, (int, float)) and not isinstance(miliseconds, bool):
+            self.seek(miliseconds)
+        elif miliseconds is not None:
+            LOG.warning(f"Ignoring set_track_position request with "
+                        f"non-numeric 'position': {miliseconds!r}")
 
     def handle_track_info_request(self, message):
         data = self.now_playing.as_dict

--- a/test/unittests/test_catalog_now_playing_intents.py
+++ b/test/unittests/test_catalog_now_playing_intents.py
@@ -300,10 +300,13 @@ class TestFiveIntentsRegistered(unittest.TestCase):
 
         OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
 
-        names = {r.get("name", "").split(":")[-1] for r in registrations}
-        for expected in ("WhatSong.intent", "WhatAlbum.intent",
-                         "WhatArtist.intent", "ShuffleOn.intent",
-                         "ShuffleOff.intent"):
+        # ovos-workshop registers under the authoring name ("WhatSong.intent")
+        # on older versions and the canonical name ("WhatSong") after the
+        # canonical-topic switch — accept either spelling, reject absence.
+        names = {r.get("name", "").split(":")[-1].removesuffix(".intent")
+                 for r in registrations}
+        for expected in ("WhatSong", "WhatAlbum", "WhatArtist",
+                         "ShuffleOn", "ShuffleOff"):
             self.assertIn(expected, names,
                           f"expected {expected} to be registered; got {names}")
         self.assertGreaterEqual(len(registrations), 5)
@@ -397,9 +400,12 @@ class TestConstructsWithoutAhocorasickNer(unittest.TestCase):
             catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
 
             self.assertIsNotNone(catalog)
-            names = {r.get("name", "").split(":")[-1] for r in registrations}
-            self.assertIn("WhatSong.intent", names)
-            self.assertIn("ShuffleOn.intent", names)
+            # accept both the authoring ("WhatSong.intent") and canonical
+            # ("WhatSong") registration spellings across workshop versions
+            names = {r.get("name", "").split(":")[-1].removesuffix(".intent")
+                     for r in registrations}
+            self.assertIn("WhatSong", names)
+            self.assertIn("ShuffleOn", names)
 
     def test_search_db_finds_nothing_without_ner(self):
         """search_db depends on the local NER matcher; without ahocorasick

--- a/test/unittests/test_player_handlers.py
+++ b/test/unittests/test_player_handlers.py
@@ -282,6 +282,15 @@ class TestHandleSeekRequest(unittest.TestCase):
         p.seek(60000)
         p.audio_service.set_track_position.assert_called_once_with(60000)
 
+    def test_seek_with_non_numeric_seconds_is_ignored(self):
+        """A non-numeric 'seconds' payload must not raise TypeError from the
+        `* 1000` multiplication — it should be logged and ignored instead."""
+        p = _make_player(PlaybackType.AUDIO)
+        p.seek = MagicMock()
+        msg = Message("ovos.common_play.seek", {"seconds": "not-a-number"})
+        p.handle_seek_request(msg)
+        p.seek.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # handle_shuffle_toggle_request / handle_set_shuffle / handle_unset_shuffle
@@ -485,6 +494,15 @@ class TestHandleTrackLengthPositionRequests(unittest.TestCase):
         msg = Message("ovos.common_play.set_track_position", {"position": 20000})
         p.handle_set_track_position_request(msg)
         p.seek.assert_called_once_with(20000)
+
+    def test_set_track_position_with_none_is_not_forwarded(self):
+        """A missing/None 'position' must not be forwarded to seek() (which
+        forwards it straight to the backend's set_track_position)."""
+        p = _make_player(PlaybackType.AUDIO)
+        p.seek = MagicMock()
+        msg = Message("ovos.common_play.set_track_position", {"position": None})
+        p.handle_set_track_position_request(msg)
+        p.seek.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/test/unittests/test_wave4_defect_fixes.py
+++ b/test/unittests/test_wave4_defect_fixes.py
@@ -260,5 +260,106 @@ class TestStopCancelsInvalidRetry(unittest.TestCase):
         player.shutdown()
 
 
+# ---------------------------------------------------------------------------
+# W4-3: play() must cancel a pending invalid-stream retry from an EARLIER
+# track — otherwise a new play() request arriving inside the retry window
+# leaves the stale timer armed against the NEW track.
+# ---------------------------------------------------------------------------
+
+class TestPlayCancelsStaleInvalidRetry(unittest.TestCase):
+
+    def _arm_stale_timer(self, bus, player):
+        """Play an always-invalid track to arm player._invalid_timer, then
+        return once it is confirmed armed."""
+        backend = _InvalidBackend(bus)
+        player.invalid_stream_delay = 0.15
+        player.audio_service.services = [backend]
+        player.audio_service.current = backend
+        bad = _track("http://example.com/bad.mp3", "Bad")
+        _load(player, [bad])
+
+        player.play()
+        time.sleep(0.05)
+        self.assertIsNotNone(player._invalid_timer,
+                             "invalid-stream retry timer was not armed")
+
+    def test_new_play_cancels_stale_timer_before_it_skips_the_new_track(self):
+        """A new play() of a valid, multi-track queue arriving inside the
+        retry window must cancel the stale timer. If it does not, the timer
+        fires play_next() against the NEW now_playing (identity-matched via
+        _current_entry, not by uri) and silently skips it mid-playback.
+        """
+        bus = FakeBus()
+        player = _make_player(bus)
+        self._arm_stale_timer(bus, player)
+
+        # a genuinely new play request for an unrelated, valid, multi-track
+        # queue arrives while the stale timer from the earlier bad track is
+        # still pending
+        good_backend = _StubBackend(bus, name="good_stub")
+        player.audio_service.services = [good_backend]
+        player.audio_service.current = good_backend
+        c = _track("http://example.com/c.mp3", "C")
+        d = _track("http://example.com/d.mp3", "D")
+        _load(player, [c, d])
+        player.play()
+        player.set_player_state(PlayerState.PLAYING)
+
+        self.assertIsNone(player._invalid_timer,
+                          "play() did not cancel the stale invalid-stream "
+                          "retry timer left over from the earlier track")
+
+        # wait past the original retry window
+        time.sleep(0.3)
+
+        self.assertEqual(player.now_playing.uri, c.uri,
+                         "the stale timer fired and skipped the new track "
+                         "(now_playing advanced to the next queue entry)")
+        self.assertEqual(player.state, PlayerState.PLAYING,
+                         "the stale timer's play_next() disturbed player "
+                         "state for the unrelated new track")
+        self.assertEqual(good_backend.loaded, [c.uri],
+                         "the stale timer asked the backend to load another "
+                         "track that was never requested")
+        self.assertEqual(good_backend.stopped, 0,
+                         "the stale timer stopped the backend for the "
+                         "unrelated new track")
+        player.shutdown()
+
+    def test_new_play_last_in_queue_stays_playing_not_stopped(self):
+        """Same scenario, but the new play() is for a single-track (i.e.
+        last-in-queue) selection. If the stale timer is not cancelled, its
+        play_next() finds no next entry and drives PlayerState.STOPPED even
+        though the new track's audio keeps playing.
+        """
+        bus = FakeBus()
+        player = _make_player(bus)
+        self._arm_stale_timer(bus, player)
+
+        good_backend = _StubBackend(bus, name="good_stub_solo")
+        player.audio_service.services = [good_backend]
+        player.audio_service.current = good_backend
+        c = _track("http://example.com/c-solo.mp3", "C-solo")
+        _load(player, [c])
+        player.play()
+        player.set_player_state(PlayerState.PLAYING)
+
+        self.assertIsNone(player._invalid_timer,
+                          "play() did not cancel the stale invalid-stream "
+                          "retry timer left over from the earlier track")
+
+        time.sleep(0.3)
+
+        self.assertEqual(player.state, PlayerState.PLAYING,
+                         "the stale timer's play_next() drove the player to "
+                         "STOPPED even though the new (last-in-queue) track "
+                         "kept playing")
+        self.assertEqual(player.now_playing.uri, c.uri)
+        self.assertEqual(good_backend.stopped, 0,
+                         "the stale timer stopped the backend for the "
+                         "unrelated new track")
+        player.shutdown()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Found during the certifying wave: starting a new play request while an invalid-stream retry timer was still pending left that stale timer armed. It would then fire against the new track instead of the one it was originally scheduled for, either skipping the new track mid-playback or, if the new track was last in the queue, stopping live audio outright. Starting play now cancels that timer under the state lock, while the retry chain still re-arms normally for tracks that are genuinely invalid. Also fixed in this pass: the seek and set-track-position handlers now ignore non-numeric payloads instead of raising an error in the executor thread.

Four tests were confirmed to fail before this fix by reverting it. On the rebased result, 626 unit tests pass (622 plus 4 new) plus 64 end-to-end tests.
