### PR TITLE
fix: validate bus-fed media metadata and message routing types

### DIFF
--- a/ovos_media/mpris.py
+++ b/ovos_media/mpris.py
@@ -856,7 +856,13 @@ class _MediaPlayer2PlayerInterface(ServiceInterface):
             # position as seconds). MPRIS2 spec requires signature 'x'
             # (int64), so cast to int - strict clients (playerctl, GNOME
             # Shell) misparse/reject a 'd' (double) wire value.
-            return int(self._ocp_player.now_playing.position * 1000)
+            position = self._ocp_player.now_playing.position
+            # a bus-fed position can arrive malformed (missing/None/wrong
+            # type); never let a bad value break Properties.GetAll for the
+            # whole Player interface, fall back to 0 like "no now_playing"
+            if isinstance(position, bool) or not isinstance(position, (int, float)):
+                return 0
+            return int(position * 1000)
         return 0
 
     @dbus_property(access=PropertyAccess.READ)

--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -460,8 +460,13 @@ class NowPlaying(MediaEntry):
         else:
             video = False
         meta = self.stream_xtract.extract_stream(uri, video)
-        # update media entry with new data
+        # validate the extractor-returned uri BEFORE mutating any state -
+        # a non-string uri (int/list/dict) must never poison self.uri, it
+        # must refuse the same way a missing uri does
         if meta:
+            extracted_uri = meta.get("uri")
+            if extracted_uri is not None and not isinstance(extracted_uri, str):
+                raise ValueError(f"invalid stream: {extracted_uri}")
             LOG.info(f"OCP plugins metadata: {meta}")
             self.update(meta, newonly=True)
             self.original_uri = uri
@@ -585,8 +590,17 @@ class NowPlaying(MediaEntry):
         Handle 'ovos.common_play.playback_time' Messages sent by audio backend
         @param message: Message with 'length' and 'position' data
         """
-        self.length = message.data["length"]
-        self.position = message.data["position"]
+        for field in ("length", "position"):
+            value = message.data.get(field)
+            # real numbers only; bool is a subclass of int but is never a
+            # legitimate ms value, and a str would otherwise silently
+            # coerce (eg. int("5000" * 1000) overflowing the MPRIS int64
+            # wire type) instead of being rejected outright
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                LOG.debug(f"ignoring invalid '{field}' in playback_time "
+                          f"message: {value!r}")
+                continue
+            setattr(self, field, int(value))
         if self._player is not None:
             self._player._update_gui()
 
@@ -1692,6 +1706,7 @@ class OCPMediaPlayer:
         if self.mpris and self.playback_type in [PlaybackType.MPRIS]:
             self.mpris.pause()
         self.set_player_state(PlayerState.STOPPED)
+        self._paused_on_duck = False
         self._update_gui()
 
     def handle_MPRIS_takeover(self):
@@ -2035,6 +2050,18 @@ class OCPMediaPlayer:
                     track = MediaEntry.from_dict(track)
                 if not isinstance(track, (MediaEntry, Playlist, PluginStream)):
                     raise ValueError(f"not a valid track: {track!r}")
+                # a non-numeric length/position (eg. bus-fed "garbage")
+                # must not poison Playlist.length's later sum() over all
+                # entries - sanitize to 0 rather than reject the whole entry.
+                # Playlist.length is a read-only computed property (sum of
+                # its own entries), so only individual tracks are sanitized.
+                if isinstance(track, (MediaEntry, PluginStream)):
+                    for field in ("length", "position"):
+                        value = getattr(track, field, None)
+                        if isinstance(value, bool) or not isinstance(value, (int, float)):
+                            LOG.debug(f"coercing invalid '{field}' on "
+                                      f"playlist entry to 0: {value!r}")
+                            setattr(track, field, 0)
                 entries.append(track)
             except Exception as e:
                 LOG.warning(f"skipping invalid playlist entry: {e}")

--- a/ovos_media/utils.py
+++ b/ovos_media/utils.py
@@ -73,7 +73,18 @@ def require_default_session():
 def validate_message_context(message, native_sources=None):
     destination = message.context.get("destination")
     if destination:
-        # moved to global config level, used to be in "Audio" subsection 
+        # a bare string destination is legitimate (ovos-bus-client's
+        # .reply()/.forward() produce one) - normalize it to a single-element
+        # list so membership below is exact, not substring containment
+        # (destination "audio_settings_skill" must NOT match native source
+        # "audio")
+        if isinstance(destination, str):
+            destination = [destination]
+        elif not isinstance(destination, (list, tuple, set)):
+            # anything else (int, dict, ...) is not a valid destination
+            # container - refuse without raising, treat as external
+            return False
+        # moved to global config level, used to be in "Audio" subsection
         native_sources = native_sources or \
                         Configuration().get("native_sources") or \
                         Configuration().get("Audio", {}).get("native_sources") or \

--- a/test/unittests/test_mpris.py
+++ b/test/unittests/test_mpris.py
@@ -67,6 +67,25 @@ class TestPosition(unittest.TestCase):
         result = iface.Position
         self.assertIsInstance(result, int)
 
+    def test_position_none_returns_zero(self):
+        # a bus-fed position can arrive as None (missing/invalid seekbar
+        # data) - Properties.GetAll for the whole Player interface must
+        # not blow up on it, fall back to 0 like "no now_playing"
+        iface, player = _make_interface()
+        player.now_playing.position = None
+        result = iface.Position
+        self.assertEqual(result, 0)
+        self.assertIsInstance(result, int)
+
+    def test_position_str_does_not_overflow_wire_type(self):
+        # a str position must never be multiplied/coerced (eg.
+        # int("5000" * 1000) would overflow int64 on the wire) - it is
+        # invalid, fall back to 0
+        iface, player = _make_interface()
+        player.now_playing.position = "5000"
+        result = iface.Position
+        self.assertEqual(result, 0)
+
     def test_position_dbus_signature_is_x(self):
         # The dbus-next @dbus_property decorator stores the declared wire
         # signature on the underlying property object (a dbus_next

--- a/test/unittests/test_player_coverage.py
+++ b/test/unittests/test_player_coverage.py
@@ -180,6 +180,66 @@ class TestNowPlayingInit(unittest.TestCase):
         self.assertEqual(np.position, 45000)
         self.assertEqual(np.length, 180000)
 
+    def test_handle_sync_seekbar_missing_keys_does_not_raise(self):
+        np, _ = self._make_now_playing()
+        np.position = 1000
+        np.length = 2000
+        msg = Message("ovos.common_play.playback_time", {})
+        np.handle_sync_seekbar(msg)  # must not raise KeyError
+        # prior values are kept, not clobbered
+        self.assertEqual(np.position, 1000)
+        self.assertEqual(np.length, 2000)
+
+    def test_handle_sync_seekbar_none_position_keeps_prior_value(self):
+        np, _ = self._make_now_playing()
+        np.position = 1000
+        msg = Message("ovos.common_play.playback_time",
+                      {"length": 180000, "position": None})
+        np.handle_sync_seekbar(msg)
+        self.assertEqual(np.position, 1000)
+        self.assertEqual(np.length, 180000)
+
+    def test_handle_sync_seekbar_str_position_keeps_prior_value(self):
+        np, _ = self._make_now_playing()
+        np.position = 1000
+        msg = Message("ovos.common_play.playback_time",
+                      {"length": 180000, "position": "5000"})
+        np.handle_sync_seekbar(msg)  # must not string-repeat/overflow
+        self.assertEqual(np.position, 1000)
+        self.assertEqual(np.length, 180000)
+
+    def test_extract_stream_non_string_uri_raises_and_leaves_uri_untouched(self):
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.stream_xtract = MagicMock()
+        # extractor plugin returns a garbage non-string uri
+        np.stream_xtract.extract_stream.return_value = {"uri": ["not", "a", "str"]}
+        with self.assertRaises(ValueError):
+            np.extract_stream()
+        # self.uri must not have been poisoned by the garbage value
+        self.assertEqual(np.uri, "ocp://original")
+
+    def test_extract_stream_valid_uri_updates_normally(self):
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.stream_xtract = MagicMock()
+        np.stream_xtract.extract_stream.return_value = {"uri": "http://example.com/x.mp3"}
+        np.extract_stream()  # must not raise
+        self.assertEqual(np.uri, "http://example.com/x.mp3")
+
+    def test_on_invalid_stream_after_bad_extract_does_not_raise(self):
+        p = _make_player()
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.stream_xtract = MagicMock()
+        np.stream_xtract.extract_stream.return_value = {"uri": ["bad"]}
+        with self.assertRaises(ValueError):
+            np.extract_stream()
+        p.now_playing = np
+        # the retry-guard recovery path must not crash on the (still
+        # valid, untouched) uri left behind by the refused extraction
+        p.on_invalid_stream()  # must not raise
+
     def test_handle_external_play_updates_metadata(self):
         np, _ = self._make_now_playing()
         msg = Message("ovos.common_play.play",

--- a/test/unittests/test_shuffle_mpris_playlist_validation.py
+++ b/test/unittests/test_shuffle_mpris_playlist_validation.py
@@ -134,6 +134,42 @@ class TestPlaylistSetValidatesBeforeClearing(unittest.TestCase):
         self.assertEqual(len(p.playlist), 0)
         p.shutdown()
 
+    def test_garbage_length_is_sanitized_not_left_poisoning_sum(self):
+        # a non-numeric length must not survive into the playlist: it
+        # would otherwise blow up Playlist.length's sum() over all
+        # entries the next time anything asks for the playlist length
+        bus, p = _player()
+        self._set(p, bus, [{"uri": "file:///ok.mp3", "title": "ok",
+                            "length": "garbage"}])
+        self.assertEqual(len(p.playlist), 1)
+        self.assertEqual(p.playlist[0].length, 0)
+        # must not raise
+        total = p.playlist.length
+        self.assertIsInstance(total, (int, float))
+        p.shutdown()
+
+    def test_none_length_is_sanitized(self):
+        bus, p = _player()
+        self._set(p, bus, [{"uri": "file:///ok.mp3", "title": "ok",
+                            "length": None}])
+        self.assertEqual(p.playlist[0].length, 0)
+        p.shutdown()
+
+
+class TestStopClearsPausedOnDuckFlag(unittest.TestCase):
+    """D5 sibling to pause(): stop() must reset the duck-pause flag same
+    as pause() does, or a later ovos.utterance.handled fires a spurious
+    restore_volume against whatever plays next."""
+
+    def test_stop_resets_paused_on_duck(self):
+        bus, p = _player()
+        p.audio_service.services = [MagicMock()]
+        p.play()
+        p._paused_on_duck = True
+        p.stop()
+        self.assertFalse(p._paused_on_duck)
+        p.shutdown()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -173,5 +173,41 @@ class TestRequireDefaultSessionMalformedContext(unittest.TestCase):
         self.assertEqual(len(calls), 1)
 
 
+class TestValidateMessageContextStringDestination(unittest.TestCase):
+    """A bare string destination (produced by ovos-bus-client's
+    .reply()/.forward()) must be matched exactly, never by substring
+    containment."""
+
+    def _call(self, destination, native_sources):
+        from ovos_media.utils import validate_message_context
+        msg = _make_message(destination=destination)
+        with patch("ovos_media.utils.Configuration", return_value={}):
+            return validate_message_context(msg, native_sources=native_sources)
+
+    def test_substring_match_returns_false(self):
+        # "audio_settings_skill" contains "audio" but is not the native
+        # "audio" source - must not be treated as a device-originated request
+        result = self._call("audio_settings_skill", ["debug_cli", "audio"])
+        self.assertFalse(result)
+
+    def test_exact_string_match_returns_true(self):
+        result = self._call("audio", ["debug_cli", "audio"])
+        self.assertTrue(result)
+
+    def test_non_matching_string_returns_false(self):
+        result = self._call("remote_client", ["debug_cli", "audio"])
+        self.assertFalse(result)
+
+    def test_int_destination_returns_false_without_raising(self):
+        result = self._call(12345, ["debug_cli", "audio"])
+        self.assertFalse(result)
+
+    def test_dict_destination_returns_false(self):
+        # previously `in` on a dict checked its keys, an accident that
+        # let a dict destination slip through as a "match"
+        result = self._call({"audio": True}, ["debug_cli", "audio"])
+        self.assertFalse(result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Five input-validation defects at bus-facing entry points, all reproduced live before fixing. The playback_time handler assigned length and position straight from message data with no key or type checks: a missing key raised KeyError in the handler, a None position made the MPRIS Position property raise, and because dbus-next aborts a Properties.GetAll reply on the first failing property, every MPRIS client reading the standard GetAll (GNOME Shell, playerctl, KDE Connect) lost the entire Player interface, not just Position. A string position was worse than a crash: "5000" times 1000 string-repeats before int(), yielding a four-thousand-digit integer that overflows the int64 wire type. The handler now accepts only real numbers and keeps the prior value otherwise, and Position itself falls back to 0 on a malformed value so one bad property can never take down GetAll.

validate_message_context, the check that keeps externally-originated (e.g. satellite) playback commands from being handled as native-device requests, used Python containment on a bare string destination — so a destination like "audio_settings_skill" matched the native source "audio" by substring and was wrongly trusted, while an int destination raised TypeError inside every namespace handler. String destinations (legitimately produced by ovos-bus-client reply/forward) are now normalized to exact membership, and non-container destination types are refused without raising.

extract_stream force-updated now_playing.uri with whatever the stream-extractor plugin returned before validating it, so a plugin returning a non-string uri left the poisoned value in place and the invalid-stream recovery path then crashed adding an unhashable value to the failed-uris set — defeating the retry-loop guard that exists precisely to contain bad tracks. The uri is now validated as a string before any state mutation and refuses with the same ValueError as a missing uri. Playlist entries arriving over the bus with non-numeric length or position are sanitized to 0 so the later Playlist.length sum cannot raise asynchronously, and stop() now clears the paused-on-duck flag the way pause() already did, closing a window where a stale flag triggered a spurious volume restore on a later utterance.handled.

Sixteen regression tests were added across the four affected areas; with the source changes reverted via patch, thirteen fail on the exact defects (the remainder are controls pinning behavior that was already correct). Gate on the rebased branch: 700 unit tests (684 baseline + 16 new) and 64 end-to-end tests green.
