### PR TITLE
fix: guard preferred-backend matching and validate play_media payloads before mutation

### DIFF
--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -1272,8 +1272,13 @@ class OCPMediaPlayer:
             return None
         for name in preferred_names:
             for backend in media_service.services:
-                if backend.name == name or name in getattr(backend, "aliases", []):
-                    return backend
+                try:
+                    if backend.name == name or name in getattr(backend, "aliases", []):
+                        return backend
+                except Exception as e:
+                    LOG.exception(f"Failed to check backend {backend} against "
+                                  f"preferred name {name!r}: {e}")
+                    continue
         return None
 
     # stream handling
@@ -1363,7 +1368,12 @@ class OCPMediaPlayer:
         @param playlist: list of tracks in the current playlist
         """
         if isinstance(track, dict):
-            track = MediaEntry.from_dict(track)
+            try:
+                track = MediaEntry.from_dict(track)
+            except Exception as e:
+                LOG.warning(f"Ignoring play request, track can not be "
+                            f"represented as a valid media entry: {e}")
+                return
             LOG.debug(f"deserialized: {track}")
 
         if isinstance(track, Playlist):
@@ -1389,11 +1399,14 @@ class OCPMediaPlayer:
                 LOG.exception(f"Failed to speak no.playback.backend dialog: {e}")
 
         if disambiguation:
-            self.media.search_playlist.replace([t for t in disambiguation
+            valid_disambiguation = self._validated_entries(disambiguation)
+            self.media.search_playlist.replace([t for t in valid_disambiguation
                                                 if t not in self.media.search_playlist])
             self.media.search_playlist.sort_by_conf()
         if playlist:
-            self.playlist.replace(playlist)
+            valid_playlist = self._validated_entries(playlist)
+            if valid_playlist:
+                self.playlist.replace(valid_playlist)
         if track in self.playlist:
             self.playlist.goto_track(track)
         self.set_now_playing(track)

--- a/test/unittests/test_player_play_media_validation.py
+++ b/test/unittests/test_player_play_media_validation.py
@@ -1,0 +1,140 @@
+"""Tests that play_media validates disambiguation/playlist/track payloads
+before mutating any playlist state, instead of letting a malformed
+skill/bus-supplied entry raise mid-mutation."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import (
+    PlayerState, MediaState, LoopState, PlaybackType, MediaEntry, Playlist,
+)
+
+
+def _make_player():
+    from ovos_media.player import OCPMediaPlayer
+
+    with patch("ovos_media.player.AudioService"), \
+         patch("ovos_media.player.VideoService"), \
+         patch("ovos_media.player.WebService"), \
+         patch("ovos_media.player.OcpMprisExporter"), \
+         patch("ovos_media.player.GUIInterface"), \
+         patch("ovos_media.player.Configuration", return_value={"media": {}}), \
+         patch("ovos_media.player.OCPMediaCatalog"):
+        p = OCPMediaPlayer.__new__(OCPMediaPlayer)
+        p._init_runtime_state()
+        p.ocp_config = {}
+        p.state = PlayerState.STOPPED
+        p.loop_state = LoopState.NONE
+        p.media_state = MediaState.NO_MEDIA
+        p.shuffle = False
+        p.track_history = {}
+        p._paused_on_duck = False
+        p.now_playing = MagicMock()
+        p.now_playing.playback = PlaybackType.AUDIO
+        p.playlist = Playlist()
+        p.media = MagicMock()
+        p.media.search_playlist = Playlist()
+        p.audio_service = MagicMock()
+        p.video_service = MagicMock()
+        p.web_service = MagicMock()
+        p.current = None
+        p.mpris = None
+        p._no_backend_dialog_spoken = True
+        p.bus = FakeBus()
+        p.gui = MagicMock()
+    return p
+
+
+VALID_TRACK = {"uri": "http://example.com/a.mp3", "title": "A"}
+VALID_TRACK_2 = {"uri": "http://example.com/b.mp3", "title": "B"}
+NO_URI_TRACK = {"title": "no uri"}
+
+
+class TestPlayMediaValidatesDisambiguation(unittest.TestCase):
+
+    def test_invalid_entry_dropped_valid_entry_kept_no_crash(self):
+        p = _make_player()
+        p.set_now_playing = MagicMock()
+        p.play = MagicMock()
+
+        p.play_media(VALID_TRACK, disambiguation=[VALID_TRACK, NO_URI_TRACK])
+
+        uris = [e.uri for e in p.media.search_playlist.entries]
+        self.assertEqual(uris, [VALID_TRACK["uri"]])
+        p.play.assert_called_once()
+
+    def test_all_invalid_entries_leave_search_playlist_empty(self):
+        p = _make_player()
+        p.set_now_playing = MagicMock()
+        p.play = MagicMock()
+
+        p.play_media(VALID_TRACK, disambiguation=[None, 42, "str"])
+
+        self.assertEqual(len(p.media.search_playlist.entries), 0)
+        p.play.assert_called_once()
+
+
+class TestPlayMediaValidatesPlaylist(unittest.TestCase):
+
+    def test_invalid_playlist_entries_do_not_raise_and_are_dropped(self):
+        p = _make_player()
+        p.set_now_playing = MagicMock()
+        p.play = MagicMock()
+
+        p.play_media(VALID_TRACK, playlist=[VALID_TRACK, NO_URI_TRACK])
+
+        uris = [e.uri for e in p.playlist.entries]
+        self.assertEqual(uris, [VALID_TRACK["uri"]])
+
+    def test_fully_invalid_playlist_leaves_prior_playlist_untouched(self):
+        p = _make_player()
+        p.playlist.add_entry(MediaEntry.from_dict(VALID_TRACK_2))
+        p.set_now_playing = MagicMock()
+        p.play = MagicMock()
+
+        p.play_media(VALID_TRACK, playlist=[None, 42, "str"])
+
+        uris = [e.uri for e in p.playlist.entries]
+        self.assertEqual(uris, [VALID_TRACK_2["uri"]])
+
+
+class TestPlayMediaValidatesTrack(unittest.TestCase):
+
+    def test_malformed_track_returns_without_mutating_or_playing(self):
+        p = _make_player()
+        p.playlist.add_entry(MediaEntry.from_dict(VALID_TRACK_2))
+        p.media.search_playlist.add_entry(MediaEntry.from_dict(VALID_TRACK_2))
+        p.set_now_playing = MagicMock()
+        p.play = MagicMock()
+
+        p.play_media(NO_URI_TRACK, disambiguation=[VALID_TRACK],
+                     playlist=[VALID_TRACK])
+
+        self.assertEqual([e.uri for e in p.playlist.entries],
+                         [VALID_TRACK_2["uri"]])
+        self.assertEqual([e.uri for e in p.media.search_playlist.entries],
+                         [VALID_TRACK_2["uri"]])
+        p.set_now_playing.assert_not_called()
+        p.play.assert_not_called()
+
+
+class TestPlayMediaValidPayloadStillPlays(unittest.TestCase):
+
+    def test_fully_valid_payload_plays(self):
+        p = _make_player()
+        p.set_now_playing = MagicMock()
+        p.play = MagicMock()
+
+        p.play_media(VALID_TRACK, disambiguation=[VALID_TRACK],
+                     playlist=[VALID_TRACK])
+
+        p.set_now_playing.assert_called_once()
+        p.play.assert_called_once()
+        self.assertEqual([e.uri for e in p.media.search_playlist.entries],
+                         [VALID_TRACK["uri"]])
+        self.assertEqual([e.uri for e in p.playlist.entries],
+                         [VALID_TRACK["uri"]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_player_preferred_service_resolution.py
+++ b/test/unittests/test_player_preferred_service_resolution.py
@@ -1,0 +1,80 @@
+"""Tests for OCPMediaPlayer._resolve_preferred_service resilience to
+backends whose `.name`/`.aliases` access raises."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ovos_utils.ocp import PlayerState, MediaState, LoopState, PlaybackType
+
+
+def _make_player():
+    from ovos_media.player import OCPMediaPlayer
+
+    with patch("ovos_media.player.AudioService"), \
+         patch("ovos_media.player.VideoService"), \
+         patch("ovos_media.player.WebService"), \
+         patch("ovos_media.player.OcpMprisExporter"), \
+         patch("ovos_media.player.GUIInterface"), \
+         patch("ovos_media.player.Configuration", return_value={"media": {}}), \
+         patch("ovos_media.player.OCPMediaCatalog"):
+        p = OCPMediaPlayer.__new__(OCPMediaPlayer)
+        p._init_runtime_state()
+        p.ocp_config = {}
+        p.state = PlayerState.STOPPED
+        p.loop_state = LoopState.NONE
+        p.media_state = MediaState.NO_MEDIA
+        p.shuffle = False
+        p.track_history = {}
+        p._paused_on_duck = False
+        p.now_playing = MagicMock()
+        p.now_playing.playback = PlaybackType.AUDIO
+        p.playlist = MagicMock()
+        p.media = MagicMock()
+        p.audio_service = MagicMock()
+        p.video_service = MagicMock()
+        p.web_service = MagicMock()
+        p.current = None
+        p.mpris = None
+        from ovos_utils.fakebus import FakeBus
+        p.bus = FakeBus()
+        p.gui = MagicMock()
+    return p
+
+
+class _RaisingBackend:
+    """A backend whose `.name` property raises, like a real broken plugin."""
+
+    @property
+    def name(self):
+        raise RuntimeError("backend is misconfigured")
+
+
+class _GoodBackend:
+    name = "good"
+    aliases = []
+
+
+class TestResolvePreferredServiceSkipsRaisingBackend(unittest.TestCase):
+
+    def test_resolves_good_backend_despite_raising_peer(self):
+        p = _make_player()
+        media_service = MagicMock()
+        media_service.get_preferred_players.return_value = ["good"]
+        media_service.services = [_RaisingBackend(), _GoodBackend()]
+
+        result = p._resolve_preferred_service(media_service)
+
+        self.assertIs(result, media_service.services[1])
+
+    def test_no_match_returns_none(self):
+        p = _make_player()
+        media_service = MagicMock()
+        media_service.get_preferred_players.return_value = ["nonexistent"]
+        media_service.services = [_RaisingBackend(), _GoodBackend()]
+
+        result = p._resolve_preferred_service(media_service)
+
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Preferred-backend resolution had one remaining unguarded touch of plugin code: get_preferred_players() skips a backend whose name attribute raises, but _resolve_preferred_service — which runs on every audio, video, and web playback — then does its own matching loop over the same backends and read backend.name bare. One misbehaving plugin crashed playback dispatch for everything. The comparison is now guarded per backend, logging and skipping the broken one while the rest stay matchable, which closes the last call site of this failure class.

The play request handler trusted skill-supplied payloads further than it should. The disambiguation and playlist lists arriving on ovos.common_play.play went straight into Playlist.replace and membership checks, and ovos-utils' dict2entry raises on a dict without a uri (ValueError) or on entries that aren't dicts at all (AssertionError) — the exception escaped the bus handler, and because replace() clears its target before adding, a bad entry midway left the search playlist half-mutated: cleared but only partially refilled. Both lists now pass through the existing entry-validation pathway first, so malformed members are skipped with warnings before any mutation, and an all-invalid playlist leaves the current playlist intact rather than replacing it with nothing. A track that cannot be represented as a media entry at all now logs a warning and abandons the request before touching any state, instead of raising mid-flight.

Eight regression tests were added in two new test modules, seven verified to fail with the source changes reverted via patch (the eighth is the fully-valid control). Gate on the rebased branch: 774 unit tests (766 baseline + 8 new) and 64 end-to-end tests green.
