### PR TITLE
fix: shuffle failure bounds and dead-player duck handler leak

### DIFF
--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -741,10 +741,33 @@ class OCPMediaPlayer:
         self._register('ovos.common_play.unduck', self.handle_unduck_request)
         self._register('ovos.common_play.cork', self.handle_cork_request)
         self._register('ovos.common_play.uncork', self.handle_uncork_request)
-        # legacy recognizer_loop ducking — same semantics as the ocp equivalents
-        self._register('recognizer_loop:audio_output_start', self.handle_duck_request)
-        self._register('recognizer_loop:audio_output_end', self.handle_unduck_request)
-        self._register('recognizer_loop:record_begin', self.handle_cork_request)
+        # legacy recognizer_loop ducking — same semantics as the ocp equivalents.
+        #
+        # NOTE: these are bound through distinct per-topic wrapper functions
+        # rather than the bare self.handle_*_request methods, on purpose.
+        # 'recognizer_loop:audio_output_start'/'_end'/'record_begin' are
+        # migrated legacy topics (ovos_spec_tools.messages.MIGRATION_MAP), so
+        # ovos-bus-client's MessageBusClient.on() (client.py) wraps them in a
+        # per-HANDLER dedup guard and tracks that wrapper in
+        # self._dedup_registrations[func]. Because a bound method compares
+        # equal (and hashes the same) across separate attribute accesses,
+        # self.handle_duck_request used here is "the same" func as the one
+        # passed to _register('ovos.common_play.duck', ...) above. remove()
+        # branches on `if target in self._dedup_registrations`, and once ANY
+        # topic put that func in the dedup table, remove() takes the dedup
+        # path for EVERY topic registered under it — including the plain,
+        # non-migrated 'ovos.common_play.duck' registration, whose entry
+        # never lived in that table. The dedup path then filters
+        # self._dedup_registrations[target] for the given event_name, finds
+        # nothing (the plain topic was never recorded there), and silently
+        # removes zero listeners instead of falling through to
+        # _remove_normal() — so a shut-down OCPMediaPlayer keeps answering
+        # 'ovos.common_play.duck'/'unduck'/'cork' forever. Binding the
+        # bridged topic to its own wrapper object keeps it out of the plain
+        # topic's identity entirely, so each remove() call resolves cleanly.
+        self._register('recognizer_loop:audio_output_start', lambda message: self.handle_duck_request(message))
+        self._register('recognizer_loop:audio_output_end', lambda message: self.handle_unduck_request(message))
+        self._register('recognizer_loop:record_begin', lambda message: self.handle_cork_request(message))
         self._register('recognizer_loop:record_end', self.handle_record_end)
         self._register('ovos.utterance.handled', self.handle_utterance_handled)
         # global stop
@@ -1388,25 +1411,52 @@ class OCPMediaPlayer:
         self.set_player_state(PlayerState.PLAYING)
         self._update_gui()
 
-    def play_shuffle(self):
+    def play_shuffle(self) -> bool:
         """
         Go to a random position in the merged queue and set that MediaEntry as
         ``now_playing`` (does NOT call ``play``).
 
         Uses ``_merged_queue()`` so the shuffle pool respects the same
-        deduplication and ``merge_search`` config as ``play_next``.
+        deduplication and ``merge_search`` config as ``play_next``, and
+        excludes any uri already recorded in ``_failed_uris`` so a shuffle
+        advance never re-picks a track already known to be broken.
+
+        @return: True if a track was selected (or there is nothing
+            meaningful to shuffle to and the current track should just keep
+            playing — e.g. an empty/singleton queue, or repeat-on with only
+            the current, unfailed track left). False if the queue is
+            non-empty but no viable (unfailed, not-currently-playing) track
+            remains, or the queue is empty and the current track itself has
+            already failed — the caller should treat this like the
+            sequential path's "no more tracks" end-of-queue case instead of
+            replaying forever.
         """
         queue = self._merged_queue()
-        if len(queue) < 2:
-            LOG.debug("Shuffle: queue too small, replaying current track")
-            return
+        if not queue:
+            current_uri = self.now_playing.uri if self.now_playing else None
+            if current_uri is not None and current_uri in self._failed_uris:
+                LOG.debug("Shuffle: queue is empty and current track failed")
+                return False
+            LOG.debug("Shuffle: queue is empty, replaying current track")
+            return True
         current_uri = self.now_playing.uri if self.now_playing else None
-        candidates = [e for e in queue if e.uri != current_uri]
+        candidates = [e for e in queue
+                      if e.uri != current_uri and e.uri not in self._failed_uris]
         if not candidates:
-            return
+            if self.loop_state == LoopState.REPEAT and current_uri and \
+                    current_uri not in self._failed_uris:
+                # nothing else to shuffle to, but repeat is on and the
+                # current track itself hasn't failed - keep it playing
+                # instead of stopping (mirrors play_next's sequential
+                # end-of-queue-with-repeat restart)
+                LOG.debug("Shuffle: no other viable tracks, repeat is on "
+                          "— keeping current track")
+                return True
+            return False
         pick = random.choice(candidates)
         LOG.debug(f"Shuffle pick: {pick.title!r}")
         self.set_now_playing(pick)
+        return True
 
     def _all_tracks_failed(self, queue: List[MediaEntry]) -> bool:
         """True if every track in *queue* has failed to load since the last
@@ -1450,9 +1500,33 @@ class OCPMediaPlayer:
 
         if self.shuffle:
             LOG.debug("Shuffling")
-            self.play_shuffle()
-            # play_shuffle only selects the track - actually start it
-            self.play()
+            # A shuffle advance must respect the same termination bounds as
+            # the sequential path (_all_tracks_failed(), end-of-queue) —
+            # otherwise an all-failing queue with shuffle+REPEAT hot-loops
+            # forever, since play_shuffle() would always pick something and
+            # self.play() would be called unconditionally.
+            queue = self._merged_queue()
+            if self._all_tracks_failed(queue):
+                LOG.warning("Shuffle requested, but every track in the "
+                            "queue failed to load — stopping instead of "
+                            "shuffling forever")
+                self.set_player_state(PlayerState.STOPPED)
+                return
+            if self.play_shuffle():
+                # play_shuffle only selects the track - actually start it
+                self.play()
+            else:
+                # no unfailed candidate remains to shuffle to (e.g. a
+                # single-track queue with repeat off) - this is the
+                # shuffle-path equivalent of the sequential "no more
+                # tracks" branch below, so mirror its behavior exactly
+                LOG.info("Requested next (shuffle), but there are no more "
+                         "tracks in the queue")
+                self.set_player_state(PlayerState.STOPPED)
+                try:
+                    self.media.speak_dialog("queue.finished")
+                except Exception as e:
+                    LOG.exception(f"Failed to speak queue.finished dialog: {e}")
             return
 
         queue = self._merged_queue()

--- a/test/unittests/test_certification_c_fixes.py
+++ b/test/unittests/test_certification_c_fixes.py
@@ -1,0 +1,219 @@
+"""Regression tests covering two OCPMediaPlayer defect fixes.
+
+Shuffle bounds
+    play_next's shuffle branch must respect the same termination bounds as
+    the sequential path (_all_tracks_failed(), end-of-queue): an all-failing
+    queue with shuffle+REPEAT must not hot-loop forever picking a "random"
+    failed track and calling self.play() unconditionally.
+
+Dead-player duck/unduck/cork leak
+    A shut-down OCPMediaPlayer must not keep answering duck/unduck/cork.
+    handle_duck_request/handle_unduck_request/handle_cork_request must not
+    be bound (as the SAME bound-method object) to both a plain
+    'ovos.common_play.*' topic and a migrated legacy 'recognizer_loop:*'
+    topic: upstream MessageBusClient.remove() (ovos-bus-client client.py)
+    dedups registrations of a shared callable via self._dedup_registrations,
+    keyed by that callable; once ANY of its topics is migrated, remove()
+    takes the dedup branch for EVERY topic bound to it — including a plain
+    topic whose registration never lived in that table — and silently
+    removes nothing for it instead of falling through to _remove_normal().
+
+The console-script resolution fix for test_help_flag.py (resolving
+Path(sys.executable).parent / "ovos-media" instead of shutil.which(), which
+could certify a stale shared-venv script) is covered by test_help_flag.py
+itself; no separate regression test is needed here.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import (
+    PlayerState, MediaState, TrackState, LoopState,
+    PlaybackType, MediaEntry, Playlist,
+)
+
+
+def _make_player(playback_type=PlaybackType.AUDIO):
+    """Return a minimal OCPMediaPlayer with all external deps mocked
+    (same helper shape as test_player_coverage2.py's _make_player)."""
+    from ovos_media.player import OCPMediaPlayer
+
+    with patch("ovos_media.player.AudioService"), \
+         patch("ovos_media.player.VideoService"), \
+         patch("ovos_media.player.WebService"), \
+         patch("ovos_media.player.OcpMprisExporter"), \
+         patch("ovos_media.player.GUIInterface"), \
+         patch("ovos_media.player.Configuration", return_value={"media": {}}), \
+         patch("ovos_media.player.OCPMediaCatalog"):
+        p = OCPMediaPlayer.__new__(OCPMediaPlayer)
+        p._init_runtime_state()
+        p.ocp_config = {}
+        p.state = PlayerState.STOPPED
+        p.loop_state = LoopState.NONE
+        p.media_state = MediaState.NO_MEDIA
+        p.shuffle = True
+        p.track_history = {}
+        p._paused_on_duck = False
+        p.now_playing = MagicMock()
+        p.now_playing.playback = playback_type
+        p.now_playing.skill_id = "test.skill"
+        p.now_playing.uri = "http://a.mp3"
+        p.now_playing.original_uri = "http://a.mp3"
+        p.now_playing.title = "Track A"
+        p.now_playing.artist = "Test Artist"
+        p.now_playing.image = ""
+        p.now_playing.length = 180000
+        p.now_playing.position = 0
+        p.now_playing.media_type = MagicMock()
+        p.now_playing.infocard = {"uri": "http://a.mp3", "title": "Track A"}
+        p.now_playing.as_dict = {"uri": "http://a.mp3", "title": "Track A"}
+        p.playlist = Playlist()
+        p.media = MagicMock()
+        p.media.search_playlist.entries = []
+        p.audio_service = MagicMock()
+        p.video_service = MagicMock()
+        p.web_service = MagicMock()
+        p.current = None
+        p.mpris = None
+        p.bus = FakeBus()
+        p.gui = MagicMock()
+    return p
+
+
+def _track(uri, title="T"):
+    return MediaEntry(uri=uri, title=title, playback=PlaybackType.AUDIO)
+
+
+class TestShuffleAllFailedBounded(unittest.TestCase):
+    """An all-failing shuffle+REPEAT queue must stop instead of hot-looping."""
+
+    def test_all_failing_shuffle_repeat_stops_bounded(self):
+        p = _make_player()
+        p.loop_state = LoopState.REPEAT
+        tracks = [_track(f"http://{i}.mp3", f"T{i}") for i in range(4)]
+        for t in tracks:
+            p.playlist.add_entry(t)
+        p.now_playing.uri = tracks[0].uri
+        for t in tracks:
+            p._failed_uris.add(t.uri)
+
+        with patch.object(p, "play") as mock_play, \
+             patch.object(p, "set_player_state") as mock_state:
+            # bounded: even calling play_next several times in a row must
+            # never resume playback - it must settle into STOPPED and stay
+            # there, not loop forever picking new "random" failed tracks
+            for _ in range(5):
+                p.play_next()
+
+        mock_play.assert_not_called()
+        mock_state.assert_any_call(PlayerState.STOPPED)
+
+    def test_one_good_track_keeps_playing_bound_not_over_triggered(self):
+        """Control: the failure bound must not fire when at least one
+        unfailed track remains - shuffle should keep advancing/replaying
+        the good track, never stopping."""
+        p = _make_player()
+        p.loop_state = LoopState.REPEAT
+        good = _track("http://good.mp3", "Good")
+        bad_tracks = [_track(f"http://bad{i}.mp3", f"Bad{i}") for i in range(3)]
+        for t in [good] + bad_tracks:
+            p.playlist.add_entry(t)
+        for t in bad_tracks:
+            p._failed_uris.add(t.uri)
+        p.now_playing.uri = good.uri
+
+        with patch.object(p, "play") as mock_play, \
+             patch.object(p, "set_player_state") as mock_state:
+            p.play_next()
+
+        mock_play.assert_called_once()
+        mock_state.assert_not_called()
+        self.assertEqual(p.now_playing.uri, good.uri,
+                        "the only unfailed track must still be the one selected")
+
+    def test_single_track_shuffle_repeat_off_stops_with_queue_finished(self):
+        """A single-track shuffle queue with repeat off has no other track
+        to shuffle to - must stop and speak queue.finished, exactly like
+        the sequential end-of-queue path, not replay forever."""
+        p = _make_player()
+        p.loop_state = LoopState.NONE
+        only = _track("http://only.mp3", "Only")
+        p.playlist.add_entry(only)
+        p.now_playing.uri = only.uri
+
+        with patch.object(p, "play") as mock_play, \
+             patch.object(p, "set_player_state") as mock_state:
+            p.play_next()
+
+        mock_play.assert_not_called()
+        mock_state.assert_called_once_with(PlayerState.STOPPED)
+        p.media.speak_dialog.assert_called_once_with("queue.finished")
+
+
+class TestDeadPlayerStopsHandlingDuckTopics(unittest.TestCase):
+    """After shutdown, a player must not react to duck/unduck/cork anymore -
+    neither via the plain ovos.common_play.* topics nor the legacy
+    recognizer_loop:* ones."""
+
+    def _make_real_player(self, bus):
+        from ovos_media.player import OCPMediaPlayer
+        with patch("ovos_media.player.AudioService"), \
+             patch("ovos_media.player.VideoService"), \
+             patch("ovos_media.player.WebService"), \
+             patch("ovos_media.player.OcpMprisExporter"), \
+             patch("ovos_media.player.GUIInterface"), \
+             patch("ovos_media.player.Configuration", return_value={"media": {}}), \
+             patch("ovos_media.player.OCPMediaCatalog"):
+            p = OCPMediaPlayer(bus, config={})
+        return p
+
+    def test_unduck_after_shutdown_does_not_restore_volume(self):
+        bus = FakeBus()
+        p = self._make_real_player(bus)
+        p.playback_type = PlaybackType.AUDIO
+        p.state = PlayerState.PLAYING
+        p._paused_on_duck = True
+        p.audio_service = MagicMock()
+
+        p.unregister_bus_handlers()
+
+        bus.emit(Message("ovos.common_play.unduck"))
+        p.audio_service.restore_volume.assert_not_called()
+
+    def test_duck_after_shutdown_does_not_lower_volume(self):
+        bus = FakeBus()
+        p = self._make_real_player(bus)
+        p.playback_type = PlaybackType.AUDIO
+        p.state = PlayerState.PLAYING
+        p.audio_service = MagicMock()
+
+        p.unregister_bus_handlers()
+
+        bus.emit(Message("ovos.common_play.duck"))
+        p.audio_service.lower_volume.assert_not_called()
+
+
+class TestShuffleEmptyQueueFailedTrackBounded(unittest.TestCase):
+    """An empty merged queue (e.g. playlist cleared mid-play) whose
+    now_playing track already failed must not be replayed forever."""
+
+    def test_empty_merged_queue_failed_current_track_stops_bounded(self):
+        p = _make_player()
+        p.loop_state = LoopState.NONE
+        p.shuffle = True
+        p.playlist = Playlist()
+        p.media.search_playlist.entries = []
+        p._failed_uris.add(p.now_playing.uri)
+
+        with patch.object(p, "play") as mock_play, \
+             patch.object(p, "set_player_state") as mock_state:
+            p.play_next()
+
+        mock_play.assert_not_called()
+        mock_state.assert_called_once_with(PlayerState.STOPPED)
+        p.media.speak_dialog.assert_called_once_with("queue.finished")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_help_flag.py
+++ b/test/unittests/test_help_flag.py
@@ -23,10 +23,10 @@ module guards against). The behavioral proof therefore MUST invoke the
 actual installed script via its real entry point, not `python -m
 ovos_media` (the module path bypasses the console-script argv wiring
 entirely) and not `main(argv=...)` with an explicit list."""
-import shutil
 import subprocess
 import sys
 import unittest
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 
@@ -87,13 +87,23 @@ class TestHelpFlagSubprocess(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.exe = shutil.which("ovos-media")
+        # NOTE: shutil.which("ovos-media") resolves against the FULL ambient
+        # PATH, so it can certify whatever "ovos-media" console script
+        # happens to be first on PATH — e.g. a stale script installed in an
+        # unrelated shared venv — instead of the one this test run just
+        # installed into sys.executable's venv. That silently validated the
+        # wrong binary and produced false test failures. The console script
+        # is always installed as a sibling of the interpreter that installed
+        # it, so resolve it relative to sys.executable instead of trusting
+        # ambient PATH.
+        candidate = Path(sys.executable).parent / "ovos-media"
+        cls.exe = str(candidate) if candidate.is_file() else None
         if not cls.exe:
             raise unittest.SkipTest(
-                "ovos-media console script not found on PATH — package "
-                "must be installed (pip/uv install -e .), not just "
-                "importable, for this test to exercise the real "
-                "entry point")
+                f"ovos-media console script not found at {candidate} — "
+                "package must be installed (uv pip install -e .) into "
+                "this interpreter's venv, not just importable, for this "
+                "test to exercise the real entry point")
 
     def test_help_subprocess_exits_zero_and_prints_usage(self):
         proc = subprocess.run(


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Two related fixes found by the latest certification round, plus a test-infrastructure repair.

Shuffle mode ignored the failure bounds that sequential playback respects. With every track in the queue already marked failed, shuffle kept picking known-bad tracks and replaying them through the invalid-stream retry timer forever: on the released 0.4.12a1 that's 26 play attempts in 2 seconds and a player wedged in PLAYING, where sequential playback stops after one attempt and speaks queue.finished. play_shuffle now excludes failed uris, reports whether it found anything playable, and play_next stops the player (STOPPED plus queue.finished) when it didn't — including the edge where the merged queue is empty but the current track has already failed, which previously slipped past the bound and looped just the same.

Separately, a shut-down player kept reacting to duck and cork messages. The three legacy recognizer_loop topics are bridged inside ovos-bus-client, and its remove() dedup branch no-ops when the same bound method is also registered on a plain topic — so shutdown left the plain ovos.common_play duck/unduck/cork handlers alive, and a dead player would still lower or restore system volume. Each legacy topic now gets its own wrapper so removal works on both spellings; an adversarial pass verified zero residual handlers over three construct/shutdown cycles against a real messagebus, no double-binds with two live players, and unchanged session gating through the wrappers. The bus-client bug itself is filed upstream; this makes ovos-media correct regardless.

The help-flag test resolved the console script via PATH, which silently tested whatever stale install shutil.which found first. It now resolves the script next to sys.executable.

Every regression test was verified red before the fix (a first draft of one leak test passed against the reverted fix and was dropped for the two that fail correctly). Gate on the rebased result: 675 unit tests and 64 end-to-end tests green, baseline arithmetic 675 − 1 removed false-green + 1 new bound test.
