### PR TITLE
fix: resume corked playback when the utterance is handled

### DIFF
--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -2135,14 +2135,17 @@ class OCPMediaPlayer:
         - Duck (PLAYING): ``_paused_on_duck`` is True, player is PLAYING →
           ``handle_unduck_request`` restores volume.
         - Cork (PAUSED): ``_paused_on_duck`` is True, player is PAUSED →
-          ``handle_unduck_request`` restores volume; caller should also
-          uncork via ``handle_uncork_request`` if resume is desired.
+          ``handle_uncork_request`` resumes playback and restores state.
 
         @param message: Message associated with event
         """
-        if self._paused_on_duck:
-            # The intent has been handled; restore volume regardless of whether
-            # the player was ducked (PLAYING) or corked (PAUSED).
+        if self._paused_on_duck and self.state == PlayerState.PAUSED:
+            # The intent has been handled; resume playback that was paused
+            # for the cork path, since 'recognizer_loop:record_end' already
+            # no-op'd while the 'speak' was in flight.
+            self.handle_uncork_request(message)
+        elif self._paused_on_duck:
+            # The intent has been handled; restore volume for the duck path.
             self.handle_unduck_request(message)
 
     def handle_mycroft_stop(self, message):

--- a/test/unittests/test_player_coverage2.py
+++ b/test/unittests/test_player_coverage2.py
@@ -429,6 +429,59 @@ class TestPlayerUtteranceHandled(unittest.TestCase):
 
         mock_unduck.assert_called_once()
 
+    def test_utterance_handled_cork_path_resumes_playback(self):
+        """Cork path: PAUSED + _paused_on_duck=True must resume via
+        handle_uncork_request, not just restore volume, otherwise the
+        player stays paused forever (record_end already no-op'd while a
+        'speak' was in flight)."""
+        p = _make_player(PlaybackType.AUDIO)
+        p.state = PlayerState.PAUSED
+        p._paused_on_duck = True
+        p.handle_status = MagicMock()
+
+        with patch.object(p, "handle_unduck_request") as mock_unduck:
+            p.handle_utterance_handled(Message("ovos.utterance.handled"))
+
+        mock_unduck.assert_not_called()
+        self.assertEqual(p.state, PlayerState.PLAYING)
+        self.assertFalse(p._paused_on_duck)
+
+    def test_utterance_handled_duck_path_unchanged(self):
+        """Duck path: PLAYING + _paused_on_duck=True must only restore
+        volume, never call resume/uncork."""
+        p = _make_player(PlaybackType.AUDIO)
+        p.state = PlayerState.PLAYING
+        p._paused_on_duck = True
+
+        with patch.object(p, "handle_uncork_request") as mock_uncork:
+            p.handle_utterance_handled(Message("ovos.utterance.handled"))
+
+        mock_uncork.assert_not_called()
+        p.audio_service.restore_volume.assert_called_once()
+        self.assertEqual(p.state, PlayerState.PLAYING)
+        self.assertFalse(p._paused_on_duck)
+
+    def test_cork_then_utterance_handled_end_to_end_resumes(self):
+        """End-to-end: record_begin corks playback, then
+        ovos.utterance.handled must resume it (the previously-stuck
+        sequence), and a late record_end afterwards is a harmless no-op."""
+        p = _make_player(PlaybackType.AUDIO)
+        p.state = PlayerState.PLAYING
+        p.handle_status = MagicMock()
+
+        p.handle_cork_request(Message("recognizer_loop:record_begin"))
+        self.assertEqual(p.state, PlayerState.PAUSED)
+        self.assertTrue(p._paused_on_duck)
+
+        p.handle_utterance_handled(Message("ovos.utterance.handled"))
+        self.assertEqual(p.state, PlayerState.PLAYING)
+        self.assertFalse(p._paused_on_duck)
+
+        # a late record_end must no-op harmlessly (flag already cleared)
+        p.handle_record_end(Message("recognizer_loop:record_end"))
+        self.assertEqual(p.state, PlayerState.PLAYING)
+        self.assertFalse(p._paused_on_duck)
+
 
 class TestPlayerHandlePlayRequestNoMedia(unittest.TestCase):
     """Test handle_play_request with no media."""


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Corked playback never resumed after a voice interaction that actually spoke a reply. record_begin pauses the music and sets the resume guard, and when the response speech finishes, ovos.utterance.handled was supposed to bring playback back — but the handler only restored volume and cleared the guard flag, never calling resume. Since record_end only resumes when no speak message arrives within its window, and every other resume path checks the guard flag that had just been cleared, the player stayed paused until the user manually asked for playback again.

handle_utterance_handled now resumes via the uncork path when the player is paused under the guard, and keeps the volume-only restore for the duck path where playback never stopped. Three regression tests cover the cork resume, the unchanged duck behavior, and the full record_begin → utterance.handled → late record_end sequence on a bus; all three were verified to fail with the fix reverted. Gate on the rebased branch: 678 unit tests (675 baseline + 3 new) and 64 end-to-end tests green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Playback now correctly resumes after an utterance when it was paused by corking.
  * Volume restoration continues to work correctly after ducking during playback.
  * Late recording completion events no longer disrupt playback.

* **Tests**
  * Added coverage for corked, ducked, paused, and resumed playback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->