### PR TITLE
fix: sanitize nested playlists, clamp MPRIS position, dispatch video seek

### DIFF
--- a/ovos_media/legacy_api.py
+++ b/ovos_media/legacy_api.py
@@ -62,7 +62,14 @@ def _tracks_to_entries(
                 continue
             uri = t[0]
         else:
-            uri = str(t)
+            if not isinstance(t, str) or not t:
+                # not a (uri, mime) pair and not a usable uri string (eg. a
+                # dict or int) - skip with a warning instead of stringifying
+                # it into a garbage uri, mirroring the malformed
+                # list/tuple case above
+                LOG.warning(f"skipping malformed legacy track entry: {t!r}")
+                continue
+            uri = t
         entry = MediaEntry(
             uri=uri,
             title=uri,

--- a/ovos_media/mpris.py
+++ b/ovos_media/mpris.py
@@ -866,7 +866,13 @@ class _MediaPlayer2PlayerInterface(ServiceInterface):
             # 0 like "no now_playing"
             if not is_real_number(position):
                 return 0
-            return int(position * 1000)
+            # dbus_next marshals 'x' as a signed 64-bit int; a value outside
+            # that range raises during marshalling (after this getter has
+            # already returned), so clamp into range rather than let a huge
+            # finite position (eg. a bogus seekbar sync) blow up the whole
+            # Properties.GetAll response
+            value = int(position * 1000)
+            return max(0, min(value, 2 ** 63 - 1))
         return 0
 
     @dbus_property(access=PropertyAccess.READ)

--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -472,12 +472,24 @@ class NowPlaying(MediaEntry):
                 raise ValueError(f"invalid stream: {extracted_uri!r}")
             if isinstance(extracted_uri, str) and extracted_uri and not extracted_uri.strip():
                 raise ValueError(f"invalid stream: {extracted_uri!r}")
+            if isinstance(extracted_uri, str) and any(
+                    ord(c) < 0x20 or ord(c) == 0x7f for c in extracted_uri):
+                # a uri that otherwise looks fine (eg. a valid http prefix)
+                # may still smuggle control characters/newlines - refuse
+                # before mutating state, same as the non-string/whitespace
+                # checks above (log/header-injection surface downstream)
+                raise ValueError(f"invalid stream: {extracted_uri!r}")
             LOG.info(f"OCP plugins metadata: {meta}")
             self.update(meta, newonly=True)
             self.original_uri = uri
 
         # validate extracted uri
         if not any((self.uri.startswith(s) for s in ["http", "file", "/"])):
+            raise ValueError(f"invalid stream: {self.uri!r}")
+        # a uri passing the prefix check above may still smuggle control
+        # characters (eg. embedded newlines for header/log injection) -
+        # refuse those too
+        if any(ord(c) < 0x20 or ord(c) == 0x7f for c in self.uri):
             raise ValueError(f"invalid stream: {self.uri!r}")
 
     # bus api
@@ -1680,7 +1692,12 @@ class OCPMediaPlayer:
 
     def seek(self, position: int):
         """
-        Request playback to go to a specific position in the current media
+        Request playback to go to a specific position in the current media.
+        Only AUDIO, UNDEFINED and VIDEO playback support seeking. SKILL
+        playback would require a new bus message to ask the skill to seek,
+        and MPRIS players have no seek passthrough - those types (and any
+        other unhandled one) are logged and dropped rather than silently
+        doing nothing.
         @param position: milliseconds position to seek to
         """
         if self.playback_type in [PlaybackType.AUDIO,
@@ -1689,6 +1706,11 @@ class OCPMediaPlayer:
             # matching the milliseconds contract documented on this
             # method and on MediaBackend.set_track_position
             self.audio_service.set_track_position(position)
+        elif self.playback_type == PlaybackType.VIDEO:
+            self.video_service.set_track_position(position)
+        else:
+            LOG.warning(f"seek() is not supported for playback_type "
+                        f"{self.playback_type}, ignoring")
 
     def stop(self):
         """
@@ -2089,16 +2111,39 @@ class OCPMediaPlayer:
                     # a nested Playlist's own tracks are entries too - bad
                     # values inside them would otherwise reach the outer
                     # Playlist.length (a sum over all contained entries)
-                    # unsanitized. Recurse arbitrarily deep. `entries` is a
-                    # read-only property backed by the list itself (no
-                    # setter), so sanitize in place.
-                    sanitized = OCPMediaPlayer._validated_entries(track.entries)
-                    track.entries.clear()
-                    track.entries.extend(sanitized)
+                    # unsanitized. Recurse arbitrarily deep.
+                    OCPMediaPlayer._sanitize_nested_playlist(track, set())
                 entries.append(track)
             except Exception as e:
                 LOG.warning(f"skipping invalid playlist entry: {e}")
         return entries
+
+    @staticmethod
+    def _sanitize_nested_playlist(playlist, visited):
+        """Sanitize length/position on every MediaEntry/PluginStream
+        reachable inside a (possibly self-referential) tree of nested
+        Playlists, mutating the shared objects in place.
+
+        `Playlist.entries` is a computed property that returns a filtered
+        copy of the list and drops nested Playlist members entirely, so it
+        cannot be used to reach or fix them. Iterating the Playlist itself
+        (it subclasses list) reaches every raw member, including nested
+        Playlists. Dict members are left untouched - `Playlist.entries`
+        converts them to MediaEntry on read.
+        """
+        if id(playlist) in visited:
+            return
+        visited.add(id(playlist))
+        for member in list.__iter__(playlist):
+            if isinstance(member, (MediaEntry, PluginStream)):
+                for field in ("length", "position"):
+                    value = getattr(member, field, None)
+                    if not is_real_number(value):
+                        LOG.debug(f"coercing invalid '{field}' on "
+                                  f"playlist entry to 0: {value!r}")
+                        setattr(member, field, 0)
+            elif isinstance(member, Playlist):
+                OCPMediaPlayer._sanitize_nested_playlist(member, visited)
 
     @require_default_session()
     def handle_playlist_queue_request(self, message):

--- a/test/unittests/test_legacy_api.py
+++ b/test/unittests/test_legacy_api.py
@@ -241,6 +241,17 @@ class TestTracksToEntries(unittest.TestCase):
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0]["uri"], "http://a.com/a.mp3")
 
+    def test_non_str_non_list_entries_are_skipped_not_stringified(self):
+        # a dict or int track entry must not be turned into a garbage uri
+        # via str(t) (eg. a dict becomes its literal repr string) - skip
+        # it with a warning instead, same convention as the malformed
+        # list/tuple case. Valid siblings must still convert.
+        from ovos_media.legacy_api import _tracks_to_entries
+        entries = _tracks_to_entries(
+            [{"uri": "http://bad.example/dict"}, 42, "http://a.com/a.mp3"])
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["uri"], "http://a.com/a.mp3")
+
 
 class TestLegacyCompatShutdown(unittest.TestCase):
     """shutdown() must remove all listeners."""

--- a/test/unittests/test_mpris.py
+++ b/test/unittests/test_mpris.py
@@ -112,6 +112,29 @@ class TestPosition(unittest.TestCase):
         prop = _MediaPlayer2PlayerInterface.__dict__["Position"]
         self.assertEqual(prop.signature, "x")
 
+    def test_position_huge_finite_clamps_into_int64_and_packs(self):
+        # a position like 1e16 ms is finite and non-negative (accepted by
+        # the seekbar sync handler), but *1000 overflows a signed 64-bit
+        # int - the getter must clamp it, not hand dbus_next a value that
+        # blows up during marshalling (outside the per-getter guard)
+        from dbus_next.signature import Variant
+        iface, player = _make_interface()
+        player.now_playing.position = 1e16
+        result = iface.Position
+        self.assertIsInstance(result, int)
+        self.assertLessEqual(result, 2 ** 63 - 1)
+        Variant('x', result)  # must not raise
+
+    def test_position_absurd_float_clamps_into_int64_and_packs(self):
+        from dbus_next.signature import Variant
+        iface, player = _make_interface()
+        player.now_playing.position = 1e300
+        result = iface.Position
+        self.assertIsInstance(result, int)
+        self.assertGreaterEqual(result, 0)
+        self.assertLessEqual(result, 2 ** 63 - 1)
+        Variant('x', result)  # must not raise
+
 
 class TestLoopStatusSetter(unittest.TestCase):
     """LoopStatus setter must map MPRIS strings to LoopState enum values."""

--- a/test/unittests/test_player_coverage.py
+++ b/test/unittests/test_player_coverage.py
@@ -286,6 +286,23 @@ class TestNowPlayingInit(unittest.TestCase):
         np.extract_stream()  # must not raise
         self.assertEqual(np.uri, "http://example.com/x.mp3")
 
+    def test_extract_stream_control_char_uri_raises_and_leaves_uri_untouched(self):
+        # a uri that passes the prefix check may still embed control
+        # characters (eg. a newline for header/log injection) - it must be
+        # refused, same as a non-string or whitespace-only uri
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.title = "original title"
+        np.stream_xtract = MagicMock()
+        np.stream_xtract.extract_stream.return_value = {
+            "uri": "http://evil.example/\nSet-Cookie: x=1",
+            "title": "poisoned"}
+        with self.assertRaises(ValueError) as cm:
+            np.extract_stream()
+        self.assertIn("Set-Cookie", str(cm.exception))
+        self.assertEqual(np.uri, "ocp://original")
+        self.assertEqual(np.title, "original title")
+
     def test_on_invalid_stream_after_bad_extract_does_not_raise(self):
         p = _make_player()
         np, _ = self._make_now_playing()

--- a/test/unittests/test_player_handlers.py
+++ b/test/unittests/test_player_handlers.py
@@ -282,6 +282,31 @@ class TestHandleSeekRequest(unittest.TestCase):
         p.seek(60000)
         p.audio_service.set_track_position.assert_called_once_with(60000)
 
+    def test_seek_video_calls_video_service(self):
+        """A VIDEO seek (eg. GUI seekbar drag, "skip forward 30s" on a
+        video skill) must reach video_service.set_track_position, not
+        evaporate silently."""
+        p = _make_player(PlaybackType.VIDEO)
+        p.seek(60000)
+        p.video_service.set_track_position.assert_called_once_with(60000)
+        p.audio_service.set_track_position.assert_not_called()
+
+    def test_seek_skill_logs_warning_and_does_not_raise(self):
+        p = _make_player(PlaybackType.SKILL)
+        with patch("ovos_media.player.LOG") as mock_log:
+            p.seek(60000)
+            mock_log.warning.assert_called_once()
+        p.audio_service.set_track_position.assert_not_called()
+        p.video_service.set_track_position.assert_not_called()
+
+    def test_seek_mpris_logs_warning_and_does_not_raise(self):
+        p = _make_player(PlaybackType.MPRIS)
+        with patch("ovos_media.player.LOG") as mock_log:
+            p.seek(60000)
+            mock_log.warning.assert_called_once()
+        p.audio_service.set_track_position.assert_not_called()
+        p.video_service.set_track_position.assert_not_called()
+
     def test_seek_with_non_numeric_seconds_is_ignored(self):
         """A non-numeric 'seconds' payload must not raise TypeError from the
         `* 1000` multiplication — it should be logged and ignored instead."""

--- a/test/unittests/test_shuffle_mpris_playlist_validation.py
+++ b/test/unittests/test_shuffle_mpris_playlist_validation.py
@@ -197,6 +197,50 @@ class TestPlaylistSetValidatesBeforeClearing(unittest.TestCase):
         self.assertNotEqual(total, float("inf"))
         p.shutdown()
 
+    def test_playlist_nested_in_playlist_is_sanitized(self):
+        # Playlist.entries is a computed property that builds a NEW
+        # filtered list and drops nested Playlist members entirely, so
+        # recursing over track.entries never reaches a Playlist nested
+        # inside a Playlist. The raw list members (Playlist subclasses
+        # list) must be walked instead.
+        from ovos_media.player import OCPMediaPlayer
+        from ovos_utils.ocp import Playlist as OcpPlaylist
+
+        bus, p = _player()
+        inner = OcpPlaylist(title="inner")
+        inner.add_entry(_entry("file:///n1.mp3", "n1"))
+        # Playlist subclasses list - indexing/iterating it directly hits
+        # the raw members, unlike the .entries property
+        inner[0].length = "garbage"
+
+        outer = OcpPlaylist(title="outer")
+        outer.add_entry(inner)
+
+        entries = OCPMediaPlayer._validated_entries([outer])
+        self.assertEqual(len(entries), 1)
+        outer_result = entries[0]
+        self.assertIsInstance(outer_result, OcpPlaylist)
+        inner_result = outer_result[0]
+        self.assertIsInstance(inner_result, OcpPlaylist)
+        # inner.length must not raise TypeError from "garbage" + int, and
+        # the sanitized value must be visible
+        self.assertEqual(inner_result[0].length, 0)
+        self.assertEqual(inner_result.length, 0)
+        p.shutdown()
+
+    def test_self_referential_playlist_does_not_recurse_forever(self):
+        from ovos_media.player import OCPMediaPlayer
+        from ovos_utils.ocp import Playlist as OcpPlaylist
+
+        bus, p = _player()
+        cycle = OcpPlaylist(title="cycle")
+        cycle.add_entry(_entry("file:///a.mp3", "a"))
+        list.append(cycle, cycle)  # self-reference via raw list append
+
+        entries = OCPMediaPlayer._validated_entries([cycle])
+        self.assertEqual(len(entries), 1)
+        p.shutdown()
+
 
 class TestStopClearsPausedOnDuckFlag(unittest.TestCase):
     """D5 sibling to pause(): stop() must reset the duck-pause flag same


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

The nested-playlist sanitization added in the previous hardening pass turned out to be dead code. ovos-utils' Playlist.entries is a computed property that builds and returns a new filtered list on every access — and it silently drops nested Playlist members. So clearing and extending that returned list mutated throwaway copies, and a playlist nested inside a playlist (built through the legitimate add_entry API) was never visited at all: an entry with a garbage length inside it still made the inner playlist's length computation raise TypeError. Single-level nesting only worked because the property returns references to shared entry objects, which the sanitizer mutates in place. The recursion now iterates the raw list members (Playlist subclasses list), sanitizes entries in place, recurses into nested playlists, and carries a visited-set so a self-referential playlist cannot cause infinite recursion. The misleading comment and the dead clear/extend lines are gone.

Two more edges in the same seams: the MPRIS Position getter rejected non-finite values but not finite-but-huge ones — a bogus playback_time sync above roughly 9.2e15 ms produced an int outside the signed 64-bit D-Bus range, and dbus-next then raised during marshalling, after the getter had already returned and outside its per-getter exception guard, failing the whole Properties.GetAll response. The value is now clamped into the int64 range. And extract_stream accepted extractor uris that pass the prefix check but embed control characters or newlines (a log/header-injection surface); those are refused before any state mutation, alongside the existing non-string and whitespace refusals.

seek() dispatched only for audio playback while pause, resume and stop all branch on every playback type — a seek during video playback reached no backend, logged nothing, and simply evaporated, though VideoService has the identical set_track_position capability. Video seeks now dispatch, and the unsupported types (skill playback would need a new bus message; MPRIS players have no seek passthrough) log a warning instead of dropping silently. Finally, the legacy track converter stringified dict or int track entries into garbage repr uris; the fallback branch now accepts only non-empty strings and skips anything else with the same warning convention as malformed tuples.

Nine regression tests were added; eight were verified to fail with the source changes reverted via patch, and the ninth (playlist self-cycle) is a forward-looking guard for the new raw-iteration code, documented as such. Gate on the rebased branch: 721 unit tests (712 baseline + 9 new) and 64 end-to-end tests green.
