### PR TITLE
fix: seed mpris signal-created meta with identity and always register the empty song_name keyword fallback

### DIFF
--- a/ovos_media/mpris.py
+++ b/ovos_media/mpris.py
@@ -160,7 +160,7 @@ class OcpMprisExporter(Thread):
             self._ocp_player.playback_type = PlaybackType.MPRIS
 
             # update ocp metadata
-            data["skill_id"] = data["external_player"]
+            data["skill_id"] = data.get("external_player") or self.main_player
             data["bg_image"] = data.get("image") or data.get("thumbnail")
             data["playback"] = PlaybackType.MPRIS
             data["status"] = TrackState.PLAYING_MPRIS
@@ -483,7 +483,7 @@ class OcpMprisExporter(Thread):
                 player_name = properties.bus_name
                 if player_name in self.ignored_players:
                     continue
-                meta = self.player_meta.setdefault(player_name, {})
+                meta = self.player_meta.setdefault(player_name, {"external_player": player_name})
                 if changed == "PlaybackStatus":
                     await self.handle_player_state(variant.value)
                     state = meta.get("state")

--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -147,8 +147,6 @@ class OCPMediaCatalog(OVOSCommonPlaybackSkill):
         Used as a fallback when ahocorasick_ner is not installed.
         """
         samples = list(set(samples))
-        if not samples:
-            return
         for lang in self.native_langs:
             if len(samples) >= 20:
                 csv_path = f"{self.ocp_cache_dir}/{self.skill_id}_{label}_{lang}.csv"

--- a/test/unittests/test_catalog_now_playing_intents.py
+++ b/test/unittests/test_catalog_now_playing_intents.py
@@ -431,6 +431,28 @@ class TestConstructsWithoutAhocorasickNer(unittest.TestCase):
             labels = {r["label"] for r in registered}
             self.assertIn("playlist_name", labels)
 
+    def test_song_name_label_registers_even_with_no_liked_songs(self):
+        """register_ocp_keyword (the real, NER-backed path) always emits
+        'ovos.common_play.register_keyword' regardless of sample count - the
+        classifier still needs to know the "song_name" label exists even
+        when the liked-songs store is empty. The fallback used when
+        ahocorasick_ner is missing must mirror that: a fresh install with no
+        liked songs must still register the song_name label with an empty
+        samples list, not silently skip it."""
+        with patch("ovos_workshop.skills.common_play.AhocorasickNER", None):
+            bus = FakeBus()
+            registered = []
+            bus.on("ovos.common_play.register_keyword",
+                  lambda m: registered.append(m.data))
+
+            OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+
+            song_name_msgs = [r for r in registered if r["label"] == "song_name"]
+            self.assertEqual(len(song_name_msgs), 1)
+            self.assertEqual(song_name_msgs[0]["samples"], [])
+            self.assertEqual(set(song_name_msgs[0].keys()),
+                              {"skill_id", "label", "samples", "media_type"})
+
 
 class TestSkillAnnounceMediaTypesNormalization(unittest.TestCase):
     """D2: a skill announcing with the singular "media_type" key can send

--- a/test/unittests/test_mpris_properties_changed_missing_meta.py
+++ b/test/unittests/test_mpris_properties_changed_missing_meta.py
@@ -103,3 +103,45 @@ class TestPropertiesChangedBeforeMetaExists(unittest.IsolatedAsyncioTestCase):
                         {"PlaybackStatus": _Variant("Playing")}, [])
 
         self.assertEqual(ctl.player_meta[name]["state"], "Playing")
+
+
+class TestOcpUpdateWithManagedPlayersAndMissingMeta(unittest.IsolatedAsyncioTestCase):
+    """With manage_external_players enabled, a PlaybackStatus signal for an
+    unknown player must reach _update_ocp without raising, and the reflected
+    metadata must carry a usable skill_id.
+    """
+
+    async def test_playback_status_before_metadata_completes_ocp_update(self):
+        ctl, player = _make_exporter({"manage_external_players": True})
+        name = "org.mpris.MediaPlayer2.mpv"
+        callback = _register_handler(ctl, name)
+        self.assertNotIn(name, ctl.player_meta)
+
+        # unknown player -> no crash reaching _update_ocp, half-mutated OCP
+        # state must still finish with a real skill_id
+        await callback("org.mpris.MediaPlayer2.Player",
+                        {"PlaybackStatus": _Variant("Playing")}, [])
+
+        self.assertEqual(ctl.main_player, name)
+        self.assertIn(name, ctl.player_meta)
+        self.assertEqual(ctl.player_meta[name]["skill_id"], name)
+        player.set_now_playing.assert_called()
+
+    async def test_playback_status_with_full_metadata_flows_unchanged(self):
+        ctl, player = _make_exporter({"manage_external_players": True})
+        name = "org.mpris.MediaPlayer2.mpv"
+        ctl.player_meta[name] = {
+            "external_player": name,
+            "state": "Stopped",
+            "title": "Song",
+            "artist": "Band",
+            "uri": "mpris://mpv",
+        }
+        callback = _register_handler(ctl, name)
+
+        await callback("org.mpris.MediaPlayer2.Player",
+                        {"PlaybackStatus": _Variant("Playing")}, [])
+
+        self.assertEqual(ctl.player_meta[name]["skill_id"], name)
+        self.assertEqual(ctl.player_meta[name]["title"], "Song")
+        player.set_now_playing.assert_called()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

The MPRIS PropertiesChanged callback creates a player's metadata entry on first touch when a signal arrives before the initial player query completes. That entry was created empty, which prevented the original KeyError at the signal branch but let execution continue into the OCP-side update, which hard-indexes the entry's external_player field — crashing inside the async callback only after the main player, active skill, and player state had already been committed, a worse failure shape than the one the guard removed. The setdefault now seeds the entry with its identity, and the OCP update reads the field tolerantly with the main player name as fallback, so a metadata-less entry flows through cleanly. The rest of that update path was audited for other hard-indexed optional keys; none remain.

The no-NER fallback for classifier keyword registration returned early on an empty sample list, while the real register_ocp_keyword it mirrors always emits the registration message even with no samples. A fresh install without the ner extra and with no liked songs therefore never announced the song_name label to the classifier at all — observably diverging from the with-ner path the fallback's contract promises to match. The early return is gone; the deduped (possibly empty) sample list is always emitted.

Three regression tests were added: the signal-before-query flow now runs with external-player management enabled (the configuration under which the downstream crash occurred, previously untested), plus a populated-metadata control, and the empty-liked-songs registration case. Both behavioral tests were verified to fail with the source changes reverted via patch. Gate on the rebased branch: 788 unit tests (785 baseline + 3 new) and 64 end-to-end tests green.
