### PR TITLE
fix: guard external-play tracks and play_media track types from crashing bus handlers

### DIFF
--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -544,8 +544,13 @@ class NowPlaying(MediaEntry):
             media = playlist[0]
         else:
             media = message.data.get("media", {})
-        if media:
-            self.update(media, newonly=False)
+        if not media:
+            return
+        if not isinstance(media, dict):
+            LOG.warning(f"ignoring '{message.msg_type}' now_playing update, "
+                        f"expected a dict track, got: {media!r}")
+            return
+        self.update(media, newonly=False)
 
     # events from media services
     def handle_track_state_change(self, message):
@@ -1379,8 +1384,16 @@ class OCPMediaPlayer:
         if isinstance(track, Playlist):
             playlist = track
             track = track[0]
-        elif not isinstance(track, MediaEntry):
-            raise TypeError(f"Expected MediaEntry, got: {track}")
+        elif not isinstance(track, (MediaEntry, PluginStream)):
+            LOG.warning(f"Ignoring play request, track can not be "
+                        f"represented as a valid media entry: {track!r}")
+            return
+        if isinstance(track, PluginStream):
+            # set_now_playing/playlist machinery only understand MediaEntry;
+            # as_media_entry maps extractor_id/stream onto uri the same way
+            # PluginStream.extract_uri does, so extract_stream() resolves it
+            # via the same stream_xtract call later on.
+            track = track.as_media_entry
 
         if self.mpris:
             self.mpris.stop()
@@ -1400,9 +1413,10 @@ class OCPMediaPlayer:
 
         if disambiguation:
             valid_disambiguation = self._validated_entries(disambiguation)
-            self.media.search_playlist.replace([t for t in valid_disambiguation
-                                                if t not in self.media.search_playlist])
-            self.media.search_playlist.sort_by_conf()
+            if valid_disambiguation:
+                self.media.search_playlist.replace([t for t in valid_disambiguation
+                                                    if t not in self.media.search_playlist])
+                self.media.search_playlist.sort_by_conf()
         if playlist:
             valid_playlist = self._validated_entries(playlist)
             if valid_playlist:

--- a/test/unittests/test_player_coverage.py
+++ b/test/unittests/test_player_coverage.py
@@ -388,6 +388,16 @@ class TestNowPlayingInit(unittest.TestCase):
         np.handle_external_play(msg)
         self.assertEqual(np.title, "Track 0")
 
+    def test_handle_external_play_old_style_tracks_non_dict_entry_ignored(self):
+        """A non-dict entry in an old-style 'tracks' list (eg. a bare str)
+        must be skipped with a warning, not raise AttributeError out of the
+        raw bus handler."""
+        np, _ = self._make_now_playing()
+        np.title = "unchanged"
+        msg = Message("ovos.common_play.play", {"tracks": ["not-a-dict"]})
+        np.handle_external_play(msg)  # must not raise
+        self.assertEqual(np.title, "unchanged")
+
     def test_handle_track_state_change_updates_status(self):
         np, _ = self._make_now_playing()
         msg = Message("ovos.common_play.track.state",
@@ -884,10 +894,15 @@ class TestPlayMedia(unittest.TestCase):
         p.play_media(track_dict)
         p.play.assert_called_once()
 
-    def test_play_media_raises_on_invalid_type(self):
+    def test_play_media_invalid_type_warns_and_returns_without_raising(self):
+        # play_media is bus-facing; an unrepresentable track type must not
+        # raise out of the handler, just be logged and skipped.
         p = _make_player()
-        with self.assertRaises(TypeError):
-            p.play_media(12345)
+        p.set_now_playing = MagicMock()
+        p.play = MagicMock()
+        p.play_media(12345)  # must not raise
+        p.set_now_playing.assert_not_called()
+        p.play.assert_not_called()
 
     def test_play_media_stops_mpris(self):
         p = _make_player(PlaybackType.AUDIO)

--- a/test/unittests/test_player_play_media_validation.py
+++ b/test/unittests/test_player_play_media_validation.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.ocp import (
     PlayerState, MediaState, LoopState, PlaybackType, MediaEntry, Playlist,
+    PluginStream,
 )
 
 
@@ -134,6 +135,54 @@ class TestPlayMediaValidPayloadStillPlays(unittest.TestCase):
                          [VALID_TRACK["uri"]])
         self.assertEqual([e.uri for e in p.playlist.entries],
                          [VALID_TRACK["uri"]])
+
+
+class TestPlayMediaAcceptsPluginStream(unittest.TestCase):
+
+    def test_plugin_stream_shaped_track_reaches_set_now_playing(self):
+        """A valid PluginStream-shaped dict (extractor_id+stream, no uri) is
+        deserialized by MediaEntry.from_dict's dict2entry fallback into a
+        PluginStream, which is a legitimate single-track play request and
+        must not raise."""
+        p = _make_player()
+        p.set_now_playing = MagicMock()
+        p.play = MagicMock()
+
+        track = {"extractor_id": "ocp_youtube", "stream": "abc123",
+                 "title": "Plugin Track"}
+        p.play_media(track)  # must not raise
+
+        p.set_now_playing.assert_called_once()
+        played = p.set_now_playing.call_args[0][0]
+        self.assertIsInstance(played, MediaEntry)
+        p.play.assert_called_once()
+
+    def test_unrepresentable_track_warns_and_returns_without_mutation(self):
+        p = _make_player()
+        p.playlist.add_entry(MediaEntry.from_dict(VALID_TRACK_2))
+        p.set_now_playing = MagicMock()
+        p.play = MagicMock()
+
+        p.play_media(42)  # not a dict, MediaEntry, or PluginStream
+
+        p.set_now_playing.assert_not_called()
+        p.play.assert_not_called()
+        self.assertEqual([e.uri for e in p.playlist.entries],
+                         [VALID_TRACK_2["uri"]])
+
+
+class TestPlayMediaAllInvalidDisambiguationKeepsPriorResults(unittest.TestCase):
+
+    def test_all_invalid_disambiguation_leaves_prior_search_playlist_intact(self):
+        p = _make_player()
+        p.media.search_playlist.add_entry(MediaEntry.from_dict(VALID_TRACK_2))
+        p.set_now_playing = MagicMock()
+        p.play = MagicMock()
+
+        p.play_media(VALID_TRACK, disambiguation=[None, 42, "str"])
+
+        self.assertEqual([e.uri for e in p.media.search_playlist.entries],
+                         [VALID_TRACK_2["uri"]])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

handle_external_play was the one bus ingestion point still trusting its payload shape. The backwards-compatible "tracks" branch took the first list element and passed it straight into NowPlaying.update(), which iterates entry.items() — so a single non-dict element (a string, a number) raised AttributeError out of the raw ovos.common_play.play subscription, which has no wrapping framework to catch it. The handler now accepts only dict tracks and logs what it skipped, the same contract every other ingestion path already enforces.

play_media's single-track gate had two problems. A track dict without a uri but with extractor_id and stream — a plugin-stream, which the plural playlist and disambiguation entry points already accept as valid — deserialized into a PluginStream and then hit the strict MediaEntry isinstance check, crashing a legitimate play request with TypeError. And that TypeError was a raise out of a bus-facing path in the first place. The gate now accepts PluginStream and converts it through ovos-utils' own as_media_entry (the same extractor mapping the stream-extraction step resolves later), because the downstream now-playing machinery only understands MediaEntry — widening the gate alone would just have moved the crash one call further. Anything genuinely unrepresentable now logs a warning and abandons the request without mutation instead of raising. One existing test pinned the raise itself and was rewritten to assert the new warn-and-return behavior.

The disambiguation branch also gains the guard its playlist sibling already had: an all-invalid disambiguation list previously still called replace() and wiped whatever valid search results the player held; it now leaves the search playlist intact, consistent with the playlist path.

Four regression tests were added, all verified to fail with the source changes reverted via patch (the AttributeError from the raw handler, the TypeError and the moved ValueError from the track gate, and the disambiguation wipe). Gate on the rebased branch: 778 unit tests (774 baseline + 4 new, one pin rewritten in place) and 64 end-to-end tests green.
