### PR TITLE
fix: isolate backend supported_uris failures, guard MPRIS Volume, lock liked_songs, narrow injection check

### DIFF
--- a/ovos_media/media_backends/base.py
+++ b/ovos_media/media_backends/base.py
@@ -15,6 +15,21 @@ from ovos_utils.log import LOG
 from ovos_utils.process_utils import MonotonicEvent
 
 
+def _safe_supported_uris(s) -> list:
+    """Call s.supported_uris() defensively.
+
+    A plugin raising here must not abort backend listing/selection for
+    every other, healthy backend. Treated the same as a plugin that
+    supports nothing.
+    """
+    try:
+        return s.supported_uris()
+    except Exception:
+        LOG.exception(f"{getattr(s, 'name', s.__class__.__name__)}"
+                      f".supported_uris() raised")
+        return []
+
+
 class BaseMediaService:
 
     def __init__(self, bus, namespace: str, plugin_loader: Callable,
@@ -79,7 +94,7 @@ class BaseMediaService:
         data = {}
         for s in self.services:
             info = {
-                'supported_uris': s.supported_uris(),
+                'supported_uris': _safe_supported_uris(s),
                 'remote': isinstance(s, RemoteAudioPlayerBackend) or
                           isinstance(s, RemoteWebPlayerBackend) or
                           isinstance(s, RemoteVideoPlayerBackend)
@@ -455,16 +470,16 @@ class BaseMediaService:
         uri_type = uri.split(':')[0]
 
         # check if user requested a particular service
-        if preferred_service and uri_type in preferred_service.supported_uris():
+        if preferred_service and uri_type in _safe_supported_uris(preferred_service):
             selected_service = preferred_service
 
         # check if default supports the uri
-        elif self.current and uri_type in self.current.supported_uris():
+        elif self.current and uri_type in _safe_supported_uris(self.current):
             selected_service = self.current
 
         else:  # Check if any media service can play the media
             for s in self.services:
-                if uri_type in s.supported_uris():
+                if uri_type in _safe_supported_uris(s):
                     LOG.debug(f"Service {s.__class__.__name__} supports URI {uri_type}")
                     selected_service = s
                     break

--- a/ovos_media/mpris.py
+++ b/ovos_media/mpris.py
@@ -846,9 +846,18 @@ class _MediaPlayer2PlayerInterface(ServiceInterface):
 
     @dbus_property()
     def Volume(self) -> 'd':
+        # a failing property getter kills Properties.GetAll for the whole
+        # Player interface, not just this property (same class of failure
+        # the Metadata/Position guards prevent) - the bus response is
+        # unvalidated, so fall back to full volume rather than let a
+        # missing/None/non-numeric "percent" propagate.
         msg = self._ocp_player.bus.wait_for_response(Message("mycroft.volume.get"), timeout=0.5)
         if msg:
-            return float(msg.data["percent"])
+            try:
+                return float(msg.data["percent"])
+            except Exception as e:
+                LOG.warning(f"failed to parse volume percent: {e}")
+                return 1.0
         return 1.0
 
     @Volume.setter

--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -313,6 +313,11 @@ class OCPMediaCatalog(OVOSCommonPlaybackSkill):
         media_types = message.data.get("media_types") or \
                       message.data.get("media_type") or \
                       [MediaType.GENERIC]
+        if not isinstance(media_types, (list, tuple)):
+            # a skill announcing the singular "media_type" key sends a bare
+            # scalar (eg. an int); normalize to a container so downstream
+            # "in media_types" membership checks don't blow up
+            media_types = [media_types]
 
         if skill_id not in self.ocp_skills:
             LOG.debug(f"Registered {skill_id}")
@@ -710,6 +715,12 @@ class OCPMediaPlayer:
         # re-enters, and because set_player_state() calls handle_status()
         # which may itself touch player/media state.
         self._state_lock = RLock()
+        # Guards every liked_songs mutation + store() together. store() does
+        # a json.dump that iterates the dict, and handle_like/handle_unlike/
+        # play()'s play-count block all mutate it from separate bus-dispatch
+        # threads; without this a store() racing a pop() raises
+        # "dictionary changed size during iteration".
+        self._liked_songs_lock = RLock()
         # True between a stop request and the next play(). An explicit stop
         # must NOT advance the queue, but OPM backends emit END_OF_MEDIA from
         # ocp_stop(), so a stop is indistinguishable from a natural track end at
@@ -881,9 +892,10 @@ class OCPMediaPlayer:
         title = message.data.get("title") or self.now_playing.title
         image = message.data.get("image") or message.data.get("thumbnail") or self.now_playing.image
         artist = message.data.get("artist") or self.now_playing.artist
-        self.media.liked_songs[uri] = {"title": title, "artist": artist,
-                                       "image": image, "uri": uri}
-        self.media.liked_songs.store()
+        with self._liked_songs_lock:
+            self.media.liked_songs[uri] = {"title": title, "artist": artist,
+                                           "image": image, "uri": uri}
+            self.media.liked_songs.store()
         LOG.info(f"liked song: {uri}")
         self._update_gui()
         self.bus.emit(message.forward("mycroft.audio.play_sound",
@@ -893,10 +905,11 @@ class OCPMediaPlayer:
     def handle_unlike(self, message):
         # sent from GUI or intent
         uri = message.data.get("uri") or self.now_playing.original_uri
-        if uri in self.media.liked_songs:
-            self.media.liked_songs.pop(uri)
-            self.media.liked_songs.store()
-            LOG.info(f"unliked song: {uri}")
+        with self._liked_songs_lock:
+            if uri in self.media.liked_songs:
+                self.media.liked_songs.pop(uri)
+                self.media.liked_songs.store()
+                LOG.info(f"unliked song: {uri}")
 
     # This and service.py's MediaService.handle_search_start both
     # registered on 'ovos.common_play.search.start' unconditionally, so a
@@ -1401,14 +1414,15 @@ class OCPMediaPlayer:
                                   f"backend on playback-type switch: {e}")
                 svc.current = None
 
-        # track play count - fetch the entry once rather than check-then-index;
-        # handle_unlike() can pop this uri between the two on another bus
-        # dispatch thread, and mutating an entry that got concurrently
-        # popped is harmless, so no lock is needed
-        entry = self.media.liked_songs.get(self.now_playing.uri)
-        if entry is not None:
-            entry["play_count"] = entry.get("play_count", 0) + 1
-            self.media.liked_songs.store()
+        # track play count - store() does a json.dump that iterates the
+        # dict, and handle_like()/handle_unlike() can mutate it concurrently
+        # from another bus-dispatch thread, so every mutation+store goes
+        # through _liked_songs_lock to serialize access to the dict.
+        with self._liked_songs_lock:
+            entry = self.media.liked_songs.get(self.now_playing.uri)
+            if entry is not None:
+                entry["play_count"] = entry.get("play_count", 0) + 1
+                self.media.liked_songs.store()
 
         # validate new stream
         if not self.validate_stream():
@@ -2158,7 +2172,7 @@ class OCPMediaPlayer:
                 # dict2entry() only turns a dict into a nested Playlist when
                 # it carries a truthy "playlist" key - recurse into that
                 # list of raw (also unsanitized) member dicts too.
-                if member.get("playlist"):
+                if isinstance(member.get("playlist"), list):
                     OCPMediaPlayer._sanitize_raw_playlist_dicts(
                         member["playlist"], visited)
 
@@ -2182,7 +2196,7 @@ class OCPMediaPlayer:
                 for field in ("length", "position"):
                     if field in member and not is_real_number(member[field]):
                         member[field] = 0
-                if member.get("playlist"):
+                if isinstance(member.get("playlist"), list):
                     OCPMediaPlayer._sanitize_raw_playlist_dicts(
                         member["playlist"], visited)
 

--- a/ovos_media/utils.py
+++ b/ovos_media/utils.py
@@ -40,12 +40,19 @@ def is_real_number(value) -> bool:
 def is_injection_char(c: str) -> bool:
     """True for a character that acts as a newline/format-injection
     surface in log viewers or HTTP stacks: C0/C1 controls (category Cc,
-    also covering the historical ``< 0x20`` and ``0x7f`` checks), format
-    chars like zero-width/bidi overrides (Cf), and the Unicode line/
-    paragraph separators U+2028/U+2029 (Zl/Zp) - all of which act as
-    newline-equivalents even though they aren't ASCII control characters.
+    also covering the historical ``< 0x20`` and ``0x7f`` checks) and the
+    Unicode line/paragraph separators U+2028/U+2029 (Zl/Zp) - all of which
+    act as newline-equivalents even though they aren't ASCII control
+    characters.
+
+    Format chars (Cf: soft hyphen U+00AD, zero-width joiner U+200D, BOM
+    U+FEFF, bidi overrides, ...) are deliberately NOT rejected here - they
+    show up in legitimate real-world filenames, and rejecting them refused
+    playback of real local files. Bidi/zero-width spoofing via Cf is
+    cosmetic, not a newline-equivalent, and isn't worth breaking those
+    files over.
     """
-    return unicodedata.category(c) in ("Cc", "Cf", "Zl", "Zp")
+    return unicodedata.category(c) in ("Cc", "Zl", "Zp")
 
 
 def require_default_session():

--- a/test/unittests/test_catalog_now_playing_intents.py
+++ b/test/unittests/test_catalog_now_playing_intents.py
@@ -432,5 +432,52 @@ class TestConstructsWithoutAhocorasickNer(unittest.TestCase):
             self.assertIn("playlist_name", labels)
 
 
+class TestSkillAnnounceMediaTypesNormalization(unittest.TestCase):
+    """D2: a skill announcing with the singular "media_type" key can send
+    a bare scalar (eg. an int), which used to be stored as-is and blow up
+    get_featured_skills()'s "in media_types" membership checks."""
+
+    def _announce(self, catalog, bus, **data):
+        bus.emit(Message("ovos.common_play.announce", data))
+
+    def test_singular_int_media_type_is_featured_and_does_not_raise(self):
+        bus = FakeBus()
+        catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+        self._announce(catalog, bus,
+                       skill_id="skill.a", skill_name="A",
+                       featured_tracks=["t1"],
+                       media_type=int(MediaType.MUSIC))
+
+        skills = catalog.get_featured_skills()  # must not raise
+
+        self.assertEqual(len(skills), 1)
+        self.assertEqual(skills[0]["skill_id"], "skill.a")
+
+    def test_plural_list_media_types_still_works(self):
+        bus = FakeBus()
+        catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+        self._announce(catalog, bus,
+                       skill_id="skill.b", skill_name="B",
+                       featured_tracks=["t1"],
+                       media_types=[MediaType.MUSIC])
+
+        skills = catalog.get_featured_skills()
+
+        self.assertEqual(len(skills), 1)
+        self.assertEqual(skills[0]["skill_id"], "skill.b")
+
+    def test_adult_singular_media_type_is_filtered_out(self):
+        bus = FakeBus()
+        catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+        self._announce(catalog, bus,
+                       skill_id="skill.c", skill_name="C",
+                       featured_tracks=["t1"],
+                       media_type=int(MediaType.ADULT))
+
+        skills = catalog.get_featured_skills()  # must not raise
+
+        self.assertEqual(skills, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unittests/test_lifecycle_hygiene.py
+++ b/test/unittests/test_lifecycle_hygiene.py
@@ -6,6 +6,7 @@ L2 - a malformed liked-songs store entry crashed daemon startup.
 L3 - liking with nothing playing persisted an empty-string store entry.
 L4 - opm.audio.query was bound before self.ocp existed.
 """
+import threading
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -184,6 +185,7 @@ class TestL3EmptyLikeGuarded(unittest.TestCase):
         p.media.liked_songs = _FakeStore()
         p.media.speak_dialog = MagicMock()
         p._update_gui = MagicMock()
+        p._liked_songs_lock = threading.RLock()
         return p
 
     def test_like_with_nothing_playing_does_not_store_empty_key(self):

--- a/test/unittests/test_media_backends.py
+++ b/test/unittests/test_media_backends.py
@@ -1179,5 +1179,42 @@ class TestPauseResumeRealTemplateIntegration(unittest.TestCase):
         self.assertFalse(b.paused)  # toggled exactly once -> unpaused
 
 
+class _RaisingUrisBackend(_FakeBackend):
+    """A backend whose supported_uris() always raises - simulates a
+    misbehaving plugin at runtime (not load time)."""
+
+    def supported_uris(self):
+        raise RuntimeError("boom")
+
+
+class TestSupportedUrisExceptionIsolation(unittest.TestCase):
+    """D1: a plugin raising from supported_uris() must not kill
+    available_backends() or abort backend selection in _play() before
+    healthy backends are tried."""
+
+    def test_available_backends_skips_raising_backend(self):
+        good = _FakeBackend({"name": "good", "uris": ["http"]}, None)
+        bad = _RaisingUrisBackend({"name": "bad"}, None)
+        svc, _bus = _make_base_svc(services=[bad, good])
+
+        data = svc.available_backends()
+
+        self.assertIn("good", data)
+        self.assertEqual(data["good"]["supported_uris"], ["http"])
+        self.assertIn("bad", data)
+        self.assertEqual(data["bad"]["supported_uris"], [])
+
+    def test_play_selects_good_backend_after_raising_one(self):
+        good = _FakeBackend({"name": "good", "uris": ["http"]}, None)
+        good.load_track = MagicMock()
+        bad = _RaisingUrisBackend({"name": "bad"}, None)
+        svc, _bus = _make_base_svc(services=[bad, good])
+
+        svc._play("http://example.com/track.mp3")
+
+        self.assertIs(svc.current, good)
+        good.load_track.assert_called_once_with("http://example.com/track.mp3")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unittests/test_mpris.py
+++ b/test/unittests/test_mpris.py
@@ -443,6 +443,43 @@ class TestMetadata(unittest.TestCase):
         self.assertIn("xesam:url", result)
 
 
+class TestVolumeGetter(unittest.TestCase):
+    """D3: Volume must never raise: the wait_for_response bus reply is
+    unvalidated (missing/None/non-numeric "percent"), and a failing
+    property getter kills Properties.GetAll for the whole Player interface,
+    the same failure class the Metadata/Position guards prevent."""
+
+    def _msg(self, data):
+        m = MagicMock()
+        m.data = data
+        return m
+
+    def test_missing_percent_key_returns_default(self):
+        iface, player = _make_interface()
+        player.bus.wait_for_response.return_value = self._msg({})
+        self.assertEqual(iface.Volume, 1.0)
+
+    def test_none_percent_returns_default(self):
+        iface, player = _make_interface()
+        player.bus.wait_for_response.return_value = self._msg({"percent": None})
+        self.assertEqual(iface.Volume, 1.0)
+
+    def test_non_numeric_percent_returns_default(self):
+        iface, player = _make_interface()
+        player.bus.wait_for_response.return_value = self._msg({"percent": "loud"})
+        self.assertEqual(iface.Volume, 1.0)
+
+    def test_no_response_returns_default(self):
+        iface, player = _make_interface()
+        player.bus.wait_for_response.return_value = None
+        self.assertEqual(iface.Volume, 1.0)
+
+    def test_valid_percent_returns_value(self):
+        iface, player = _make_interface()
+        player.bus.wait_for_response.return_value = self._msg({"percent": 0.7})
+        self.assertEqual(iface.Volume, 0.7)
+
+
 class TestPlaybackStatus(unittest.TestCase):
     """PlaybackStatus must return the right MPRIS string for each PlayerState."""
 

--- a/test/unittests/test_player_coverage.py
+++ b/test/unittests/test_player_coverage.py
@@ -346,6 +346,18 @@ class TestNowPlayingInit(unittest.TestCase):
         np.extract_stream()  # must not raise
         self.assertEqual(np.uri, "http://example.com/song.mp3")
 
+    def test_extract_stream_soft_hyphen_and_zwj_uri_still_passes(self):
+        # D5: U+00AD (SOFT HYPHEN) and U+200D (ZERO WIDTH JOINER) are
+        # category Cf and appear in real-world filenames - a file:// uri
+        # containing them must be accepted, not refused as "injection".
+        uri = "file:///music/so­ft‍join.mp3"
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.stream_xtract = MagicMock()
+        np.stream_xtract.extract_stream.return_value = {"uri": uri}
+        np.extract_stream()  # must not raise
+        self.assertEqual(np.uri, uri)
+
     def test_on_invalid_stream_after_bad_extract_does_not_raise(self):
         p = _make_player()
         np, _ = self._make_now_playing()

--- a/test/unittests/test_player_coverage2.py
+++ b/test/unittests/test_player_coverage2.py
@@ -241,6 +241,70 @@ class TestPlayerPlayWithLikedSongs(unittest.TestCase):
         liked_songs.store.assert_not_called()
 
 
+class _LockProbe:
+    """Records acquire()/release() calls, standing in for an RLock so a
+    test can assert a critical section actually took the lock."""
+
+    def __init__(self):
+        self.acquire_count = 0
+        self.release_count = 0
+
+    def __enter__(self):
+        self.acquire_count += 1
+        return self
+
+    def __exit__(self, *exc):
+        self.release_count += 1
+        return False
+
+
+class TestLikedSongsLockSerialization(unittest.TestCase):
+    """D4: liked_songs.store() (json.dump) iterates the dict while
+    handle_like/handle_unlike/play()'s play-count block can mutate it from
+    other bus-dispatch threads - all three sites must go through the same
+    _liked_songs_lock. Fails on the old code because the lock attribute
+    doesn't exist / isn't held around these sites."""
+
+    def test_play_play_count_block_holds_liked_songs_lock(self):
+        p = _make_player()
+        p.now_playing.uri = "http://liked.mp3"
+        liked_songs_mock = MagicMock()
+        liked_songs_dict = {"http://liked.mp3": {"title": "Liked"}}
+        liked_songs_mock.__getitem__.side_effect = liked_songs_dict.__getitem__
+        liked_songs_mock.__setitem__.side_effect = liked_songs_dict.__setitem__
+        liked_songs_mock.__contains__.side_effect = liked_songs_dict.__contains__
+        liked_songs_mock.get.side_effect = liked_songs_dict.get
+        p.media.liked_songs = liked_songs_mock
+
+        probe = _LockProbe()
+        p._liked_songs_lock = probe
+
+        with patch.object(p, "validate_stream", return_value=True), \
+             patch.object(p, "set_player_state"), \
+             patch.object(p, "_update_gui"):
+            p.play()
+
+        self.assertGreaterEqual(probe.acquire_count, 1)
+        self.assertEqual(probe.acquire_count, probe.release_count)
+        liked_songs_mock.store.assert_called_once()
+
+    def test_handle_unlike_holds_liked_songs_lock(self):
+        p = _make_player()
+        p.media.liked_songs = MagicMock()
+        p.media.liked_songs.__contains__ = MagicMock(return_value=True)
+
+        probe = _LockProbe()
+        p._liked_songs_lock = probe
+
+        from ovos_bus_client.message import Message
+        p.handle_unlike(Message("ovos.common_play.unlike", {"uri": "http://liked.mp3"}))
+
+        self.assertGreaterEqual(probe.acquire_count, 1)
+        self.assertEqual(probe.acquire_count, probe.release_count)
+        p.media.liked_songs.pop.assert_called_once()
+        p.media.liked_songs.store.assert_called_once()
+
+
 class TestPlayerValidateStreamException(unittest.TestCase):
     """Test validate_stream with extraction exception."""
 

--- a/test/unittests/test_shuffle_mpris_playlist_validation.py
+++ b/test/unittests/test_shuffle_mpris_playlist_validation.py
@@ -268,6 +268,46 @@ class TestPlaylistSetValidatesBeforeClearing(unittest.TestCase):
         self.assertNotEqual(total, float("inf"))
         p.shutdown()
 
+    def test_non_list_playlist_key_on_raw_dict_member_is_left_untouched_not_discarded(self):
+        # D6: `if member.get("playlist"):` used to recurse into ANY truthy
+        # value - a non-list (eg. an int) raised a TypeError from the outer
+        # per-track try/except in _validated_entries, discarding the WHOLE
+        # top-level entry. Sanitizing is meant to leave non-list values
+        # alone, not lose data.
+        from ovos_media.player import OCPMediaPlayer
+        from ovos_utils.ocp import Playlist as OcpPlaylist
+
+        bus, p = _player()
+        outer = OcpPlaylist(title="outer")
+        list.append(outer, {"uri": "file://y.mp3", "length": "garbage",
+                            "playlist": 5})
+
+        entries = OCPMediaPlayer._validated_entries([outer])
+        self.assertEqual(len(entries), 1)  # entry survives, not discarded
+        result = entries[0]
+        raw_member = list.__getitem__(result, 0)
+        self.assertEqual(raw_member["playlist"], 5)  # left untouched
+        self.assertEqual(raw_member["length"], 0)  # still coerced
+        p.shutdown()
+
+    def test_list_playlist_key_on_raw_dict_member_still_recursed(self):
+        # control: a real list under "playlist" must still be recursed and
+        # sanitized, same as before D6.
+        from ovos_media.player import OCPMediaPlayer
+        from ovos_utils.ocp import Playlist as OcpPlaylist
+
+        bus, p = _player()
+        outer = OcpPlaylist(title="outer")
+        list.append(outer, {"uri": "file://y.mp3",
+                            "playlist": [{"uri": "file://z.mp3", "length": "garbage"}]})
+
+        entries = OCPMediaPlayer._validated_entries([outer])
+        result = entries[0]
+        raw_member = list.__getitem__(result, 0)
+        nested_member = raw_member["playlist"][0]
+        self.assertEqual(nested_member["length"], 0)  # recursed and sanitized
+        p.shutdown()
+
     def test_self_referential_playlist_does_not_recurse_forever(self):
         from ovos_media.player import OCPMediaPlayer
         from ovos_utils.ocp import Playlist as OcpPlaylist


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Backend plugin failures were isolated at load time but not at runtime: available_backends() and _play()'s backend-selection logic called each plugin's supported_uris() bare, so one plugin raising there crashed the list_backends reply (leaving bus callers waiting on a response that never comes) and aborted playback selection before healthy backends later in the list were ever tried. All four call sites now go through a guarded helper that logs the failure and treats the plugin as supporting nothing, matching the per-plugin isolation the loader already had. In the same spirit of one-bad-actor containment, a skill announcing itself with the singular media_type key (a bare int, rather than the plural list) was stored unwrapped, and the membership checks in get_featured_skills() then raised TypeError — hiding every featured skill, including correctly-announced ones. The value is now normalized to a list on ingestion.

The MPRIS Volume getter parsed float(msg.data["percent"]) from an unvalidated bus response, so a missing key, a None, or a non-numeric string raised inside the property getter — and a failing getter takes down Properties.GetAll for the entire Player interface, the same failure class the Metadata and Position guards exist for. It now falls back to full volume with a warning. The liked-songs store needed a real lock after all: store() runs a json.dump that iterates the dict, while like, unlike, and the play-count update all mutate the same dict from separate bus-dispatch threads — a store racing a pop raises "dictionary changed size during iteration" out of play(), aborting playback startup for that track. Every liked-songs mutation-plus-store now serializes through a dedicated lock.

Two calibration fixes to recent hardening. The stream-uri injection check rejected all of Unicode category Cf, which includes soft hyphens, zero-width joiners, and BOMs — characters that occur in real-world filenames — so legitimate local files became unplayable. The rejected set is now Cc, Zl, and Zp, which still covers every newline-equivalent the check exists to catch, while bidi and zero-width spoofing is a cosmetic concern not worth refusing real files over. And the nested-playlist sanitizer recursed into any truthy "playlist" value; a non-list there raised TypeError, which the outer per-entry guard handled by discarding the whole entry — data loss where the design intent is to sanitize and keep. Recursion now happens only into actual lists.

Fifteen regression tests were added across the existing test files, all verified to fail with the source changes reverted via patch (propagating RuntimeError from backend listing and selection, TypeError from featured skills, unguarded Volume conversions, absent lock serialization, rejected legitimate filenames, and the discarded playlist entry). Gate on the rebased branch: 745 unit tests (730 baseline + 15 new) and 64 end-to-end tests green.
