### PR TITLE
fix: certification round — console script argv, honest queue.finished, playback-evidence resets, gui teardown

### DIFF
--- a/ovos_media/__main__.py
+++ b/ovos_media/__main__.py
@@ -23,14 +23,16 @@ from ovos_media.version import __version__
 
 
 def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
-         watchdog=lambda: None, argv=()):
+         watchdog=lambda: None, argv=None):
     """Start the Media Service and connect to the Message Bus
 
-    @param argv: CLI arguments to parse (defaults to an empty tuple, NOT
-        sys.argv — callers such as tests invoke main() directly under a test
-        runner whose own argv must never leak in here). The `if __name__ ==
-        '__main__'` entry point below is the only caller that passes the
-        real process argv.
+    @param argv: CLI arguments to parse. Defaults to None, which means
+        "parse the real process argv" (sys.argv[1:]) — this is what makes
+        the installed `ovos-media` console script (entry point:
+        ovos_media.__main__:main) actually parse --help/--version/unknown
+        flags instead of silently booting the daemon. Pass an explicit
+        list (e.g. []) to override, e.g. from tests that must not leak the
+        test runner's own argv in here.
     """
     parser = argparse.ArgumentParser(prog="ovos-media",
                                      description="OCP-native audio/video/web "
@@ -39,7 +41,7 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
                         version=f"%(prog)s {__version__}")
     # parse_args exits the process (SystemExit) on --help/--version/bad args
     # before any service/socket is touched, matching every other OVOS daemon
-    parser.parse_args(list(argv))
+    parser.parse_args(sys.argv[1:] if argv is None else list(argv))
 
     reset_sigint_handler()
     init_service_logger("media")

--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -524,6 +524,21 @@ class NowPlaying(MediaEntry):
             # backend confirmed playback started — mark player as PLAYING
             if hasattr(self, '_player') and self._player is not None:
                 self._player.set_player_state(PlayerState.PLAYING)
+                # W4-followup: reset the per-queue failure guards on evidence
+                # of PLAYBACK, not on LOADED_MEDIA. base.py's
+                # handle_media_state_change emits LOADED_MEDIA and THEN, for
+                # a track that loads fine but raises out of current.play(),
+                # INVALID_MEDIA — with the guard reset on LOADED_MEDIA that
+                # sequence reset both _failed_uris and _track_failed_spoken
+                # on every single failing track (rate limit degraded to
+                # per-track chatter, and a REPEAT queue where every track
+                # loads-ok-but-fails-to-play never accumulated enough of
+                # _failed_uris to trip _all_tracks_failed(), looping without
+                # bound). This TrackState.PLAYING_* branch only fires after
+                # current.play() returns without raising, ie. real evidence
+                # of playback — see base.py's handle_media_state_change.
+                self._player._failed_uris.clear()
+                self._player._track_failed_spoken = False
         elif state in (TrackState.QUEUED_SKILL, TrackState.QUEUED_VIDEO,
                        TrackState.QUEUED_AUDIO, TrackState.QUEUED_AUDIOSERVICE,
                        TrackState.QUEUED_WEBVIEW):
@@ -1462,6 +1477,27 @@ class OCPMediaPlayer:
             # state untouched (still PLAYING from the just-ended track) —
             # nothing ever told the GUI/MPRIS/bus that playback stopped.
             self.set_player_state(PlayerState.STOPPED)
+            # This is the ONLY place a natural end-of-queue is detected:
+            # every track played through in order and none remain. Speak
+            # here, not in handle_playback_ended — that call site fires on
+            # every autoplay-off track end and on MPRIS-external track
+            # ends too, neither of which is really "the queue finished".
+            # FOLLOW-UP (certification round, item 6): this always speaks
+            # into the default session. play_next() is reached from an
+            # END_OF_MEDIA bus event (or the invalid-stream retry timer),
+            # neither of which carries the session of whatever
+            # 'ovos.common_play.play' request originally started this
+            # queue — so a satellite-triggered playback's queue.finished
+            # announces on the default/local session instead of the
+            # satellite's. Fixing this needs the player to stash the
+            # triggering message's session at play time (handle_play_request)
+            # and thread it through to speak_dialog here and at the
+            # track.failed site below; that plumbing was out of scope for
+            # this round and needs its own PR + tests.
+            try:
+                self.media.speak_dialog("queue.finished")
+            except Exception as e:
+                LOG.exception(f"Failed to speak queue.finished dialog: {e}")
             return
         self.play()
 
@@ -1644,6 +1680,12 @@ class OCPMediaPlayer:
         self.audio_service.shutdown()
         self.video_service.shutdown()
         self.web_service.shutdown()
+        # self.gui is a GUIInterface("ovos.common_play", bus=bus) — its own
+        # shutdown() removes the 'ovos.common_play.set' listener it
+        # registers on construction. Without this call, every OCPMediaPlayer
+        # created (eg. in a test loop, or a real service restart) leaked one
+        # such bus listener for the lifetime of the process.
+        self.gui.shutdown()
         # L1: register_bus_handlers() above bound ~35 handlers directly via
         # self.bus.on() (not add_event(), since OCPMediaPlayer is not an
         # OVOSSkill) — remove exactly what was registered so a shut-down
@@ -1684,10 +1726,13 @@ class OCPMediaPlayer:
                 playback_uri = self.now_playing.uri
                 stop_requested = self._stop_requested
                 self.now_playing.on_end_of_media()
-            elif state in (MediaState.LOADED_MEDIA, MediaState.BUFFERED_MEDIA):
-                # a track loaded successfully: the queue is not wholly broken
-                self._failed_uris.clear()
-                self._track_failed_spoken = False
+            # NOTE: _failed_uris/_track_failed_spoken are reset on evidence
+            # of PLAYBACK (NowPlaying.handle_track_state_change's
+            # TrackState.PLAYING_* branch), not here on LOADED_MEDIA/
+            # BUFFERED_MEDIA — a track that loads fine but fails to play
+            # emits LOADED_MEDIA then INVALID_MEDIA (see base.py's
+            # handle_media_state_change), and resetting on LOADED_MEDIA
+            # cleared both guards on every single failing track.
 
         if ended:
             # handle_playback_ended manages its own _update_gui() call
@@ -1720,6 +1765,9 @@ class OCPMediaPlayer:
         # does not talk over itself
         if not self._track_failed_spoken:
             self._track_failed_spoken = True
+            # FOLLOW-UP (certification round, item 6): same default-session
+            # gap as queue.finished above — see that comment. INVALID_MEDIA
+            # carries no session either.
             try:
                 self.media.speak_dialog("track.failed")
             except Exception as e:
@@ -1761,15 +1809,12 @@ class OCPMediaPlayer:
 
         LOG.info("Playback ended")
         self._update_gui()
-        # a natural end-of-queue: a track actually finished (playback_uri is
-        # set) rather than "nothing was ever loaded" (PlaybackType.UNDEFINED,
-        # eg. an explicit stop already handled above, or handle_playback_ended
-        # invoked with no track ever played)
-        if playback_uri and playback_type != PlaybackType.UNDEFINED:
-            try:
-                self.media.speak_dialog("queue.finished")
-            except Exception as e:
-                LOG.exception(f"Failed to speak queue.finished dialog: {e}")
+        # NOTE: no queue.finished speak here. This branch is reached
+        # whenever play_next() is NOT invoked automatically — autoplay
+        # disabled after any track, or an MPRIS-external player's track
+        # ending — neither of which is the queue actually finishing.
+        # The real "no more tracks" detection, and the single speak site
+        # for it, lives in play_next()'s end-of-queue branch.
 
     # ovos common play bus api requests
     @require_default_session()

--- a/test/unittests/test_help_flag.py
+++ b/test/unittests/test_help_flag.py
@@ -11,7 +11,19 @@
 # limitations under the License.
 #
 """ovos_media.__main__ --help/--version must short-circuit before any
-service or socket is touched (Quick-win #1)."""
+service or socket is touched (Quick-win #1).
+
+The `ovos-media` console script (setuptools entry point
+`ovos_media.__main__:main`) invokes `main()` with NO arguments, so it only
+ever exercises the function's *default* argv handling — never a value
+supplied by a test. Any test that calls `main(argv=[...])` explicitly is
+exercising a path the installed script never takes, and would stay green
+even if the default silently ignored real process args (the exact bug this
+module guards against). The behavioral proof therefore MUST invoke the
+actual installed script via its real entry point, not `python -m
+ovos_media` (the module path bypasses the console-script argv wiring
+entirely) and not `main(argv=...)` with an explicit list."""
+import shutil
 import subprocess
 import sys
 import unittest
@@ -49,15 +61,16 @@ class TestHelpFlagInProcess(unittest.TestCase):
             mock_svc_cls.assert_not_called()
 
     def test_no_args_still_starts_service(self):
-        """Regression guard: adding the parser must not break normal
-        daemon startup (argv defaults to empty, not the test runner's
-        real sys.argv)."""
+        """Regression guard: the default argv=None path (what the real
+        console script uses) must still start the daemon when the actual
+        process argv is empty."""
         with patch("ovos_media.__main__.reset_sigint_handler"), \
              patch("ovos_media.__main__.init_service_logger"), \
              patch("ovos_media.__main__.LOG"), \
              patch("ovos_media.__main__.setup_locale"), \
              patch("ovos_media.__main__.wait_for_exit_signal"), \
-             patch("ovos_media.__main__.MediaService") as mock_svc_cls:
+             patch("ovos_media.__main__.MediaService") as mock_svc_cls, \
+             patch.object(sys, "argv", ["ovos-media"]):
             mock_svc_cls.return_value = MagicMock()
             from ovos_media.__main__ import main
             main()
@@ -65,14 +78,26 @@ class TestHelpFlagInProcess(unittest.TestCase):
 
 
 class TestHelpFlagSubprocess(unittest.TestCase):
-    """End-to-end: run the real entrypoint in a subprocess. This is the
-    behavioral proof — it exercises the real sys.argv path and confirms no
-    bus socket is bound (the process exits almost instantly instead of
-    blocking in wait_for_exit_signal)."""
+    """End-to-end: run the real INSTALLED `ovos-media` console script (not
+    `python -m ovos_media`, which never exercises the entry-point's own
+    argv wiring). This is the behavioral proof that
+    `ovos-media --help`/`--version` exit fast without binding a bus socket,
+    and that `ovos-media --bogus` is rejected instead of silently booting
+    the daemon."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.exe = shutil.which("ovos-media")
+        if not cls.exe:
+            raise unittest.SkipTest(
+                "ovos-media console script not found on PATH — package "
+                "must be installed (pip/uv install -e .), not just "
+                "importable, for this test to exercise the real "
+                "entry point")
 
     def test_help_subprocess_exits_zero_and_prints_usage(self):
         proc = subprocess.run(
-            [sys.executable, "-m", "ovos_media", "--help"],
+            [self.exe, "--help"],
             capture_output=True, text=True, timeout=15,
         )
         self.assertEqual(proc.returncode, 0)
@@ -81,11 +106,19 @@ class TestHelpFlagSubprocess(unittest.TestCase):
     def test_version_subprocess_exits_zero_and_prints_version(self):
         from ovos_media.version import __version__
         proc = subprocess.run(
-            [sys.executable, "-m", "ovos_media", "--version"],
+            [self.exe, "--version"],
             capture_output=True, text=True, timeout=15,
         )
         self.assertEqual(proc.returncode, 0)
         self.assertIn(__version__, proc.stdout + proc.stderr)
+
+    def test_bogus_flag_subprocess_exits_nonzero_and_does_not_hang(self):
+        proc = subprocess.run(
+            [self.exe, "--bogus-flag-that-does-not-exist"],
+            capture_output=True, text=True, timeout=15,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("error", (proc.stdout + proc.stderr).lower())
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_lifecycle_hygiene.py
+++ b/test/unittests/test_lifecycle_hygiene.py
@@ -90,6 +90,13 @@ class TestL1ZombieServiceShutdown(unittest.TestCase):
         self.assertTrue(registered_pairs, "construction should have registered handlers")
         self.assertEqual(registered_pairs - removed_pairs, set(),
                         "shutdown left some registered handlers un-removed")
+        # OCPMediaPlayer.shutdown() must also tear down its GUIInterface
+        # (self.gui = GUIInterface("ovos.common_play", bus=bus)), which
+        # registers its own 'ovos.common_play.set' listener on construction
+        # via bus.on() outside of register_bus_handlers()/_bus_events. Without
+        # gui.shutdown() that listener leaked for the lifetime of the process
+        # — one per OCPMediaPlayer ever constructed.
+        svc.ocp.gui.shutdown.assert_called_once()
 
     def test_ping_gets_no_pong_after_shutdown(self):
         bus = FakeBus()

--- a/test/unittests/test_main.py
+++ b/test/unittests/test_main.py
@@ -11,12 +11,24 @@
 # limitations under the License.
 #
 """Unit tests for ovos_media.__main__.main()."""
+import sys
 import unittest
 from unittest.mock import patch, MagicMock, call
 
 
 class TestMainStartsService(unittest.TestCase):
-    """main() must create a MediaService, start it, and shut it down."""
+    """main() must create a MediaService, start it, and shut it down.
+
+    argv defaults to None -> sys.argv[1:] (so the real installed console
+    script actually parses its own CLI args). These tests call main() with
+    no explicit argv, so sys.argv is patched to a bare argv (no flags) for
+    the duration of the test class to avoid leaking the test runner's own
+    argv into argparse."""
+
+    def setUp(self):
+        self._argv_patcher = patch.object(sys, "argv", ["ovos-media"])
+        self._argv_patcher.start()
+        self.addCleanup(self._argv_patcher.stop)
 
     def _run_main(self, ready_hook=None, error_hook=None, stopping_hook=None,
                   watchdog=None):

--- a/test/unittests/test_spoken_failure_dialogs.py
+++ b/test/unittests/test_spoken_failure_dialogs.py
@@ -14,15 +14,20 @@
 
 - no.playback.backend: spoken once, at the first play attempt, when zero
   backends of any kind are loaded.
-- track.failed: spoken on an INVALID_MEDIA skip, rate-limited to once per
-  queue (not once per skipped track).
-- queue.finished: spoken on a natural end-of-queue STOPPED.
+- track.failed: spoken once per queue, on evidence of PLAYBACK (not on
+  every LOADED_MEDIA — base.py emits LOADED_MEDIA then INVALID_MEDIA for a
+  track that loads ok but fails to play, which would otherwise reset the
+  guard on every single failing track).
+- queue.finished: spoken exactly once, when play_next() finds there really
+  are no more tracks — not on every autoplay-off track end, not on an
+  MPRIS-external track end, not on an explicit stop.
 """
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from ovos_bus_client.message import Message
 from ovos_utils.fakebus import FakeBus
-from ovos_utils.ocp import PlaybackType
+from ovos_utils.ocp import MediaEntry, MediaState, PlaybackType, PlayerState
 
 
 def _make_player():
@@ -39,6 +44,7 @@ def _make_player():
     p.search_playlist = MagicMock()
     p.ocp_config = {}
     p.gui = MagicMock()
+    p.state = PlayerState.STOPPED
     return p
 
 
@@ -79,10 +85,22 @@ class TestNoPlaybackBackendDialog(unittest.TestCase):
 
 
 class TestTrackFailedDialog(unittest.TestCase):
-    """Spoken on an INVALID_MEDIA skip, rate-limited to once per queue."""
+    """Spoken on an INVALID_MEDIA skip, rate-limited to once per queue.
+
+    The guard (`_track_failed_spoken`/`_failed_uris`) is reset on evidence
+    of PLAYBACK — NowPlaying.handle_track_state_change's TrackState.PLAYING_*
+    branch — never by hand-setting the flags. Driving the real
+    'ovos.common_play.track.state' PLAYING_AUDIO event through a real
+    NowPlaying instance is what makes these tests fail if the reset site is
+    gutted or moved back to LOADED_MEDIA."""
 
     def _make_player(self):
+        from ovos_media.player import NowPlaying
         p = _make_player()
+        # a real NowPlaying wired to the same bus/player, exactly as
+        # OCPMediaPlayer.__init__ constructs it, so handle_track_state_change
+        # is the genuine reset site under test (not a stand-in).
+        p.now_playing = NowPlaying(p.bus, player=p)
         return p
 
     def test_spoken_on_first_invalid_media(self):
@@ -97,16 +115,46 @@ class TestTrackFailedDialog(unittest.TestCase):
         p.handle_invalid_media()
         self.assertEqual(p.media.speak_dialog.call_count, 1)
 
-    def test_spoken_again_after_a_track_successfully_loads(self):
-        """A successful load (LOADED_MEDIA/BUFFERED_MEDIA) clears the
-        per-queue rate limit, so a later failure in a DIFFERENT run of
-        playback speaks again."""
+    def test_not_reset_by_loaded_media_alone(self):
+        """LOADED_MEDIA without a subsequent confirmed-PLAYING TrackState
+        (eg. a track that loads fine but raises out of current.play() —
+        base.py's handle_media_state_change emits LOADED_MEDIA then
+        INVALID_MEDIA for exactly that case) must NOT reset the guard. If it
+        did, a REPEAT queue where every track loads-ok-but-fails-to-play
+        would never trip _all_tracks_failed() and would loop unbounded."""
         p = self._make_player()
         p.handle_invalid_media()
         self.assertEqual(p.media.speak_dialog.call_count, 1)
-        # simulate a subsequent track loading successfully
-        p._failed_uris.clear()
-        p._track_failed_spoken = False
+        # a bare LOADED_MEDIA/BUFFERED_MEDIA transition (no PLAYING_* track
+        # state) must be a no-op for the guard
+        with p._state_lock:
+            p.media_state = MediaState.LOADED_MEDIA
+        p.handle_invalid_media()
+        self.assertEqual(p.media.speak_dialog.call_count, 1,
+                        "LOADED_MEDIA alone must not reset the track.failed "
+                        "rate limit")
+
+    def test_spoken_again_after_a_track_actually_plays(self):
+        """Real evidence of playback — TrackState.PLAYING_AUDIO on
+        'ovos.common_play.track.state', driven through the real NowPlaying
+        handler — clears the per-queue rate limit, so a later failure in a
+        DIFFERENT run of playback speaks again."""
+        from ovos_utils.ocp import TrackState
+        p = self._make_player()
+        p.handle_invalid_media()
+        self.assertEqual(p.media.speak_dialog.call_count, 1)
+        # set_player_state()'s own status-report side effects need a fuller
+        # player than this fixture builds; stub it so the test isolates the
+        # guard-reset logic under test (handle_track_state_change calling
+        # set_player_state, then unconditionally clearing the guards) without
+        # also exercising unrelated status-report plumbing.
+        p.set_player_state = MagicMock()
+        # drive the real bus event a backend emits after current.play()
+        # returns without raising (see base.py handle_media_state_change)
+        p.bus.emit(Message("ovos.common_play.track.state",
+                           {"state": TrackState.PLAYING_AUDIO}))
+        self.assertEqual(p._failed_uris, set())
+        self.assertFalse(p._track_failed_spoken)
         p.handle_invalid_media()
         self.assertEqual(p.media.speak_dialog.call_count, 2)
 
@@ -117,60 +165,131 @@ class TestTrackFailedDialog(unittest.TestCase):
         p = self._make_player()
         p.handle_invalid_media()
         self.assertTrue(p._track_failed_spoken)
-        # exercise exactly the two lines reset() runs for this bookkeeping,
-        # without pulling in the rest of reset()'s GUI/MPRIS/state-machine
-        # side effects (covered by other lifecycle tests)
-        p._failed_uris.clear()
-        p._track_failed_spoken = False
+        # drive the REAL reset() body (not a hand-set of the two flags) —
+        # stub out the collaborators reset() also touches that this fixture
+        # doesn't construct, so only the bookkeeping under test is real.
+        p.now_playing.reset = MagicMock()
+        p._invalid_timer = None
+        p.playlist.clear = MagicMock()
+        p.set_media_state = MagicMock()
+        p.playback_type = PlaybackType.UNDEFINED
+        p.shuffle = True
+        p.loop_state = MagicMock()
+        p.set_player_state = MagicMock()
+        p._update_gui = MagicMock()
+        p.reset()
+        self.assertFalse(p._track_failed_spoken)
+        self.assertEqual(p._failed_uris, set())
         p.handle_invalid_media()
         self.assertEqual(p.media.speak_dialog.call_count, 2)
 
 
+def _track(uri, title, playback=PlaybackType.AUDIO):
+    return MediaEntry(uri=uri, title=title, playback=playback)
+
+
+def _real_player(bus=None, config=None):
+    """A real OCPMediaPlayer on a FakeBus (same construction pattern as
+    test_wave3_end_of_track.py), with stream extraction and the actual
+    speak_dialog call stubbed out so tests observe calls without touching
+    real dialog resources."""
+    from ovos_media.player import OCPMediaPlayer
+    bus = bus or FakeBus()
+    player = OCPMediaPlayer(bus, config=config if config is not None else {})
+    player.now_playing.extract_stream = lambda: None
+    player.media.speak_dialog = MagicMock()
+    return player
+
+
+def _load(player, entries):
+    player.playlist.clear()
+    for e in entries:
+        player.playlist.add_entry(e)
+    player.set_now_playing(player.playlist[0])
+
+
 class TestQueueFinishedDialog(unittest.TestCase):
-    """Spoken on a natural end-of-queue STOPPED, not on every explicit stop."""
+    """Spoken exactly once, when play_next() finds no more tracks — the
+    ONLY state real playback reaches at the true end of a queue. Every test
+    here drives a real, non-empty playlist through the real handlers (never
+    a hand-set playlist length of 0, which real playback never reaches)."""
 
-    def _make_player(self):
-        p = _make_player()
-        p._update_gui = MagicMock()
-        p.play_next = MagicMock()
-        return p
+    def test_two_track_queue_speaks_once_at_the_natural_end(self):
+        player = _real_player(config={"autoplay": True})
+        a = _track("http://example.com/a.mp3", "A")
+        b = _track("http://example.com/b.mp3", "B")
+        _load(player, [a, b])
+        player.set_player_state(PlayerState.PLAYING)
+        player.media_state = MediaState.BUFFERED_MEDIA
 
-    def test_spoken_when_a_track_finishes_and_nothing_else_to_play(self):
-        p = self._make_player()
-        p.handle_playback_ended(
-            message=None, playback_type=PlaybackType.AUDIO,
-            playback_uri="http://last.mp3", stop_requested=False,
+        with patch.object(player, "play"):
+            # track A ends -> advances to B, no announcement yet
+            player.bus.emit(Message("ovos.common_play.media.state",
+                                    {"state": MediaState.END_OF_MEDIA}))
+            self.assertEqual(player.now_playing.uri, b.uri)
+            player.media.speak_dialog.assert_not_called()
+
+            # track B ends -> no more tracks -> spoken exactly once
+            player.media_state = MediaState.BUFFERED_MEDIA
+            player.bus.emit(Message("ovos.common_play.media.state",
+                                    {"state": MediaState.END_OF_MEDIA}))
+        player.media.speak_dialog.assert_called_once_with("queue.finished")
+        self.assertEqual(player.state, PlayerState.STOPPED)
+        player.shutdown()
+
+    def test_autoplay_off_mid_queue_is_silent(self):
+        """With autoplay disabled, a track ending mid-queue must not
+        announce the queue as finished — play_next() (the only speak site)
+        is never even invoked automatically here."""
+        player = _real_player(config={"autoplay": False})
+        a = _track("http://example.com/a.mp3", "A")
+        b = _track("http://example.com/b.mp3", "B")
+        _load(player, [a, b])
+        player.set_player_state(PlayerState.PLAYING)
+        player.media_state = MediaState.BUFFERED_MEDIA
+
+        with patch.object(player, "play_next") as mock_play_next:
+            player.bus.emit(Message("ovos.common_play.media.state",
+                                    {"state": MediaState.END_OF_MEDIA}))
+            mock_play_next.assert_not_called()
+        player.media.speak_dialog.assert_not_called()
+        player.shutdown()
+
+    def test_mpris_track_end_is_silent(self):
+        """An MPRIS-external player's track ending must not announce
+        queue.finished — ovos-media never controlled that queue."""
+        player = _real_player(config={"autoplay": True})
+        a = _track("mpris://player/a", "A", playback=PlaybackType.MPRIS)
+        _load(player, [a])
+        player.handle_playback_ended(
+            message=None, playback_type=PlaybackType.MPRIS,
+            playback_uri=a.uri, stop_requested=False,
         )
-        p.media.speak_dialog.assert_called_once_with("queue.finished")
+        player.media.speak_dialog.assert_not_called()
+        player.shutdown()
 
-    def test_not_spoken_on_explicit_stop(self):
-        p = self._make_player()
-        p.handle_playback_ended(
+    def test_explicit_stop_is_silent(self):
+        player = _real_player(config={"autoplay": True})
+        a = _track("http://example.com/a.mp3", "A")
+        b = _track("http://example.com/b.mp3", "B")
+        _load(player, [a, b])
+        player.handle_playback_ended(
             message=None, playback_type=PlaybackType.AUDIO,
-            playback_uri="http://last.mp3", stop_requested=True,
+            playback_uri=a.uri, stop_requested=True,
         )
-        p.media.speak_dialog.assert_not_called()
+        player.media.speak_dialog.assert_not_called()
+        player.shutdown()
 
     def test_not_spoken_when_nothing_ever_played(self):
         """PlaybackType.UNDEFINED means no media was ever loaded (eg. an
         explicit stop before any play) - nothing to announce the end of."""
-        p = self._make_player()
-        p.handle_playback_ended(
+        player = _real_player()
+        player.handle_playback_ended(
             message=None, playback_type=PlaybackType.UNDEFINED,
             playback_uri=None, stop_requested=False,
         )
-        p.media.speak_dialog.assert_not_called()
-
-    def test_not_spoken_when_queue_advances_to_next_track(self):
-        p = self._make_player()
-        p.playlist.__len__ = MagicMock(return_value=2)
-        p.ocp_config = {"autoplay": True}
-        p.handle_playback_ended(
-            message=None, playback_type=PlaybackType.AUDIO,
-            playback_uri="http://a.mp3", stop_requested=False,
-        )
-        p.media.speak_dialog.assert_not_called()
-        p.play_next.assert_called_once()
+        player.media.speak_dialog.assert_not_called()
+        player.shutdown()
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_wave3_end_of_track.py
+++ b/test/unittests/test_wave3_end_of_track.py
@@ -31,7 +31,7 @@ backend), never by hand-calling the handler under test in isolation.
 import threading
 import time
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from ovos_bus_client.message import Message
 from ovos_utils.fakebus import FakeBus
@@ -361,14 +361,122 @@ class TestBoundedInvalidRetries(unittest.TestCase):
         self.assertEqual(player.state, PlayerState.STOPPED)
         player.shutdown()
 
-    def test_successful_load_clears_the_failed_uri_memory(self):
+    def test_loaded_media_alone_does_not_clear_the_failed_uri_memory(self):
+        """LOADED_MEDIA is reached by a track that loads fine but then
+        fails to play (base.py's handle_media_state_change emits
+        LOADED_MEDIA then INVALID_MEDIA for exactly that case) — clearing
+        _failed_uris here degraded the rate limit to per-track chatter and
+        let a REPEAT queue of load-ok/play-fail tracks loop unbounded,
+        since _all_tracks_failed() never accumulated enough of
+        _failed_uris to trip. The guard is cleared only on evidence of
+        PLAYBACK (TrackState.PLAYING_* via NowPlaying, see the
+        certification-round follow-up test in test_wave4_defect_fixes.py /
+        test_spoken_failure_dialogs.py)."""
         bus = FakeBus()
         player = _make_player(bus)
         player._failed_uris.add("http://example.com/a.mp3")
         player.media_state = MediaState.LOADING_MEDIA
         bus.emit(Message("ovos.common_play.media.state",
                          {"state": MediaState.LOADED_MEDIA}))
+        self.assertEqual(player._failed_uris, {"http://example.com/a.mp3"})
+        player.shutdown()
+
+    def test_confirmed_playback_clears_the_failed_uri_memory(self):
+        """Real evidence of playback — TrackState.PLAYING_AUDIO on
+        'ovos.common_play.track.state', which base.py only emits after
+        current.play() returns without raising — DOES clear the guard."""
+        from ovos_utils.ocp import TrackState
+        bus = FakeBus()
+        player = _make_player(bus)
+        player._failed_uris.add("http://example.com/a.mp3")
+        bus.emit(Message("ovos.common_play.track.state",
+                         {"state": TrackState.PLAYING_AUDIO}))
         self.assertEqual(player._failed_uris, set())
+        player.shutdown()
+
+
+class TestLoadOkPlayFailQueue(unittest.TestCase):
+    """A queue where every track LOADS fine but FAILS TO PLAY (base.py emits
+    LOADED_MEDIA then INVALID_MEDIA for exactly this case — see
+    handle_media_state_change's try/except around current.play()). Since the
+    guards reset only on confirmed PLAYBACK, none of these tracks ever reset
+    them, so the rate limit and the bounded-repeat check behave correctly."""
+
+    def _four_track_queue(self, bus):
+        player = _make_player(bus)
+        player.media.speak_dialog = MagicMock()
+        player.invalid_stream_delay = 0.02
+        tracks = [_track(f"http://example.com/{n}.mp3", n)
+                  for n in ("a", "b", "c", "d")]
+        _load(player, tracks)
+
+        # patch play() itself to reproduce, for whichever track is current,
+        # "loaded fine but failed to play": emit LOADED_MEDIA then
+        # INVALID_MEDIA, exactly the sequence base.py's
+        # handle_media_state_change produces when current.play() raises
+        # after a successful load. Hooking play() (rather than manually
+        # driving bus events from the test) means the player's own
+        # on_invalid_stream -> _schedule_play_next -> play_next -> play()
+        # retry chain drives every advance itself, through the real
+        # deferred timer, with no test-side racing against it.
+        calls = []
+
+        def fake_play():
+            calls.append(player.now_playing.uri if player.now_playing else None)
+            # mirror real play(): mark PLAYING before the (here, simulated)
+            # backend dispatch — otherwise player.state never leaves its
+            # initial STOPPED and a test polling for "reached STOPPED"
+            # would trivially pass without the retry chain ever running.
+            player.set_player_state(PlayerState.PLAYING)
+            with player._state_lock:
+                player.media_state = MediaState.LOADING_MEDIA
+            player.bus.emit(Message("ovos.common_play.media.state",
+                                    {"state": MediaState.LOADED_MEDIA}))
+            with player._state_lock:
+                player.media_state = MediaState.BUFFERED_MEDIA
+            player.bus.emit(Message("ovos.common_play.media.state",
+                                    {"state": MediaState.INVALID_MEDIA}))
+
+        player.play = fake_play
+        return player, tracks, calls
+
+    def test_track_failed_spoken_exactly_once_across_four_failing_tracks(self):
+        bus = FakeBus()
+        player, tracks, calls = self._four_track_queue(bus)
+        player.play()  # kick off track a; on_invalid_stream's timer cascades
+        deadline = time.monotonic() + 5
+        while len(calls) < len(tracks) and time.monotonic() < deadline:
+            time.sleep(0.02)
+
+        speak_calls = [c for c in player.media.speak_dialog.call_args_list
+                      if c.args and c.args[0] == "track.failed"]
+        self.assertEqual(len(speak_calls), 1,
+                        "track.failed must be spoken once per queue, not "
+                        "once per failing track")
+        player.shutdown()
+
+    def test_repeat_over_all_failing_queue_is_bounded_and_ends_stopped(self):
+        """LoopState.REPEAT over a queue where every track loads-ok/plays-fail
+        must not spin: _all_tracks_failed() must eventually trip and stop
+        the player, within a small bounded number of advances."""
+        bus = FakeBus()
+        player, tracks, calls = self._four_track_queue(bus)
+        player.loop_state = LoopState.REPEAT
+
+        player.play()  # kick off track a; the retry chain cascades itself
+        deadline = time.monotonic() + 5
+        while player.state != PlayerState.STOPPED and time.monotonic() < deadline:
+            time.sleep(0.02)
+
+        self.assertEqual(player.state, PlayerState.STOPPED,
+                        f"REPEAT over an all-failing queue did not stop "
+                        f"within 5s — unbounded loop ({len(calls)} play() "
+                        f"attempts made)")
+        # bounded: at most a couple of full passes over the 4-track queue,
+        # not hundreds of attempts
+        self.assertLessEqual(len(calls), len(tracks) * 3,
+                            f"play() ran {len(calls)} times — not bounded")
+        self.assertTrue(player._all_tracks_failed(player._merged_queue()))
         player.shutdown()
 
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Two final-certification reviewers each broke yesterday' UX round, so this fixes what they found. The biggest one: the --help fix never reached the installed ovos-media command, because main() defaulted argv to an empty tuple and only the python -m path passed real arguments. Running ovos-media --help from a fresh install still booted the daemon and hung. The old test only exercised the python -m path, which is why it stayed green; the new tests run the actual installed script.

The "queue finished" announcement was also placed on the wrong branch: it never fired when a queue really ended, but did fire after every track when autoplay was off, and when an external MPRIS player finished a song. It now lives in the one place that knows the queue is exhausted, next to the stop transition.

The track-failure guards used to reset when a track merely loaded, but backends emit load-success right before play-failure, so a queue of load-ok/play-fail tracks chattered "I could not play that" per track and could loop forever on repeat. The guards now reset only on real playback evidence. Also: the player now shuts down its GUI interface (one bus listener leaked per lifetime), and the dialog tests drive real state transitions instead of hand-setting private flags, so gutting the feature makes them fail.

One known gap is documented in code comments rather than fixed: failure dialogs speak into the default session even when a satellite asked for the music. Threading the session through the async retry paths deserves its own change.

Every fix has a regression test proven to fail before the change. The full suite passes: 661 unit and 64 end-to-end tests on the rebased result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playback failure handling to prevent repeated error dialogs and unbounded retries.
  - Failure tracking now clears only after playback successfully begins.
  - Queue completion announcements now occur only when playback naturally reaches the end of the queue.
  - Prevented misleading completion announcements for stopped, external, or autoplay-disabled playback.
  - Improved shutdown cleanup by closing the media interface properly.

- **Usability**
  - Command-line startup now handles process arguments more reliably, including help, version, and invalid-option behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->