### PR TITLE
refactor: single bus-edge registration layer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ The rest of this document focuses on the daemon itself.
 
 1. **`MediaService`** (`ovos_media/service.py`), the process entry point. It runs
    as a `Thread`, owns the `MessageBusClient` connection, instantiates
-   `OCPMediaPlayer`, and registers a small set of top-level bus handlers.
+   `OCPMediaPlayer`, and answers a small set of top-level bus topics.
 
 2. **`OCPMediaPlayer`** (`ovos_media/player.py`), the virtual media player. It is
    a plain bus-connected class (it is *not* a skill or an `OVOSAbstractApplication`)
@@ -62,11 +62,26 @@ The rest of this document focuses on the daemon itself.
    Each loads OPM plugins at startup and delegates actual playback to the selected
    plugin instance.
 
-Payload validation for all three layers lives in `ovos_media/bus/schemas.py`.
+Every subscription `MediaService`, `OCPMediaPlayer`, `NowPlaying` and
+`OCPMediaCatalog` make lives in the bus edge, `ovos_media/bus/api.py`.
+`OCPBusApi` holds one registration table naming, per topic, the payload decoder
+to run, whether the topic is gated to the local session, and the method to
+call. The same table drives teardown, so a shut-down daemon cannot keep
+answering a topic it registered.
+
+The backend services are the exception: each of `AudioService`,
+`VideoService` and `WebService` binds its own
+`ovos.common_play.media.state` listener in `BaseMediaService.__init__`, and the
+skill base class the catalog inherits from registers its intents and keyword
+plumbing itself. Reading the table therefore tells you what the player layer
+answers, not everything this process has bound.
+
+Payload validation for all layers lives in `ovos_media/bus/schemas.py`.
 Every rule an incoming bus payload must satisfy — numeric fields that must be
 finite, uri characters that would inject newlines into a log viewer or an HTTP
-stack downstream, track lists that must be coerced entry by entry — is a plain
-function over a raw value there, so no handler restates the numeric, uri, or track-list rules inline.
+stack downstream, track lists that must be coerced entry by entry, enum states
+that arrive as bare ints — is a plain function over a raw value there, so no
+handler restates the numeric, uri, state, or track-list rules inline.
 
 These layers communicate via the OVOS MessageBus (WebSocket pub/sub). The
 `MediaService` layer handles service-lifecycle and discovery events;
@@ -76,10 +91,12 @@ services handle low-level playback over namespaced bus events.
 ### NowPlaying
 
 `OCPMediaPlayer.now_playing` is a `NowPlaying` instance, a `MediaEntry` subclass
-that subscribes to bus events to keep the currently-playing track's metadata,
-status (`TrackState`), and seek position live. It updates on
-`ovos.common_play.track.state`, `ovos.common_play.media.state`,
-`ovos.common_play.play`, and `ovos.common_play.playback_time`. When a backend
+holding the currently-playing track's metadata, status (`TrackState`), and seek
+position. It subscribes to nothing itself: the bus edge routes
+`ovos.common_play.track.state`, `ovos.common_play.play` and
+`ovos.common_play.playback_time` to it, and the player forwards end-of-media
+from `ovos.common_play.media.state` as a plain method call so the reset cannot
+race the autoplay decision that reads it. When a backend
 confirms playback (`TrackState.PLAYING_*`), `NowPlaying` calls back into the
 player to set `PlayerState.PLAYING`; on `MediaState.END_OF_MEDIA` it resets.
 
@@ -115,7 +132,9 @@ message with no subscriber here is legal.
 
 ### OCPMediaPlayer handlers
 
-Registered in `OCPMediaPlayer.register_bus_handlers` (`ovos_media/player.py`).
+Registered by the bus edge (`ovos_media/bus/api.py`), which subscribes every
+topic in its table, decodes the payload, applies the session gate, and then
+calls the handler below.
 
 | Message type | Handler | Notes |
 | :--- | :--- | :--- |
@@ -296,7 +315,7 @@ session.
 
 `ovos-media` itself stays a **single** player bound to its own device, the
 `"default"` session. Its playback-executing handlers are gated by
-`require_default_session()` (`ovos_media/utils.py`), so a server-side daemon
+`is_default_session()` (`ovos_media/utils.py`), so a server-side daemon
 **ignores** a satellite's forwarded command (`session_id != "default"`) while
 the satellite's own embedded daemon executes it. Read-only query handlers stay
 ungated so a remote pipeline can still read state. See

--- a/docs/ocp-skills.md
+++ b/docs/ocp-skills.md
@@ -63,11 +63,11 @@ User says "play jazz"
 
 ## NowPlaying
 
-`NowPlaying` is a `MediaEntry` subclass that additionally subscribes to bus events to track live playback state. It is instantiated in `OCPMediaPlayer.__init__` and stored as `OCPMediaPlayer.now_playing`.
+`NowPlaying` is a `MediaEntry` subclass that additionally tracks live playback state. It is instantiated in `OCPMediaPlayer.__init__` and stored as `OCPMediaPlayer.now_playing`; the bus edge (`ovos_media/bus/api.py`) delivers the track-state, play and playback-time messages that update it.
 
 The `as_dict` property returns a plain `dict` with the current track's metadata fields (uri, title, artist, image, playback type, etc.). It is a property, not a method; access it as `player.now_playing.as_dict` without calling it.
 
-`NowPlaying` tracks the seek position via the `ovos.common_play.playback_time` bus event. This position is exposed through MPRIS as `Position` in microseconds, see [mpris.md](mpris.md).
+`NowPlaying` tracks the seek position from the `ovos.common_play.playback_time` bus message. This position is exposed through MPRIS as `Position` in microseconds, see [mpris.md](mpris.md).
 
 ## Writing an OCP skill
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -37,9 +37,10 @@ This mirrors how `ovos-audio` scopes TTS to native/local sources
 
 ## Implementation
 
-A `require_default_session()` decorator
-(`ovos_media/utils.py`) gates each playback-**executing** bus handler. A handler
-runs only if:
+The bus edge (`ovos_media/bus/api.py`) marks every playback-**executing**
+topic as gated in its registration table and applies
+`is_default_session()` (`ovos_media/utils.py`) before dispatching. A gated
+topic reaches its handler only if:
 
 - the message is internal/synthetic (`message is None`), **or**
 - `validate_source` is False (act on everything, see below), **or**
@@ -47,12 +48,16 @@ runs only if:
 
 Otherwise it logs at debug level and returns without acting.
 
-Gated handlers (the ones that change playback or persistent state):
+Gated topics (the ones that change playback or persistent state):
 
-| Layer | Handlers |
+| Target | Topics |
 |---|---|
-| `OCPMediaPlayer` (`player.py`) | play, pause, resume, stop, play/pause toggle, next, previous, seek, set track position, playlist set/queue/clear, shuffle set/unset/toggle, repeat set/unset/toggle, duck, cork, uncork (and unduck restore), like, unlike |
+| `OCPMediaPlayer` (`player.py`) | play, pause, resume, stop, play/pause toggle, next, previous, seek, set track position, playlist set/queue/clear, shuffle set/unset/toggle, repeat set/unset/toggle, duck, cork, uncork (and unduck restore), like, unlike, record begin/end, utterance handled |
 | `NowPlaying` (`player.py`) | `handle_external_play` (so a non-default play does not bleed metadata into the local now-playing) |
+
+`recognizer_loop:record_end` and `ovos.utterance.handled` do nothing except
+resume or unduck, both of which are gated, so the gate sits on the topic
+itself.
 
 `ovos-media` does not implement the classic `mycroft.audio.service.*` API;
 those handlers, and their session gating, live in the old ovos-audio/OCP

--- a/ovos_media/bus/api.py
+++ b/ovos_media/bus/api.py
@@ -1,0 +1,293 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Ingress edge for the player, its NowPlaying, its OCPMediaCatalog and
+MediaService: every subscription those four make is one entry in a
+registration table, and the same table drives teardown, so what is added
+and what is removed can never drift apart.
+
+An entry names the topic, an optional payload decoder from
+:mod:`ovos_media.bus.schemas`, whether the topic is gated to the local
+session, and the method to call. The wrapper built around each entry
+decodes, gates, and then calls that method synchronously — the objects
+behind the edge see only payloads that already passed both checks.
+
+The backend services (:mod:`ovos_media.media_backends`) still bind their
+own 'ovos.common_play.media.state' listener in
+``BaseMediaService.__init__``; they are not routed through this table.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Tuple
+
+from ovos_utils.log import LOG
+
+from ovos_media.bus.schemas import (decode_media, decode_media_state,
+                                    decode_playlist_tracks,
+                                    decode_seek, decode_skill_id,
+                                    decode_track_position, decode_track_state)
+from ovos_media.utils import is_default_session
+
+
+@dataclass(frozen=True)
+class BusHandler:
+    """One bus subscription.
+
+    topic: the message type to listen on.
+    target: the method called with the Message once the payload is accepted.
+    decoder: a :mod:`ovos_media.bus.schemas` function taking ``message.data``.
+        It rejects a payload by returning None or raising ValueError, and
+        the target is then not called at all.
+    gated: True when only the local/"default" session may trigger the
+        target (see :func:`ovos_media.utils.is_default_session`).
+    """
+    topic: str
+    target: Callable
+    decoder: Optional[Callable] = None
+    gated: bool = False
+
+
+class OCPBusApi:
+    """Owns every bus subscription of an ovos-media process.
+
+    An instance is built around whichever owners it is given: a player (its
+    own handlers plus those of the NowPlaying and OCPMediaCatalog it
+    created) and/or a MediaService. Registration happens on construction;
+    :meth:`shutdown` undoes exactly it.
+    """
+
+    def __init__(self, bus, player=None, service=None) -> None:
+        self.bus = bus
+        self.player = player
+        self.service = service
+        self.table: List[BusHandler] = self._build_table()
+        # (topic, wrapper) pairs actually bound on the bus
+        self._registrations: List[Tuple[str, Callable]] = []
+        self.register()
+
+    @property
+    def validate_source(self) -> bool:
+        """Whether gated topics are filtered by session at all.
+
+        A satellite whose sessions are not NAT'd to "default" sets
+        ``media.validate_source: false`` and acts on every session.
+        """
+        owner = self.player if self.player is not None else self.service
+        return getattr(owner, "validate_source", True)
+
+    def _build_table(self) -> List[BusHandler]:
+        """Build the registration table for the owners this edge was given.
+
+        Order is significant: several topics have more than one subscriber
+        and the bus dispatches them in registration order. NowPlaying's
+        'ovos.common_play.play' entry comes before the player's, matching
+        the order in which those two objects used to bind themselves.
+        """
+        table: List[BusHandler] = []
+        if self.player is not None:
+            table += self._now_playing_table(self.player.now_playing)
+            table += self._catalog_table(self.player.media)
+            table += self._player_table(self.player)
+        if self.service is not None:
+            table += self._service_table(self.service)
+        return table
+
+    @staticmethod
+    def _now_playing_table(np) -> List[BusHandler]:
+        # NowPlaying deliberately does NOT subscribe to
+        # 'ovos.common_play.media.state'. The player is the only consumer of
+        # END_OF_MEDIA on that topic (the backend services also listen, but
+        # act on LOADED_MEDIA only) and it calls NowPlaying.on_end_of_media()
+        # itself, in order, after capturing the pre-reset playback type and
+        # uri. As a second subscriber, NowPlaying had no ordering guarantee
+        # against the player and raced its own reset against the autoplay
+        # decision that reads it.
+        return [
+            BusHandler("ovos.common_play.track.state",
+                       np.handle_track_state_change,
+                       decoder=decode_track_state),
+            # a play command from a satellite session must not bleed its
+            # metadata into the local now_playing
+            BusHandler("ovos.common_play.play", np.handle_external_play,
+                       decoder=decode_media, gated=True),
+            BusHandler("ovos.common_play.playback_time",
+                       np.handle_sync_seekbar),
+        ]
+
+    @staticmethod
+    def _catalog_table(catalog) -> List[BusHandler]:
+        return [
+            BusHandler("ovos.common_play.skills.detach",
+                       catalog.handle_ocp_skill_detach,
+                       decoder=decode_skill_id),
+            BusHandler("ovos.common_play.announce",
+                       catalog.handle_skill_announce,
+                       decoder=decode_skill_id),
+        ]
+
+    @staticmethod
+    def _player_table(player) -> List[BusHandler]:
+        # NOTE: the player does NOT subscribe to its own
+        # 'ovos.common_play.player.state' event — set_player_state() is the
+        # single authoritative writer of player.state; external subscribers
+        # (MPRIS, GUI clients) may still listen on the bus.
+        #
+        # 'ovos.common_play.search.start'/'.search.end'/'.home' are
+        # pipeline-side signals (the OCP pipeline plugin uses them to drive
+        # a GUI's own loading/navigation state); this daemon has no
+        # in-process GUI and no other state to change in response to them,
+        # so none of the three is subscribed.
+        return [
+            BusHandler("ovos.common_play.media.state",
+                       player.handle_player_media_update,
+                       decoder=decode_media_state),
+            BusHandler("ovos.common_play.play", player.handle_play_request,
+                       gated=True),
+            BusHandler("ovos.common_play.pause", player.handle_pause_request,
+                       gated=True),
+            BusHandler("ovos.common_play.play_pause",
+                       player.handle_pause_toggle_request, gated=True),
+            BusHandler("ovos.common_play.resume", player.handle_resume_request,
+                       gated=True),
+            BusHandler("ovos.common_play.stop", player.handle_stop_request,
+                       gated=True),
+            BusHandler("ovos.common_play.next", player.handle_next_request,
+                       gated=True),
+            BusHandler("ovos.common_play.previous", player.handle_prev_request,
+                       gated=True),
+            BusHandler("ovos.common_play.seek", player.handle_seek_request,
+                       decoder=decode_seek, gated=True),
+            BusHandler("ovos.common_play.get_track_length",
+                       player.handle_track_length_request),
+            BusHandler("ovos.common_play.set_track_position",
+                       player.handle_set_track_position_request,
+                       decoder=decode_track_position, gated=True),
+            BusHandler("ovos.common_play.get_track_position",
+                       player.handle_track_position_request),
+            BusHandler("ovos.common_play.track_info",
+                       player.handle_track_info_request),
+            BusHandler("ovos.common_play.list_backends",
+                       player.handle_list_backends_request),
+            BusHandler("ovos.common_play.playlist.set",
+                       player.handle_playlist_set_request,
+                       decoder=decode_playlist_tracks, gated=True),
+            BusHandler("ovos.common_play.playlist.clear",
+                       player.handle_playlist_clear_request, gated=True),
+            BusHandler("ovos.common_play.playlist.queue",
+                       player.handle_playlist_queue_request,
+                       decoder=decode_playlist_tracks, gated=True),
+            BusHandler("ovos.common_play.duck", player.handle_duck_request,
+                       gated=True),
+            BusHandler("ovos.common_play.unduck", player.handle_unduck_request,
+                       gated=True),
+            BusHandler("ovos.common_play.cork", player.handle_cork_request,
+                       gated=True),
+            BusHandler("ovos.common_play.uncork", player.handle_uncork_request,
+                       gated=True),
+            # ovos-audio emits 'ovos.audio.output.started'/'.ended'
+            # unconditionally on every TTS output (ovos_audio/playback.py
+            # begin_audio/end_audio). The ovos.common_play.duck/cork
+            # messages are an alternative ducking path, only emitted when
+            # tts.ocp_duck / tts.ocp_cork are enabled in config (both
+            # default False). Binding these spec topics to the same targets
+            # keeps ducking working on default installs.
+            BusHandler("ovos.audio.output.started",
+                       player.handle_duck_request, gated=True),
+            BusHandler("ovos.audio.output.ended",
+                       player.handle_unduck_request, gated=True),
+            # mic-cork integration — no listener emits an OCP cork
+            # equivalent for the mic recording window.
+            BusHandler("recognizer_loop:record_begin",
+                       player.handle_cork_request, gated=True),
+            # record_end and utterance.handled do nothing except resume or
+            # unduck, both of which are gated, so the gate sits on the
+            # topic itself.
+            BusHandler("recognizer_loop:record_end", player.handle_record_end,
+                       gated=True),
+            BusHandler("ovos.utterance.handled",
+                       player.handle_utterance_handled, gated=True),
+            BusHandler("mycroft.stop", player.handle_mycroft_stop),
+            BusHandler("ovos.common_play.shuffle.toggle",
+                       player.handle_shuffle_toggle_request, gated=True),
+            BusHandler("ovos.common_play.shuffle.set",
+                       player.handle_set_shuffle, gated=True),
+            BusHandler("ovos.common_play.shuffle.unset",
+                       player.handle_unset_shuffle, gated=True),
+            BusHandler("ovos.common_play.repeat.toggle",
+                       player.handle_repeat_toggle_request, gated=True),
+            BusHandler("ovos.common_play.repeat.set",
+                       player.handle_set_repeat, gated=True),
+            BusHandler("ovos.common_play.repeat.unset",
+                       player.handle_unset_repeat, gated=True),
+            BusHandler("ovos.common_play.SEI.get", player.handle_get_SEIs),
+            BusHandler("ovos.common_play.like", player.handle_like,
+                       gated=True),
+            BusHandler("ovos.common_play.unlike", player.handle_unlike,
+                       gated=True),
+            BusHandler("ovos.common_play.status", player.handle_status),
+            # external MPRIS player → reflect as OCP now_playing (no local
+            # backend)
+            BusHandler("ovos.common_play.mpris.now_playing",
+                       player.handle_mpris_now_playing),
+        ]
+
+    @staticmethod
+    def _service_table(service) -> List[BusHandler]:
+        return [
+            BusHandler("ovos.common_play.ping", service.handle_ping),
+            BusHandler("opm.audio.query", service.handle_opm_audio_query),
+        ]
+
+    def _wrap(self, entry: BusHandler) -> Callable:
+        """Build the listener for one table entry.
+
+        Each entry gets its own closure. That is what makes teardown work
+        for the migrated legacy topics: ovos-bus-client wraps a handler for
+        a migrated topic ('ovos.audio.output.started'/'.ended',
+        'recognizer_loop:record_begin'/'record_end', 'mycroft.stop') in a
+        per-handler dedup guard and remembers it keyed by the function
+        object. A bound method compares equal across attribute accesses, so
+        sharing one between a migrated and a plain topic would put remove()
+        on the dedup path for both, and the plain topic — never recorded
+        there — would silently keep its listener. Per-entry closures keep
+        every registration a distinct object, so each remove() resolves on
+        its own.
+        """
+        def listener(message):
+            if entry.decoder is not None:
+                try:
+                    if entry.decoder(message.data) is None:
+                        return
+                except ValueError as e:
+                    LOG.warning(f"ignoring '{entry.topic}' message: {e}")
+                    return
+            if entry.gated and not is_default_session(message,
+                                                      self.validate_source):
+                LOG.debug(f"ignoring '{entry.topic}' message, not from the "
+                          f"default/local session")
+                return
+            entry.target(message)
+
+        return listener
+
+    def register(self) -> None:
+        """Subscribe every entry in the table."""
+        for entry in self.table:
+            listener = self._wrap(entry)
+            self.bus.on(entry.topic, listener)
+            self._registrations.append((entry.topic, listener))
+
+    def shutdown(self) -> None:
+        """Remove every subscription this edge made."""
+        for topic, listener in self._registrations:
+            self.bus.remove(topic, listener)
+        self._registrations.clear()

--- a/ovos_media/bus/schemas.py
+++ b/ovos_media/bus/schemas.py
@@ -24,25 +24,13 @@ from collections.abc import Iterable
 from typing import Optional
 
 from ovos_utils.log import LOG
-from ovos_utils.ocp import MediaEntry, Playlist, PluginStream
+from ovos_utils.ocp import (MediaEntry, MediaState, Playlist, PluginStream,
+                            TrackState)
 
 # fields carrying a duration/offset in milliseconds on every track-shaped
 # payload; a non-numeric value in any of them poisons Playlist.length,
 # which sums them over every contained entry.
 _NUMERIC_TRACK_FIELDS = ("length", "position")
-
-
-def is_number(value) -> bool:
-    """True for a plain ``int``/``float``.
-
-    ``bool`` is an ``int`` subclass but is never a legitimate numeric value
-    on the wire. ``NaN``/``inf``/``-inf`` pass this check — use
-    :func:`is_real_number` wherever the value is later fed to ``int()`` or
-    summed.
-    """
-    if isinstance(value, bool):
-        return False
-    return isinstance(value, (int, float))
 
 
 def is_real_number(value) -> bool:
@@ -52,10 +40,11 @@ def is_real_number(value) -> bool:
     here (durations/positions/etc), and ``NaN``/``inf``/``-inf`` ARE valid
     ``float`` instances that pass a bare ``isinstance(x, (int, float))``
     check yet blow up downstream (``int(nan)`` raises ``ValueError``,
-    ``int(inf)`` raises ``OverflowError``). Centralizing the check here
-    keeps every bus-fed numeric field guarded the same way.
+    ``int(inf)`` raises ``OverflowError``, ``nan * 1000`` propagates a NaN
+    into the backend). Every bus-fed numeric field is guarded by this one
+    check.
     """
-    if not is_number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
         return False
     return math.isfinite(value)
 
@@ -101,6 +90,128 @@ def decode_playback_time(data: dict) -> dict:
             continue
         decoded[field] = int(value)
     return decoded
+
+
+def decode_track_state(data: dict) -> TrackState:
+    """Decode the 'state' field of an ``ovos.common_play.track.state``
+    payload. An int is coerced to its ``TrackState`` member; anything else
+    is refused."""
+    state = data.get("state")
+    if state is None:
+        raise ValueError(f"Got state update message with no state: {data}")
+    if isinstance(state, int):
+        state = TrackState(state)
+    if not isinstance(state, TrackState):
+        raise ValueError(f"Expected int or TrackState, but got: {state}")
+    return state
+
+
+def decode_media_state(data: dict) -> MediaState:
+    """Decode the 'state' field of an ``ovos.common_play.media.state``
+    payload. An int is coerced to its ``MediaState`` member; anything else
+    is refused."""
+    state = data.get("state")
+    if state is None:
+        raise ValueError(f"Got state update message with no state: {data}")
+    if isinstance(state, int):
+        state = MediaState(state)
+    if not isinstance(state, MediaState):
+        raise ValueError(f"Expected int or MediaState, but got: {state}")
+    return state
+
+
+def decode_media(data: dict) -> Optional[dict]:
+    """Decode the 'media' track of an ``ovos.common_play.play`` payload.
+
+    Returns None when there is nothing to act on: an absent/empty track, or
+    a track that is not a dict (a list/str would bleed into the now_playing
+    metadata field by field).
+    """
+    media = data.get("media")
+    if not media:
+        return None
+    if not isinstance(media, dict):
+        LOG.warning(f"ignoring play request, expected a dict track, "
+                    f"got: {media!r}")
+        return None
+    return media
+
+
+def decode_playlist_tracks(data: dict) -> Optional[list]:
+    """Decode the 'tracks' list of a playlist payload.
+
+    An absent key decodes to an empty list (a legal "set an empty
+    playlist"); a non-list value is refused, so the current playlist is
+    never cleared on account of a malformed request.
+    """
+    tracks = data.get("tracks") or []
+    if not isinstance(tracks, (list, tuple)):
+        LOG.warning(f"ignoring playlist payload of type "
+                    f"{type(tracks).__name__} - keeping current playlist")
+        return None
+    return list(tracks)
+
+
+def decode_seek(data: dict) -> Optional[dict]:
+    """Decode an ``ovos.common_play.seek`` payload into the one path it
+    asks for.
+
+    A seek arrives either as an absolute position in milliseconds
+    ('seekValue', from the audio player GUI's seekbar) or as an offset in
+    seconds from the current position ('seconds', from the bus api). The two
+    fields are decoded independently, so a bad value in one never costs the
+    other:
+
+    - a valid 'seekValue' wins and is returned as ``{"seekValue": ms}``,
+      whatever 'seconds' holds. ``0`` is a legal absolute position (the very
+      start of the track), not a missing field.
+    - 'seekValue' present but not a finite number refuses the whole request:
+      the caller asked to jump to a specific position, so falling back to a
+      relative seek would move the track somewhere nobody asked for.
+    - otherwise the relative path is returned as ``{"seconds": offset}``,
+      an absent 'seconds' meaning 0.
+
+    NaN/inf are refused in both fields: they reach the backend's
+    set_track_position as-is, and raise out of ``int()`` in the MPRIS and
+    GUI paths.
+    """
+    if "seekValue" in data:
+        position = data["seekValue"]
+        if is_real_number(position):
+            return {"seekValue": position}
+        LOG.warning(f"ignoring seek request with non-numeric 'seekValue': "
+                    f"{position!r}")
+        return None
+    seconds = data.get("seconds", 0)
+    if not is_real_number(seconds):
+        LOG.warning(f"ignoring seek request with non-numeric 'seconds': "
+                    f"{seconds!r}")
+        return None
+    return {"seconds": seconds}
+
+
+def decode_track_position(data: dict) -> Optional[float]:
+    """Decode the 'position' of an ``ovos.common_play.set_track_position``
+    payload, in milliseconds. An absent position means there is nothing to
+    seek to; NaN/inf are refused before they reach the backend."""
+    position = data.get("position")
+    if position is None:
+        return None
+    if not is_real_number(position):
+        LOG.warning(f"ignoring set_track_position request with non-numeric "
+                    f"'position': {position!r}")
+        return None
+    return position
+
+
+def decode_skill_id(data: dict) -> Optional[str]:
+    """Decode the 'skill_id' every OCP skill announcement is keyed by."""
+    skill_id = data.get("skill_id")
+    if not skill_id or not isinstance(skill_id, str):
+        LOG.warning(f"ignoring skill announcement with invalid 'skill_id': "
+                    f"{skill_id!r}")
+        return None
+    return skill_id
 
 
 def flatten_media_types(value) -> list:

--- a/ovos_media/player.py
+++ b/ovos_media/player.py
@@ -13,14 +13,17 @@ from ovos_config import Configuration
 from ovos_config.meta import get_xdg_base
 from ovos_media.media_backends import AudioService, VideoService, WebService
 from ovos_media.mpris import OcpMprisExporter
-from ovos_media.bus.schemas import (decode_playback_time, flatten_media_types,
-                                    is_injection_char, is_number, validated_entries)
-from ovos_media.utils import require_default_session
+from ovos_media.bus.api import OCPBusApi
+from ovos_media.utils import is_default_session
+from ovos_media.bus.schemas import (decode_media, decode_media_state,
+                                    decode_playback_time, decode_playlist_tracks,
+                                    decode_seek, decode_track_position,
+                                    decode_track_state, flatten_media_types,
+                                    is_injection_char, validated_entries)
 from ovos_plugin_manager.ocp import load_stream_extractors
 from ovos_plugin_manager.templates.media import MediaBackend
 from ovos_utils.log import LOG
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import SessionManager
 from ovos_utils.ocp import MediaType, Playlist
 from ovos_utils.ocp import OCP_ID, PlayerState, LoopState, PlaybackType, PlaybackMode, TrackState, MediaState, \
     MediaEntry, PluginStream
@@ -31,9 +34,8 @@ from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill
 class OCPMediaCatalog(OVOSCommonPlaybackSkill):
     def __init__(self, *args, validate_source: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
-        # mirrors NowPlaying.handle_external_play / require_default_session:
-        # gates playback-affecting intent handlers (shuffle on/off) to the
-        # local/"default" session, unless the owning service was configured
+        # mirrors the bus edge's session gate: keeps playback-affecting
+        # intent handlers (shuffle on/off) on the local/"default" session, unless the owning service was configured
         # with media.validate_source: false (satellite acting on everything)
         self.validate_source = validate_source
         self.skill_icon = f"{dirname(__file__)}/qt5/images/liked.svg"
@@ -51,9 +53,6 @@ class OCPMediaCatalog(OVOSCommonPlaybackSkill):
         self.search_playlist = Playlist()
         self.ocp_skills = {}
         self.featured_skills = {}
-        self.add_event("ovos.common_play.skills.detach", self.handle_ocp_skill_detach)
-        self.add_event("ovos.common_play.announce", self.handle_skill_announce)
-
         # TODO - add search results clear/replace events
 
         # register keywords
@@ -189,7 +188,7 @@ class OCPMediaCatalog(OVOSCommonPlaybackSkill):
     # WhatSong/WhatAlbum/WhatArtist are deliberately UN-gated by session:
     # they mirror OCPMediaPlayer.handle_status, which itself answers every
     # session's "ovos.common_play.status" query with the single shared
-    # player's state (it is not decorated with @require_default_session()).
+    # player's state (its bus topic is not gated).
     # The consistency rule this repo follows is that each intent front-end
     # mirrors its backing handler's own gating - handle_status is global
     # read-only state, so these read handlers stay global too. Only the
@@ -236,20 +235,14 @@ class OCPMediaCatalog(OVOSCommonPlaybackSkill):
             self.speak_dialog("no.artist.info")
 
     def _is_default_session(self, message: Message) -> bool:
-        """Mirror ovos_media.utils.require_default_session in full, including
-        the validate_source short-circuit: only the
-        local/"default" session may trigger playback-affecting actions here,
-        UNLESS this catalog's owning service was configured with
-        media.validate_source: false (satellite acting on every session).
-        OCPMediaPlayer.handle_set_shuffle/handle_unset_shuffle are gated by
-        that same decorator/config value, so on a non-default (e.g. HiveMind
-        satellite) session with validate_source left True, the emitted
-        shuffle.set/unset message is silently dropped by the player - this
-        must not be reported back as a success. When validate_source is
+        """Whether the player will act on a request forwarded from this
+        message, using the same rule the bus edge applies to
+        'ovos.common_play.shuffle.set'/'.unset'. On a non-default (e.g.
+        HiveMind satellite) session with validate_source left True the
+        emitted message is silently dropped by the player - this must not be
+        reported back to the user as a success. When validate_source is
         False the player WILL act on it, so this front-end must agree."""
-        if not self.validate_source:
-            return True
-        return SessionManager.get(message).session_id == "default"
+        return is_default_session(message, self.validate_source)
 
     def handle_shuffle_on(self, message):
         if not self._is_default_session(message):
@@ -378,17 +371,6 @@ class NowPlaying(MediaEntry):
         self.position = 0
         super().__init__(*args, **kwargs)
         self.original_uri = self.uri
-        self.bus.on("ovos.common_play.track.state", self.handle_track_state_change)
-        # NOTE: NowPlaying deliberately does NOT subscribe to
-        # 'ovos.common_play.media.state'. OCPMediaPlayer.handle_player_media_update
-        # is the SINGLE subscriber to that topic and calls
-        # NowPlaying.on_end_of_media() as a plain method call, in order, after it
-        # has captured the pre-reset playback type / uri. Two independent
-        # subscribers had no ordering guarantee (pyee's ExecutorEventEmitter
-        # submits every handler to a thread pool independently), which raced the
-        # end-of-track reset against the autoplay decision that reads it.
-        self.bus.on("ovos.common_play.play", self.handle_external_play)
-        self.bus.on("ovos.common_play.playback_time", self.handle_sync_seekbar)
 
     def as_entry(self) -> MediaEntry:
         """
@@ -416,14 +398,6 @@ class NowPlaying(MediaEntry):
         """
         fields = {f.name: getattr(self, f.name) for f in dataclasses.fields(MediaEntry)}
         return MediaEntry(**fields).as_dict
-
-    def shutdown(self):
-        """
-        Remove NowPlaying events from the MessageBusClient
-        """
-        self.bus.remove("ovos.common_play.track.state", self.handle_track_state_change)
-        self.bus.remove('ovos.common_play.play', self.handle_external_play)
-        self.bus.remove('ovos.common_play.playback_time', self.handle_sync_seekbar)
 
     def reset(self):
         """
@@ -511,22 +485,8 @@ class NowPlaying(MediaEntry):
         bleed into the new track
         @param message: Message associated with request
         """
-        # NowPlaying is part of the single local player; a play command from a
-        # non-default session (e.g. a HiveMind satellite, routed by the
-        # server-side OCP pipeline) must not bleed its metadata into the local
-        # now_playing. Mirror require_default_session() using the owning
-        # player's validate_source flag.
-        validate = self._player.validate_source if self._player else True
-        if validate and SessionManager.get(message).session_id != "default":
-            LOG.debug(f"ignoring '{message.msg_type}' now_playing update, "
-                      f"not from the default/local session")
-            return
-        media = message.data.get("media", {})
-        if not media:
-            return
-        if not isinstance(media, dict):
-            LOG.warning(f"ignoring '{message.msg_type}' now_playing update, "
-                        f"expected a dict track, got: {media!r}")
+        media = decode_media(message.data)
+        if media is None:
             return
         self.update(media, newonly=False)
 
@@ -537,15 +497,7 @@ class NowPlaying(MediaEntry):
         @param message: Message with updated `state` data
         @return:
         """
-        state = message.data.get("state")
-        if state is None:
-            raise ValueError(f"Got state update message with no state: "
-                             f"{message}")
-        if isinstance(state, int):
-            state = TrackState(state)
-        if not isinstance(state, TrackState):
-            raise ValueError(f"Expected int or TrackState, but got: {state}")
-
+        state = decode_track_state(message.data)
         if state == self.status:
             return
         LOG.info(f"TrackState changed: {repr(self.status)} -> {repr(state)}")
@@ -586,9 +538,9 @@ class NowPlaying(MediaEntry):
     def on_end_of_media(self):
         """
         End-of-media reset, invoked as a plain method call by
-        OCPMediaPlayer.handle_player_media_update (the single subscriber to
-        'ovos.common_play.media.state') AFTER it has captured the pre-reset
-        playback type and uri. Playback ended, so allow the next track to
+        OCPMediaPlayer.handle_player_media_update (the only consumer of
+        END_OF_MEDIA on 'ovos.common_play.media.state') AFTER it has captured
+        the pre-reset playback type and uri. Playback ended, so allow the next track to
         change metadata again.
         """
         self.reset()
@@ -601,15 +553,7 @@ class NowPlaying(MediaEntry):
         point for out-of-tree callers that drive NowPlaying directly.
         @param message: Message with updated MediaState
         """
-        state = message.data.get("state")
-        if state is None:
-            raise ValueError(f"Got state update message with no state: "
-                             f"{message}")
-        if isinstance(state, int):
-            state = MediaState(state)
-        if not isinstance(state, MediaState):
-            raise ValueError(f"Expected int or TrackState, but got: {state}")
-
+        state = decode_media_state(message.data)
         if state == MediaState.END_OF_MEDIA:
             self.on_end_of_media()
 
@@ -635,7 +579,7 @@ class OCPMediaPlayer:
         self.bus = bus
         self.ocp_config = config or Configuration().get("media", {})
         # When True, playback-executing handlers act only on the local/"default"
-        # session (see ovos_media.utils.require_default_session). A satellite
+        # session (see ovos_media.utils.is_default_session). A satellite
         # whose sessions are not NAT'd to "default" by hivemind-core should set
         # this False so its embedded ovos-media acts on all sessions.
         self.validate_source = validate_source
@@ -669,12 +613,18 @@ class OCPMediaPlayer:
             self.mpris = OcpMprisExporter(self, config=self.ocp_config,
                                           manage_players=manage_players)
 
-        # tracks every (event, handler) pair registered via self._register()
-        # below so unregister_bus_handlers() can remove exactly what was
-        # added, without hand-maintaining a second list that can drift out
-        # of sync with register_bus_handlers().
-        self._bus_events: List[tuple] = []
-        self.register_bus_handlers()
+        # every bus subscription of this player, its NowPlaying and its
+        # OCPMediaCatalog lives in one registration table (see
+        # ovos_media.bus.api), which is also what shutdown() tears down.
+        self.bus_api = OCPBusApi(bus, player=self)
+        self._report_to_core()
+
+    def _report_to_core(self) -> None:
+        """Broadcast the supported StreamExtractorIds and the initial player
+        status, so ovos-core learns this daemon's capabilities and state
+        without having to ask for them."""
+        self.handle_get_SEIs(Message("ovos.common_play.SEI.get"))
+        self.handle_status(Message("ovos.common_play.status"))
 
     def _init_runtime_state(self) -> None:
         """Initialise the plain in-memory playback bookkeeping.
@@ -731,120 +681,6 @@ class OCPMediaPlayer:
         # finds zero backends loaded, never again
         self._no_backend_dialog_spoken: bool = False
 
-    def _register(self, event: str, handler) -> None:
-        """Register a bus handler and remember it for unregister_bus_handlers().
-
-        Every handler added by register_bus_handlers() must go through this
-        method — it is the single source of truth for what needs to be torn
-        down again, so add/remove can never drift out of sync.
-        """
-        self.bus.on(event, handler)
-        self._bus_events.append((event, handler))
-
-    def unregister_bus_handlers(self) -> None:
-        """Remove every bus handler registered via self._register()."""
-        for event, handler in self._bus_events:
-            self.bus.remove(event, handler)
-        self._bus_events.clear()
-
-    def register_bus_handlers(self) -> None:
-        """Register all OCP bus event handlers."""
-        # ovos common play bus api
-        # NOTE: OCPMediaPlayer does NOT subscribe to its own
-        # 'ovos.common_play.player.state' event — set_player_state() is the
-        # single authoritative writer of self.state; external subscribers
-        # (MPRIS, GUI clients) may still listen on the bus.
-        self._register('ovos.common_play.media.state', self.handle_player_media_update)
-        self._register('ovos.common_play.play', self.handle_play_request)
-        self._register('ovos.common_play.pause', self.handle_pause_request)
-        self._register('ovos.common_play.play_pause', self.handle_pause_toggle_request)
-        self._register('ovos.common_play.resume', self.handle_resume_request)
-        self._register('ovos.common_play.stop', self.handle_stop_request)
-        self._register('ovos.common_play.next', self.handle_next_request)
-        self._register('ovos.common_play.previous', self.handle_prev_request)
-        self._register('ovos.common_play.seek', self.handle_seek_request)
-        self._register('ovos.common_play.get_track_length', self.handle_track_length_request)
-        self._register('ovos.common_play.set_track_position', self.handle_set_track_position_request)
-        self._register('ovos.common_play.get_track_position', self.handle_track_position_request)
-        self._register('ovos.common_play.track_info', self.handle_track_info_request)
-        self._register('ovos.common_play.list_backends', self.handle_list_backends_request)
-        self._register('ovos.common_play.playlist.set', self.handle_playlist_set_request)
-        self._register('ovos.common_play.playlist.clear', self.handle_playlist_clear_request)
-        self._register('ovos.common_play.playlist.queue', self.handle_playlist_queue_request)
-        self._register('ovos.common_play.duck', self.handle_duck_request)
-        self._register('ovos.common_play.unduck', self.handle_unduck_request)
-        self._register('ovos.common_play.cork', self.handle_cork_request)
-        self._register('ovos.common_play.uncork', self.handle_uncork_request)
-        # ovos-audio emits 'ovos.audio.output.started'/'ovos.audio.output.ended'
-        # unconditionally on every TTS output (ovos_audio/playback.py
-        # begin_audio/end_audio). The ovos.common_play.duck/cork messages are
-        # an alternative ducking path, but only emitted when tts.ocp_duck /
-        # tts.ocp_cork are enabled in config (both default False). Binding
-        # these spec topics to the same handlers keeps ducking working on
-        # default installs.
-        #
-        # NOTE: bound through per-topic wrapper functions, not the bare
-        # self.handle_duck_request/self.handle_unduck_request methods, for
-        # the same reason as the record_begin/record_end binding above:
-        # 'ovos.audio.output.started'/'ended' ARE migrated legacy topics
-        # (ovos-bus-client's MessageBusClient._mirror_guard_for wraps them in
-        # a per-HANDLER dedup guard), so sharing the bare bound method with
-        # the plain 'ovos.common_play.duck'/'unduck' registrations above
-        # would put remove() on the dedup path for both topics and leave the
-        # plain one un-removable — see the block comment on the
-        # record_begin/record_end registration for the full mechanism.
-        self._register('ovos.audio.output.started', lambda message: self.handle_duck_request(message))
-        self._register('ovos.audio.output.ended', lambda message: self.handle_unduck_request(message))
-        # mic-cork integration — no listener emits an OCP cork equivalent for
-        # the mic recording window, so these stay bound directly here.
-        #
-        # NOTE: bound through a per-topic wrapper function rather than the
-        # bare self.handle_cork_request method, on purpose.
-        # 'recognizer_loop:record_begin' is a migrated legacy topic
-        # (ovos_spec_tools.messages.MIGRATION_MAP), so ovos-bus-client's
-        # MessageBusClient.on() (client.py) wraps it in a per-HANDLER dedup
-        # guard and tracks that wrapper in self._dedup_registrations[func].
-        # Because a bound method compares equal (and hashes the same) across
-        # separate attribute accesses, self.handle_duck_request used here
-        # would be "the same" func as the one passed to
-        # _register('ovos.common_play.duck', ...) above. remove() branches on
-        # `if target in self._dedup_registrations`, and once ANY topic put
-        # that func in the dedup table, remove() takes the dedup path for
-        # EVERY topic registered under it — including the plain, non-migrated
-        # 'ovos.common_play.duck' registration, whose entry never lived in
-        # that table. The dedup path then filters
-        # self._dedup_registrations[target] for the given event_name, finds
-        # nothing (the plain topic was never recorded there), and silently
-        # removes zero listeners instead of falling through to
-        # _remove_normal() — so a shut-down OCPMediaPlayer keeps answering
-        # 'ovos.common_play.duck'/'unduck'/'cork' forever. Binding the
-        # bridged topic to its own wrapper object keeps it out of the plain
-        # topic's identity entirely, so each remove() call resolves cleanly.
-        self._register('recognizer_loop:record_begin', lambda message: self.handle_cork_request(message))
-        self._register('recognizer_loop:record_end', self.handle_record_end)
-        self._register('ovos.utterance.handled', self.handle_utterance_handled)
-        # global stop
-        self._register('mycroft.stop', self.handle_mycroft_stop)
-        self._register('ovos.common_play.shuffle.toggle', self.handle_shuffle_toggle_request)
-        self._register('ovos.common_play.shuffle.set', self.handle_set_shuffle)
-        self._register('ovos.common_play.shuffle.unset', self.handle_unset_shuffle)
-        self._register('ovos.common_play.repeat.toggle', self.handle_repeat_toggle_request)
-        self._register('ovos.common_play.repeat.set', self.handle_set_repeat)
-        self._register('ovos.common_play.repeat.unset', self.handle_unset_repeat)
-        self._register('ovos.common_play.SEI.get', self.handle_get_SEIs)
-        # 'ovos.common_play.search.start'/'.search.end'/'.home' are
-        # pipeline-side signals (the OCP pipeline plugin uses them to drive
-        # a GUI's own loading/navigation state); this daemon has no
-        # in-process GUI and no other state to change in response to them,
-        # so none of the three is subscribed here.
-        self._register("ovos.common_play.like", self.handle_like)
-        self._register("ovos.common_play.unlike", self.handle_unlike)
-        self._register("ovos.common_play.status", self.handle_status)
-        # external MPRIS player → reflect as OCP now_playing (no local backend)
-        self._register("ovos.common_play.mpris.now_playing", self.handle_mpris_now_playing)
-        self.handle_get_SEIs(Message("ovos.common_play.SEI.get"))  # report to ovos-core
-        self.handle_status(Message("ovos.common_play.status"))  # report to ovos-core
-
     def handle_status(self, message):
         self.bus.emit(message.response({
             "playback_type": self.playback_type,
@@ -860,7 +696,6 @@ class OCPMediaPlayer:
             "image": self.now_playing.image
         }))
 
-    @require_default_session()
     def handle_like(self, message):
         # sent from GUI or intent
         uri = message.data.get("uri") or self.now_playing.original_uri
@@ -885,7 +720,6 @@ class OCPMediaPlayer:
         self.bus.emit(message.forward("mycroft.audio.play_sound",
                                       {"uri": "snd/acknowledge.mp3"}))
 
-    @require_default_session()
     def handle_unlike(self, message):
         # sent from GUI or intent
         uri = message.data.get("uri") or self.now_playing.original_uri
@@ -1834,37 +1668,30 @@ class OCPMediaPlayer:
                 self._invalid_timer = None
         if self.mpris:
             self.mpris.shutdown()
-        self.now_playing.shutdown()
-        # self.media.shutdown() is the no-op OVOSSkill.shutdown() hook —
-        # it does NOT remove the bus handlers add_event() registered
-        # (ovos.common_play.skills.detach, .announce, the OCP intents, ...).
+        # self.media.shutdown() is the no-op OVOSSkill.shutdown() hook — it
+        # does NOT remove what ovos-workshop registered for the catalog (the
+        # OCP intents, the keyword/announce plumbing of the skill base class).
         # default_shutdown() is the real OVOSSkill teardown that removes
         # them; without it a "shut down" service kept answering intents.
+        # The catalog's own announce/skills.detach topics belong to
+        # self.bus_api, torn down below.
         self.media.default_shutdown()
         self.audio_service.shutdown()
         self.video_service.shutdown()
         self.web_service.shutdown()
-        # register_bus_handlers() above bound ~35 handlers directly via
-        # self.bus.on() (not add_event(), since OCPMediaPlayer is not an
-        # OVOSSkill) — remove exactly what was registered so a shut-down
-        # player stops answering ping/status/search/like/etc.
-        self.unregister_bus_handlers()
+        # a shut-down player must stop answering status/like/duck/etc
+        self.bus_api.shutdown()
 
     def handle_player_media_update(self, message):
         """
         Handles 'ovos.common_play.media.state' messages with media state updates
         @param message: Message providing new "state" data
         """
-        state = message.data.get("state")
-        if state is None:
-            raise ValueError(f"Got state update message with no state: "
-                             f"{message}")
-        if isinstance(state, int):
-            state = MediaState(state)
-        if not isinstance(state, MediaState):
-            raise ValueError(f"Expected int or MediaState, but got: {state}")
+        state = decode_media_state(message.data)
 
-        # this is the SOLE subscriber to 'ovos.common_play.media.state'.
+        # this is the sole consumer of END_OF_MEDIA on
+        # 'ovos.common_play.media.state' (the backend services subscribe too,
+        # but act on LOADED_MEDIA only).
         # The compare-and-set below plus the end-of-media capture happen under
         # one lock, so two concurrent END_OF_MEDIA events can only ever advance
         # the queue once. Nothing that can re-enter the player (autoplay, GUI
@@ -1959,7 +1786,6 @@ class OCPMediaPlayer:
         # for it, lives in play_next()'s end-of-queue branch.
 
     # ovos common play bus api requests
-    @require_default_session()
     def handle_play_request(self, message):
         LOG.debug("Received OCP playback request")
         repeat = message.data.get("repeat", False)
@@ -1975,75 +1801,56 @@ class OCPMediaPlayer:
 
         self.play_media(media, disambiguation, playlist)
 
-    @require_default_session()
     def handle_pause_request(self, message):
         self.pause()
 
-    @require_default_session()
     def handle_stop_request(self, message):
         self.stop()
         self.reset()
 
-    @require_default_session()
     def handle_resume_request(self, message):
         self.resume()
 
-    @require_default_session()
     def handle_pause_toggle_request(self, message):
         if self.state == PlayerState.PAUSED:
             self.handle_resume_request(message)
         else:
             self.handle_pause_request(message)
 
-    @require_default_session()
     def handle_seek_request(self, message):
-        # from bus api
-        seconds = message.data.get("seconds", 0)
-        if not is_number(seconds):
-            LOG.warning(f"Ignoring seek request with non-numeric 'seconds': "
-                        f"{seconds!r}")
+        seek = decode_seek(message.data)
+        if seek is None:
             return
-        miliseconds = seconds * 1000
+        if "seekValue" in seek:
+            # absolute position, from the audio player GUI seekbar
+            self.seek(seek["seekValue"])
+            return
+        # relative offset, from the bus api
+        position = self.now_playing.position or 0
+        if self.playback_type in [PlaybackType.AUDIO,
+                                  PlaybackType.UNDEFINED]:
+            position = self.audio_service.get_track_position() or position
+        self.seek(position + seek["seconds"] * 1000)
 
-        # from audio player GUI
-        position = message.data.get("seekValue")
-        # `seekValue: 0` (seek to the very start) is falsy, so `if not
-        # position` misread it as "no seekValue given" and fell through to
-        # the relative-seek path instead of seeking to 0.
-        if position is None:
-            position = self.now_playing.position or 0
-            if self.playback_type in [PlaybackType.AUDIO,
-                                      PlaybackType.UNDEFINED]:
-                position = self.audio_service.get_track_position() or position
-            position += miliseconds
-        self.seek(position)
-
-    @require_default_session()
     def handle_next_request(self, message):
         self.play_next()
 
-    @require_default_session()
     def handle_prev_request(self, message):
         self.play_prev()
 
-    @require_default_session()
     def handle_set_shuffle(self, message):
         self.shuffle = True
 
-    @require_default_session()
     def handle_unset_shuffle(self, message):
         self.shuffle = False
 
-    @require_default_session()
     def handle_set_repeat(self, message):
         self.loop_state = LoopState.REPEAT
 
-    @require_default_session()
     def handle_unset_repeat(self, message):
         self.loop_state = LoopState.NONE
 
     # playlist control bus api
-    @require_default_session()
     def handle_repeat_toggle_request(self, message):
         if self.loop_state == LoopState.REPEAT_TRACK:
             self.loop_state = LoopState.NONE
@@ -2055,41 +1862,31 @@ class OCPMediaPlayer:
         if self.mpris and self.playback_type == PlaybackType.MPRIS:
             self.mpris.toggle_repeat()
 
-    @require_default_session()
     def handle_shuffle_toggle_request(self, message):
         self.shuffle = not self.shuffle
         LOG.info(f"Shuffle: {self.shuffle}")
         if self.mpris and self.playback_type == PlaybackType.MPRIS:
             self.mpris.toggle_shuffle()
 
-    @require_default_session()
     def handle_playlist_set_request(self, message):
-        # validate (and default to []) BEFORE clearing the existing
-        # playlist — the old code cleared first and then KeyError'd on a
-        # missing 'tracks' key inside handle_playlist_queue_request, leaving
-        # the player with an empty playlist for no reason on a malformed
-        # request.
-        tracks = message.data.get("tracks") or []
-        if not isinstance(tracks, (list, tuple)):
-            LOG.warning(f"ignoring playlist.set payload of type "
-                        f"{type(tracks).__name__} - keeping current playlist")
+        # decode BEFORE clearing the existing playlist, so a malformed
+        # payload never costs the user the playlist they had.
+        tracks = decode_playlist_tracks(message.data)
+        if tracks is None:
             return
         entries = validated_entries(tracks)
         self.playlist.clear()
         for track in entries:
             self.playlist.add_entry(track)
 
-    @require_default_session()
     def handle_playlist_queue_request(self, message):
-        for track in validated_entries(message.data.get("tracks") or []):
+        for track in validated_entries(decode_playlist_tracks(message.data) or []):
             self.playlist.add_entry(track)
 
-    @require_default_session()
     def handle_playlist_clear_request(self, message):
         self.playlist.clear()
 
     # audio ducking - NB: we distinguish ducking vs corking  (lower volume vs pause)
-    @require_default_session()
     def handle_cork_request(self, message):
         """
         Pause audio on 'recognizer_loop:record_begin'
@@ -2099,7 +1896,6 @@ class OCPMediaPlayer:
             self.pause()
             self._paused_on_duck = True
 
-    @require_default_session()
     def handle_uncork_request(self, message):
         """
         Resume paused audio on 'recognizer_loop:record_begin'
@@ -2109,7 +1905,6 @@ class OCPMediaPlayer:
             self.resume()
             self._paused_on_duck = False
 
-    @require_default_session()
     def handle_duck_request(self, message):
         """
         Lower volume on 'ovos.common_play.duck'
@@ -2122,7 +1917,6 @@ class OCPMediaPlayer:
                 self.audio_service.lower_volume()
             self._paused_on_duck = True
 
-    @require_default_session()
     def handle_unduck_request(self, message):
         """
         Restore volume on 'ovos.common_play.unduck'.
@@ -2212,14 +2006,10 @@ class OCPMediaPlayer:
         data = {"position": pos}
         self.bus.emit(message.response(data))
 
-    @require_default_session()
     def handle_set_track_position_request(self, message):
-        miliseconds = message.data.get("position")
-        if is_number(miliseconds):
+        miliseconds = decode_track_position(message.data)
+        if miliseconds is not None:
             self.seek(miliseconds)
-        elif miliseconds is not None:
-            LOG.warning(f"Ignoring set_track_position request with "
-                        f"non-numeric 'position': {miliseconds!r}")
 
     def handle_track_info_request(self, message):
         data = self.now_playing.as_dict

--- a/ovos_media/service.py
+++ b/ovos_media/service.py
@@ -5,6 +5,7 @@ from ovos_utils.log import LOG
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
 
 from ovos_config.config import Configuration
+from ovos_media.bus.api import OCPBusApi
 from ovos_media.player import OCPMediaPlayer
 
 def on_ready():
@@ -65,7 +66,6 @@ class MediaService(Thread):
         self.status.set_alive()
         self.init_messagebus()
         self.ocp = OCPMediaPlayer(self.bus, validate_source=self.validate_source)
-        self.bus.on("ovos.common_play.ping", self.handle_ping)
         # 'ovos.common_play.home' and 'ovos.common_play.search.start'/
         # '.search.end' are pipeline-side signals (the OCP pipeline plugin
         # uses them to drive a GUI's own navigation/loading state); this
@@ -73,11 +73,11 @@ class MediaService(Thread):
         # response to them, so it does not subscribe to any of the three.
         # A bus message with no subscriber here is legal — nothing else in
         # this daemon depends on them being handled.
-        # opm.audio.query's handler reads self.ocp.audio_service — it
-        # must not be reachable until self.ocp exists. Registered here
-        # (after OCPMediaPlayer's plugin-loading construction above), not in
-        # init_messagebus() which runs before self.ocp is assigned.
-        self.bus.on("opm.audio.query", self.handle_opm_audio_query)
+        # opm.audio.query's handler reads self.ocp.audio_service — the edge
+        # is built here (after OCPMediaPlayer's plugin-loading construction
+        # above), not in init_messagebus() which runs before self.ocp is
+        # assigned, so the topic is never answerable before self.ocp exists.
+        self.bus_api = OCPBusApi(self.bus, service=self)
 
     def handle_ping(self, message):
         """
@@ -111,10 +111,9 @@ class MediaService(Thread):
         self.ocp.reset()
         self.status.set_stopping()
         self.ocp.shutdown()
-        # Remove the handlers registered directly on MediaService (not on
-        # self.ocp) so a shut-down service stops answering ping/opm.audio.query.
-        self.bus.remove("ovos.common_play.ping", self.handle_ping)
-        self.bus.remove("opm.audio.query", self.handle_opm_audio_query)
+        # the service's own topics go last: a shut-down service must stop
+        # answering ping/opm.audio.query too.
+        self.bus_api.shutdown()
 
     def init_messagebus(self):
         """

--- a/ovos_media/utils.py
+++ b/ovos_media/utils.py
@@ -11,59 +11,39 @@
 # limitations under the License.
 #
 
-from functools import wraps
-
 from ovos_bus_client.session import SessionManager
 from ovos_utils.log import LOG
 
 
-def require_default_session():
-    """Decorator gating a bus handler to the local/"default" session only.
+def is_default_session(message=None, validate_source: bool = True) -> bool:
+    """True when a message may drive this device's playback.
 
-    ovos-media is conceptually a *single* player bound to its own device — the
-    ``"default"`` session.  In a HiveMind split the OCP pipeline runs on the
-    server and forwards playback commands stamped with the *originating*
+    ovos-media is conceptually a *single* player bound to its own device —
+    the ``"default"`` session.  In a HiveMind split the OCP pipeline runs on
+    the server and forwards playback commands stamped with the *originating*
     session.  A server-side ovos-media must NOT act on a satellite's command
     (``session_id != "default"``): the satellite has its own embedded
-    ovos-media that handles it.  hivemind-core NATs the satellite's session to
-    ``"default"`` for that embedded instance (or the satellite sets
-    ``validate_source: false``), so the satellite's instance sees ``"default"``
-    and executes.
+    ovos-media that handles it.  hivemind-core NATs the satellite's session
+    to ``"default"`` for that embedded instance (or the satellite sets
+    ``validate_source: false``), so the satellite's instance sees
+    ``"default"`` and executes.
 
     Mirrors :func:`ovos_audio.utils.require_default_session`.
 
-    A decorated handler runs only if any of:
-        - ``message`` is ``None`` (internal/synthetic call), OR
-        - the owning object's ``validate_source`` is falsy (act on everything), OR
-        - the message's session id is ``"default"`` (local request).
+    A message passes if any of:
+        - it is ``None`` (internal/synthetic call), OR
+        - ``validate_source`` is falsy (act on everything), OR
+        - its session id is ``"default"`` (local request).
 
-    Otherwise it logs at debug level and returns ``None`` without acting.
-
-    The decorated method's ``self`` must expose a ``validate_source``
-    attribute; if missing it defaults to ``True`` (filter enabled).
+    A malformed session context (empty/non-str session id, a session that is
+    not a dict) is refused rather than raised: a hostile or buggy peer must
+    never be able to crash a gated handler.
     """
-
-    def _decorator(func):
-        @wraps(func)
-        def func_wrapper(self, message=None):
-            validate = getattr(self, "validate_source", True)
-            if message is None or not validate:
-                return func(self, message)
-            try:
-                is_default = SessionManager.get(message).session_id == "default"
-            except Exception as e:
-                # malformed session context (eg. empty/non-str session_id) —
-                # a hostile or buggy peer must never be able to crash a
-                # gated handler; treat it as NOT the default/local session
-                LOG.warning(f"ignoring '{message.msg_type}' message, "
-                           f"malformed session context: {e}")
-                return None
-            if is_default:
-                return func(self, message)
-            LOG.debug(f"ignoring '{message.msg_type}' message, "
-                      f"not from the default/local session")
-            return None
-
-        return func_wrapper
-
-    return _decorator
+    if message is None or not validate_source:
+        return True
+    try:
+        return SessionManager.get(message).session_id == "default"
+    except Exception as e:
+        LOG.warning(f"ignoring '{message.msg_type}' message, "
+                    f"malformed session context: {e}")
+        return False

--- a/test/unittests/test_bus_api.py
+++ b/test/unittests/test_bus_api.py
@@ -1,0 +1,609 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for the bus edge: the registration table, the session gate, the
+payload decoders it runs before dispatching, and teardown."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session, SessionManager
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import MediaState, TrackState
+
+# The topics ovos-media answers, per owner. This list IS the contract: a
+# topic dropped from the table (or silently renamed) stops a real client
+# working, so it must fail here rather than in a deployment.
+NOW_PLAYING_TOPICS = [
+    "ovos.common_play.track.state",
+    "ovos.common_play.play",
+    "ovos.common_play.playback_time",
+]
+CATALOG_TOPICS = [
+    "ovos.common_play.skills.detach",
+    "ovos.common_play.announce",
+]
+PLAYER_TOPICS = [
+    "ovos.common_play.media.state",
+    "ovos.common_play.play",
+    "ovos.common_play.pause",
+    "ovos.common_play.play_pause",
+    "ovos.common_play.resume",
+    "ovos.common_play.stop",
+    "ovos.common_play.next",
+    "ovos.common_play.previous",
+    "ovos.common_play.seek",
+    "ovos.common_play.get_track_length",
+    "ovos.common_play.set_track_position",
+    "ovos.common_play.get_track_position",
+    "ovos.common_play.track_info",
+    "ovos.common_play.list_backends",
+    "ovos.common_play.playlist.set",
+    "ovos.common_play.playlist.clear",
+    "ovos.common_play.playlist.queue",
+    "ovos.common_play.duck",
+    "ovos.common_play.unduck",
+    "ovos.common_play.cork",
+    "ovos.common_play.uncork",
+    "ovos.audio.output.started",
+    "ovos.audio.output.ended",
+    "recognizer_loop:record_begin",
+    "recognizer_loop:record_end",
+    "ovos.utterance.handled",
+    "mycroft.stop",
+    "ovos.common_play.shuffle.toggle",
+    "ovos.common_play.shuffle.set",
+    "ovos.common_play.shuffle.unset",
+    "ovos.common_play.repeat.toggle",
+    "ovos.common_play.repeat.set",
+    "ovos.common_play.repeat.unset",
+    "ovos.common_play.SEI.get",
+    "ovos.common_play.like",
+    "ovos.common_play.unlike",
+    "ovos.common_play.status",
+    "ovos.common_play.mpris.now_playing",
+]
+SERVICE_TOPICS = [
+    "ovos.common_play.ping",
+    "opm.audio.query",
+]
+# The gated half of the table: topics that change playback or persistent
+# state, and so act only on the local/"default" session. This set IS the
+# contract in both directions — a lost gate lets a satellite drive the local
+# player, and an added one silently stops a legitimate local command.
+GATED_TOPICS = {
+    "ovos.common_play.play",
+    "ovos.common_play.pause",
+    "ovos.common_play.play_pause",
+    "ovos.common_play.resume",
+    "ovos.common_play.stop",
+    "ovos.common_play.next",
+    "ovos.common_play.previous",
+    "ovos.common_play.seek",
+    "ovos.common_play.set_track_position",
+    "ovos.common_play.playlist.set",
+    "ovos.common_play.playlist.clear",
+    "ovos.common_play.playlist.queue",
+    "ovos.common_play.duck",
+    "ovos.common_play.unduck",
+    "ovos.common_play.cork",
+    "ovos.common_play.uncork",
+    "ovos.audio.output.started",
+    "ovos.audio.output.ended",
+    "recognizer_loop:record_begin",
+    "recognizer_loop:record_end",
+    "ovos.utterance.handled",
+    "ovos.common_play.shuffle.toggle",
+    "ovos.common_play.shuffle.set",
+    "ovos.common_play.shuffle.unset",
+    "ovos.common_play.repeat.toggle",
+    "ovos.common_play.repeat.set",
+    "ovos.common_play.repeat.unset",
+    "ovos.common_play.like",
+    "ovos.common_play.unlike",
+}
+# Read-only queries, broadcasts the player only reacts to, and the global
+# stop stay ungated so a remote pipeline can still read state and stop the
+# device.
+UNGATED_TOPICS = {
+    "ovos.common_play.track.state",
+    "ovos.common_play.playback_time",
+    "ovos.common_play.skills.detach",
+    "ovos.common_play.announce",
+    "ovos.common_play.media.state",
+    "ovos.common_play.get_track_length",
+    "ovos.common_play.get_track_position",
+    "ovos.common_play.track_info",
+    "ovos.common_play.list_backends",
+    "mycroft.stop",
+    "ovos.common_play.SEI.get",
+    "ovos.common_play.status",
+    "ovos.common_play.mpris.now_playing",
+}
+
+# Topics ovos-media deliberately does NOT answer: pipeline-side GUI signals,
+# and the player's own state broadcast (set_player_state is its single
+# authoritative writer).
+UNSUBSCRIBED_TOPICS = [
+    "ovos.common_play.home",
+    "ovos.common_play.search.start",
+    "ovos.common_play.search.end",
+    "ovos.common_play.player.state",
+]
+# Topics ovos-bus-client treats as migrated legacy names: it wraps the
+# handler in a per-handler dedup guard, so a handler shared with a
+# non-migrated topic becomes un-removable.
+MIGRATED_TOPICS = [
+    "ovos.audio.output.started",
+    "ovos.audio.output.ended",
+    "recognizer_loop:record_begin",
+    "recognizer_loop:record_end",
+    "mycroft.stop",
+]
+
+NAN = float("nan")
+INF = float("inf")
+
+
+def _named_session_message(msg_type, session_id="sat-7", data=None):
+    msg = Message(msg_type, data or {})
+    msg.context["session"] = Session(session_id=session_id).serialize()
+    return msg
+
+
+def _dispatch(api, topic, data=None, message=None):
+    """Hand a message straight to the edge's listener for *topic*.
+
+    FakeBus round-trips every payload through strict JSON, which rejects
+    NaN/inf outright — a real messagebus does not (``json.dumps`` emits
+    ``NaN``/``Infinity`` and ``json.loads`` reads them back), so those
+    payloads are delivered to the listener directly.
+    """
+    message = message or Message(topic, data or {})
+    for registered_topic, listener in api._registrations:
+        if registered_topic == topic:
+            listener(message)
+
+
+def _make_player(bus):
+    from ovos_media.player import OCPMediaPlayer
+    with patch("ovos_media.player.AudioService"), \
+         patch("ovos_media.player.VideoService"), \
+         patch("ovos_media.player.WebService"), \
+         patch("ovos_media.player.OcpMprisExporter"), \
+         patch("ovos_media.player.Configuration", return_value={"media": {}}), \
+         patch("ovos_media.player.OCPMediaCatalog"):
+        return OCPMediaPlayer(bus, config={})
+
+
+def _make_api(bus, gated=True, decoder=None, topic="ovos.common_play.probe"):
+    """Return a bus edge holding one synthetic entry, plus its target."""
+    from ovos_media.bus.api import BusHandler, OCPBusApi
+
+    target = MagicMock()
+    owner = MagicMock()
+    owner.validate_source = True
+
+    class _OneEntryApi(OCPBusApi):
+        def _build_table(self):
+            return [BusHandler(topic, target, decoder=decoder, gated=gated)]
+
+    return _OneEntryApi(bus, player=owner), target
+
+
+class TestRegistrationTableCompleteness(unittest.TestCase):
+    """Every topic in the inventory above is subscribed, and nothing else."""
+
+    def test_player_table_covers_every_owner(self):
+        player = _make_player(FakeBus())
+        topics = [e.topic for e in player.bus_api.table]
+
+        self.assertEqual(topics,
+                         NOW_PLAYING_TOPICS + CATALOG_TOPICS + PLAYER_TOPICS)
+        player.shutdown()
+
+    def test_gated_column_matches_the_contract(self):
+        """The gated flag is half the table's contract: assert the exact set,
+        so a lost gate (a satellite driving the local player) and a spurious
+        one (a dropped local command) both fail here."""
+        player = _make_player(FakeBus())
+        gated = {e.topic for e in player.bus_api.table if e.gated}
+
+        self.assertEqual(gated, GATED_TOPICS)
+        player.shutdown()
+
+    def test_ungated_column_matches_the_contract(self):
+        player = _make_player(FakeBus())
+        ungated = {e.topic for e in player.bus_api.table if not e.gated}
+
+        self.assertEqual(ungated, UNGATED_TOPICS)
+        player.shutdown()
+
+    def test_the_play_topic_is_gated_for_both_of_its_targets(self):
+        """'ovos.common_play.play' is the one topic with two entries; a gate
+        on only one of them would still bleed satellite metadata into the
+        local now_playing or start local playback."""
+        player = _make_player(FakeBus())
+        play_entries = [e for e in player.bus_api.table
+                        if e.topic == "ovos.common_play.play"]
+
+        self.assertEqual(len(play_entries), 2)
+        self.assertTrue(all(e.gated for e in play_entries))
+        player.shutdown()
+
+    def test_service_topics_are_ungated(self):
+        from ovos_media.bus.api import OCPBusApi
+        api = OCPBusApi(FakeBus(), service=MagicMock())
+
+        self.assertEqual([e.gated for e in api.table], [False, False])
+
+    def test_now_playing_play_is_dispatched_before_the_player(self):
+        """Both subscribe to 'ovos.common_play.play' and the bus dispatches
+        in registration order: the metadata update must land before the
+        player acts on it."""
+        player = _make_player(FakeBus())
+        play_targets = [e.target.__name__ for e in player.bus_api.table
+                        if e.topic == "ovos.common_play.play"]
+
+        self.assertEqual(play_targets,
+                         ["handle_external_play", "handle_play_request"])
+        player.shutdown()
+
+    def test_service_table_covers_its_own_topics(self):
+        from ovos_media.bus.api import OCPBusApi
+        service = MagicMock()
+        api = OCPBusApi(FakeBus(), service=service)
+
+        self.assertEqual([e.topic for e in api.table], SERVICE_TOPICS)
+
+    def test_pipeline_side_signals_are_not_subscribed(self):
+        player = _make_player(FakeBus())
+        topics = {e.topic for e in player.bus_api.table}
+
+        for topic in UNSUBSCRIBED_TOPICS:
+            self.assertNotIn(topic, topics)
+        player.shutdown()
+
+    def test_every_entry_is_bound_on_the_bus(self):
+        bus = FakeBus()
+        player = _make_player(bus)
+
+        self.assertEqual(len(player.bus_api._registrations),
+                         len(player.bus_api.table))
+        for entry, (topic, _) in zip(player.bus_api.table,
+                                     player.bus_api._registrations):
+            self.assertEqual(entry.topic, topic)
+        for topic in {e.topic for e in player.bus_api.table}:
+            expected = sum(1 for e in player.bus_api.table if e.topic == topic)
+            self.assertGreaterEqual(len(bus.ee.listeners(topic)), expected,
+                                    f"{topic} is not subscribed")
+        player.shutdown()
+
+
+class TestSessionGate(unittest.TestCase):
+    """A gated topic acts only on the local/"default" session."""
+
+    def setUp(self):
+        SessionManager.sessions = {"default": SessionManager.default_session}
+
+    def test_named_session_does_not_reach_a_gated_target(self):
+        api, target = _make_api(FakeBus(), gated=True)
+
+        api.bus.emit(_named_session_message("ovos.common_play.probe"))
+
+        target.assert_not_called()
+
+    def test_default_session_reaches_a_gated_target(self):
+        api, target = _make_api(FakeBus(), gated=True)
+
+        api.bus.emit(Message("ovos.common_play.probe"))
+
+        target.assert_called_once()
+
+    def test_named_session_reaches_an_ungated_target(self):
+        api, target = _make_api(FakeBus(), gated=False)
+
+        api.bus.emit(_named_session_message("ovos.common_play.probe"))
+
+        target.assert_called_once()
+
+    def test_named_session_reaches_a_gated_target_without_validate_source(self):
+        api, target = _make_api(FakeBus(), gated=True)
+        api.player.validate_source = False
+
+        api.bus.emit(_named_session_message("ovos.common_play.probe"))
+
+        target.assert_called_once()
+
+    def test_malformed_session_context_is_refused_not_raised(self):
+        api, target = _make_api(FakeBus(), gated=True)
+        msg = Message("ovos.common_play.probe",
+                      context={"session": {"session_id": ""}})
+
+        _dispatch(api, "ovos.common_play.probe", message=msg)  # must not raise
+
+        target.assert_not_called()
+
+
+class TestDecodeRejection(unittest.TestCase):
+    """A payload the decoder refuses never reaches its target, and the edge
+    does not raise on it."""
+
+    def test_none_returning_decoder_drops_the_message(self):
+        api, target = _make_api(FakeBus(), gated=False,
+                                decoder=lambda data: None)
+
+        api.bus.emit(Message("ovos.common_play.probe", {"x": 1}))
+
+        target.assert_not_called()
+
+    def test_raising_decoder_drops_the_message_without_raising(self):
+        def _decoder(data):
+            raise ValueError("nope")
+
+        api, target = _make_api(FakeBus(), gated=False, decoder=_decoder)
+
+        api.bus.emit(Message("ovos.common_play.probe", {"x": 1}))  # no raise
+
+        target.assert_not_called()
+
+    def test_accepted_payload_reaches_the_target_with_the_message(self):
+        api, target = _make_api(FakeBus(), gated=False,
+                                decoder=lambda data: data["x"])
+        msg = Message("ovos.common_play.probe", {"x": 1})
+
+        api.bus.emit(msg)
+
+        target.assert_called_once()
+        self.assertEqual(target.call_args[0][0].data, {"x": 1})
+
+    def test_stateless_track_state_is_dropped_not_raised(self):
+        bus = FakeBus()
+        player = _make_player(bus)
+        player.now_playing.status = TrackState.QUEUED_AUDIO
+
+        bus.emit(Message("ovos.common_play.track.state", {}))  # no raise
+
+        self.assertEqual(player.now_playing.status, TrackState.QUEUED_AUDIO)
+        player.shutdown()
+
+    def test_stateless_media_state_is_dropped_not_raised(self):
+        bus = FakeBus()
+        player = _make_player(bus)
+        player.media_state = MediaState.LOADED_MEDIA
+
+        bus.emit(Message("ovos.common_play.media.state", {}))  # no raise
+
+        self.assertEqual(player.media_state, MediaState.LOADED_MEDIA)
+        player.shutdown()
+
+    def test_non_list_playlist_payload_keeps_the_current_playlist(self):
+        bus = FakeBus()
+        player = _make_player(bus)
+        player.playlist.add_entry({"uri": "http://a.mp3", "title": "A"})
+
+        bus.emit(Message("ovos.common_play.playlist.set",
+                         {"tracks": "not-a-list"}))
+
+        self.assertEqual(len(player.playlist), 1)
+        player.shutdown()
+
+
+class TestSeekRejectsNonFiniteNumbers(unittest.TestCase):
+    """NaN/inf are valid floats that pass an isinstance check and then
+    poison the position handed to the backend (and raise out of int() in
+    the MPRIS/GUI paths). Both seek entry points refuse them."""
+
+    def _seekable_player(self, bus):
+        player = _make_player(bus)
+        player.seek = MagicMock()
+        return player
+
+    def test_nan_seconds_seek_is_refused(self):
+        bus = FakeBus()
+        player = self._seekable_player(bus)
+
+        _dispatch(player.bus_api, "ovos.common_play.seek", {"seconds": NAN})
+
+        player.seek.assert_not_called()
+        player.shutdown()
+
+    def test_inf_seconds_seek_is_refused(self):
+        bus = FakeBus()
+        player = self._seekable_player(bus)
+
+        _dispatch(player.bus_api, "ovos.common_play.seek", {"seconds": INF})
+
+        player.seek.assert_not_called()
+        player.shutdown()
+
+    def test_finite_seconds_seek_still_works(self):
+        bus = FakeBus()
+        player = self._seekable_player(bus)
+
+        bus.emit(Message("ovos.common_play.seek", {"seekValue": 30000}))
+
+        player.seek.assert_called_once_with(30000)
+        player.shutdown()
+
+    def test_nan_track_position_is_refused(self):
+        bus = FakeBus()
+        player = self._seekable_player(bus)
+
+        _dispatch(player.bus_api, "ovos.common_play.set_track_position",
+                  {"position": NAN})
+
+        player.seek.assert_not_called()
+        player.shutdown()
+
+    def test_inf_track_position_is_refused(self):
+        bus = FakeBus()
+        player = self._seekable_player(bus)
+
+        _dispatch(player.bus_api, "ovos.common_play.set_track_position",
+                  {"position": INF})
+
+        player.seek.assert_not_called()
+        player.shutdown()
+
+    def test_bad_seconds_does_not_cancel_a_valid_absolute_seek(self):
+        """The two fields are decoded independently: a refused relative
+        offset must not swallow the absolute position in the same payload."""
+        bus = FakeBus()
+        player = self._seekable_player(bus)
+
+        _dispatch(player.bus_api, "ovos.common_play.seek",
+                  {"seconds": NAN, "seekValue": 5000})
+
+        player.seek.assert_called_once_with(5000)
+        player.shutdown()
+
+    def test_nan_seek_value_refuses_the_whole_request(self):
+        """An absolute seek to a non-finite position must not silently
+        degrade into a relative seek somewhere nobody asked for."""
+        bus = FakeBus()
+        player = self._seekable_player(bus)
+        player.now_playing.position = 1000
+
+        _dispatch(player.bus_api, "ovos.common_play.seek",
+                  {"seekValue": NAN, "seconds": 10})
+
+        player.seek.assert_not_called()
+        player.shutdown()
+
+    def test_inf_seek_value_refuses_the_whole_request(self):
+        bus = FakeBus()
+        player = self._seekable_player(bus)
+
+        _dispatch(player.bus_api, "ovos.common_play.seek",
+                  {"seekValue": INF})
+
+        player.seek.assert_not_called()
+        player.shutdown()
+
+    def test_relative_seek_adds_to_the_current_position(self):
+        bus = FakeBus()
+        player = self._seekable_player(bus)
+        player.now_playing.position = 0
+        player.audio_service.get_track_position.return_value = 5000
+
+        bus.emit(Message("ovos.common_play.seek", {"seconds": 10}))
+
+        player.seek.assert_called_once_with(15000)
+        player.shutdown()
+
+    def test_absolute_seek_to_the_very_start_is_honoured(self):
+        """`seekValue: 0` is a position, not a missing field."""
+        bus = FakeBus()
+        player = self._seekable_player(bus)
+        player.audio_service.get_track_position.return_value = 5000
+
+        bus.emit(Message("ovos.common_play.seek", {"seekValue": 0}))
+
+        player.seek.assert_called_once_with(0)
+        player.shutdown()
+
+    def test_finite_track_position_still_works(self):
+        bus = FakeBus()
+        player = self._seekable_player(bus)
+
+        bus.emit(Message("ovos.common_play.set_track_position",
+                         {"position": 20000}))
+
+        player.seek.assert_called_once_with(20000)
+        player.shutdown()
+
+    def test_direct_call_also_refuses_nan(self):
+        """The handler is a callable entry point for out-of-tree callers
+        too, so it repeats the check the edge already made."""
+        bus = FakeBus()
+        player = self._seekable_player(bus)
+
+        player.handle_seek_request(Message("ovos.common_play.seek",
+                                           {"seconds": NAN}))
+        player.handle_set_track_position_request(
+            Message("ovos.common_play.set_track_position", {"position": INF}))
+
+        player.seek.assert_not_called()
+        player.shutdown()
+
+
+class TestTeardown(unittest.TestCase):
+    """shutdown() removes exactly what register() added — including the
+    migrated legacy topics, whose per-handler dedup guard silently swallows
+    a remove() for a handler shared with a non-migrated topic."""
+
+    def test_shutdown_removes_every_registration(self):
+        bus = FakeBus()
+        player = _make_player(bus)
+        topics = {e.topic for e in player.bus_api.table}
+        before = {t: len(bus.ee.listeners(t)) for t in topics}
+
+        player.bus_api.shutdown()
+
+        for topic in topics:
+            self.assertEqual(len(bus.ee.listeners(topic)),
+                             before[topic] - sum(1 for e in player.bus_api.table
+                                                 if e.topic == topic),
+                             f"{topic} kept a listener after shutdown")
+        self.assertEqual(player.bus_api._registrations, [])
+
+    def test_no_listener_object_is_shared_between_topics(self):
+        """Per-entry closures are what make the migrated topics removable:
+        a bound method reused across topics would put remove() on the dedup
+        path for all of them."""
+        bus = FakeBus()
+        player = _make_player(bus)
+        listeners = [listener for _, listener in player.bus_api._registrations]
+
+        self.assertEqual(len({id(fn) for fn in listeners}), len(listeners))
+        player.shutdown()
+
+    def test_migrated_topics_stop_being_answered_after_shutdown(self):
+        bus = FakeBus()
+        player = _make_player(bus)
+        player.audio_service = MagicMock()
+        player.video_service = MagicMock()
+        player.bus_api.shutdown()
+
+        for topic in MIGRATED_TOPICS:
+            bus.emit(Message(topic))
+
+        player.audio_service.lower_volume.assert_not_called()
+        player.audio_service.restore_volume.assert_not_called()
+
+    def test_plain_duck_topics_stop_being_answered_after_shutdown(self):
+        """The plain topics share their target methods with the migrated
+        'ovos.audio.output.*' ones — they must still be removable."""
+        bus = FakeBus()
+        player = _make_player(bus)
+        player.audio_service = MagicMock()
+        player.bus_api.shutdown()
+
+        bus.emit(Message("ovos.common_play.duck"))
+        bus.emit(Message("ovos.common_play.unduck"))
+
+        player.audio_service.lower_volume.assert_not_called()
+        player.audio_service.restore_volume.assert_not_called()
+
+    def test_shutdown_is_idempotent(self):
+        bus = FakeBus()
+        player = _make_player(bus)
+
+        player.bus_api.shutdown()
+        player.bus_api.shutdown()  # must not raise
+
+        self.assertEqual(player.bus_api._registrations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_bus_schemas.py
+++ b/test/unittests/test_bus_schemas.py
@@ -21,8 +21,7 @@ import unittest
 from ovos_utils.ocp import MediaEntry, MediaType, PlaybackType, Playlist
 
 from ovos_media.bus.schemas import (decode_playback_time, flatten_media_types,
-                                    is_injection_char, is_number,
-                                    is_real_number, sanitize_nested_playlist,
+                                    is_injection_char, is_real_number, sanitize_nested_playlist,
                                     sanitize_raw_playlist_dicts,
                                     validated_entries)
 
@@ -32,25 +31,6 @@ INF = float("inf")
 
 def _entry(uri, title="t"):
     return MediaEntry(uri=uri, title=title, playback=PlaybackType.AUDIO)
-
-
-class TestIsNumber(unittest.TestCase):
-    """A plain int/float, bool excluded. Non-finite floats DO pass —
-    is_real_number is the check for anything later fed to int() or sum()."""
-
-    CASES = [
-        (0, True), (1, True), (-1, True), (1.5, True), (-0.0, True),
-        (10 ** 30, True),
-        (NAN, True), (INF, True), (-INF, True),
-        (True, False), (False, False),
-        (None, False), ("5", False), (b"5", False), ([5], False),
-        ({"n": 5}, False), (object(), False),
-    ]
-
-    def test_cases(self):
-        for value, expected in self.CASES:
-            with self.subTest(value=value):
-                self.assertEqual(is_number(value), expected)
 
 
 class TestIsRealNumber(unittest.TestCase):

--- a/test/unittests/test_catalog_now_playing_intents.py
+++ b/test/unittests/test_catalog_now_playing_intents.py
@@ -458,7 +458,7 @@ class TestSkillAnnounceMediaTypesNormalization(unittest.TestCase):
     get_featured_skills()'s "in media_types" membership checks."""
 
     def _announce(self, catalog, bus, **data):
-        bus.emit(Message("ovos.common_play.announce", data))
+        catalog.handle_skill_announce(Message("ovos.common_play.announce", data))
 
     def test_singular_int_media_type_is_featured_and_does_not_raise(self):
         bus = FakeBus()

--- a/test/unittests/test_end_of_track_handling.py
+++ b/test/unittests/test_end_of_track_handling.py
@@ -222,10 +222,9 @@ class TestSingleWriterEndOfMedia(unittest.TestCase):
         """NowPlaying must not be a second subscriber to the topic."""
         bus = FakeBus()
         player = _make_player(bus)
-        listeners = bus.ee.listeners("ovos.common_play.media.state")
-        owners = [getattr(fn, "__self__", None) for fn in listeners]
-        self.assertNotIn(player.now_playing, owners)
-        self.assertIn(player, owners)
+        targets = [e.target for e in player.bus_api.table
+                   if e.topic == "ovos.common_play.media.state"]
+        self.assertEqual(targets, [player.handle_player_media_update])
         player.shutdown()
 
 

--- a/test/unittests/test_lifecycle_hygiene.py
+++ b/test/unittests/test_lifecycle_hygiene.py
@@ -36,9 +36,9 @@ def _make_service(bus):
 
 
 class TestL1ZombieServiceShutdown(unittest.TestCase):
-    """shutdown() must remove every listener register_bus_handlers() added,
-    across both OCPMediaPlayer and MediaService, and a shut-down service
-    must not answer ping."""
+    """shutdown() must remove every listener the bus edge added, across both
+    OCPMediaPlayer and MediaService, and a shut-down service must not answer
+    ping."""
 
     def test_construct_shutdown_cycle_twice_unregisters_every_ocp_handler(self):
         # NOTE: this deliberately does NOT assert on aggregate FakeBus
@@ -48,18 +48,18 @@ class TestL1ZombieServiceShutdown(unittest.TestCase):
         # ovos_utils.fakebus._translator); FakeBus tracks those mirrored
         # registrations in a handler-keyed dedup table that can shadow the
         # unrelated plain-topic removal for the same handler — a FakeBus
-        # test-double quirk, not something register_bus_handlers()/
-        # unregister_bus_handlers() control. What they DO own is
-        # OCPMediaPlayer._bus_events, which is asserted directly instead.
+        # test-double quirk, not something the bus edge controls. What it
+        # DOES own is its registration list, which is asserted directly
+        # instead.
         bus = FakeBus()
 
         for _ in range(2):
             svc = _make_service(bus)
-            registered = list(svc.ocp._bus_events)
+            registered = list(svc.ocp.bus_api._registrations)
             self.assertTrue(registered, "construction should have registered handlers")
             svc.shutdown()
-            self.assertEqual(svc.ocp._bus_events, [],
-                            "shutdown must clear the OCPMediaPlayer registration list")
+            self.assertEqual(svc.ocp.bus_api._registrations, [],
+                            "shutdown must clear the bus edge registration list")
 
     def test_shutdown_calls_bus_remove_for_every_registered_ocp_handler(self):
         """Same assertion via a MagicMock bus, which has no dedup-table

--- a/test/unittests/test_player_coverage.py
+++ b/test/unittests/test_player_coverage.py
@@ -15,7 +15,7 @@
 
 Targets uncovered regions:
 - NowPlaying: reset, update, handle_track_state_change, handle_media_state_change,
-  handle_sync_seekbar, handle_external_play, as_entry, shutdown
+  handle_sync_seekbar, handle_external_play, as_entry
 - OCPMediaPlayer: play_media, play_next, play_prev, set_now_playing,
   handle_duck_request, handle_unduck_request, handle_cork_request,
   handle_uncork_request, handle_playback_ended, handle_invalid_media,
@@ -151,12 +151,6 @@ class TestNowPlayingInit(unittest.TestCase):
         self.assertEqual(np.title, "")
         self.assertEqual(np.artist, "")
         self.assertEqual(np.position, 0)
-
-    def test_shutdown_removes_bus_handlers(self):
-        """Calling shutdown() should not raise and should remove bus events."""
-        np, bus = self._make_now_playing()
-        # Should not raise
-        np.shutdown()
 
     def test_update_with_dict(self):
         np, _ = self._make_now_playing()

--- a/test/unittests/test_player_coverage2.py
+++ b/test/unittests/test_player_coverage2.py
@@ -80,8 +80,8 @@ class TestNowPlayingTrackStateChange(unittest.TestCase):
         np._player = mock_player
         np.status = TrackState.QUEUED_AUDIO  # different state
 
-        bus.emit(Message("ovos.common_play.track.state",
-                        {"state": TrackState.PLAYING_VIDEO}))
+        np.handle_track_state_change(Message("ovos.common_play.track.state",
+                                             {"state": TrackState.PLAYING_VIDEO}))
 
         mock_player.set_player_state.assert_called_with(PlayerState.PLAYING)
 
@@ -91,8 +91,8 @@ class TestNowPlayingTrackStateChange(unittest.TestCase):
         mock_player = MagicMock()
         np._player = mock_player
 
-        bus.emit(Message("ovos.common_play.track.state",
-                        {"state": TrackState.PLAYING_SKILL}))
+        np.handle_track_state_change(Message("ovos.common_play.track.state",
+                                             {"state": TrackState.PLAYING_SKILL}))
 
         mock_player.set_player_state.assert_called_with(PlayerState.PLAYING)
 

--- a/test/unittests/test_player_mpris_config.py
+++ b/test/unittests/test_player_mpris_config.py
@@ -20,7 +20,8 @@ class TestMprisConfigForwarded(unittest.TestCase):
                  patch("ovos_media.player.NowPlaying"), \
              patch("ovos_media.player.Playlist"), \
              patch("ovos_media.player.OCPMediaCatalog"), \
-             patch.object(OCPMediaPlayer, "register_bus_handlers"):
+             patch("ovos_media.player.OCPBusApi"), \
+             patch.object(OCPMediaPlayer, "_report_to_core"):
             p = OCPMediaPlayer(bus=FakeBus(), config=media_config)
         return p, mock_exporter
 

--- a/test/unittests/test_shuffle_bounds_and_handler_cleanup.py
+++ b/test/unittests/test_shuffle_bounds_and_handler_cleanup.py
@@ -173,7 +173,7 @@ class TestDeadPlayerStopsHandlingDuckTopics(unittest.TestCase):
         p._paused_on_duck = True
         p.audio_service = MagicMock()
 
-        p.unregister_bus_handlers()
+        p.bus_api.shutdown()
 
         bus.emit(Message("ovos.common_play.unduck"))
         p.audio_service.restore_volume.assert_not_called()
@@ -185,7 +185,7 @@ class TestDeadPlayerStopsHandlingDuckTopics(unittest.TestCase):
         p.state = PlayerState.PLAYING
         p.audio_service = MagicMock()
 
-        p.unregister_bus_handlers()
+        p.bus_api.shutdown()
 
         bus.emit(Message("ovos.common_play.duck"))
         p.audio_service.lower_volume.assert_not_called()

--- a/test/unittests/test_spoken_failure_dialogs.py
+++ b/test/unittests/test_spoken_failure_dialogs.py
@@ -149,10 +149,12 @@ class TestTrackFailedDialog(unittest.TestCase):
         # set_player_state, then unconditionally clearing the guards) without
         # also exercising unrelated status-report plumbing.
         p.set_player_state = MagicMock()
-        # drive the real bus event a backend emits after current.play()
-        # returns without raising (see base.py handle_media_state_change)
-        p.bus.emit(Message("ovos.common_play.track.state",
-                           {"state": TrackState.PLAYING_AUDIO}))
+        # drive the real handler the bus edge dispatches to after
+        # current.play() returns without raising (see base.py
+        # handle_media_state_change)
+        p.now_playing.handle_track_state_change(
+            Message("ovos.common_play.track.state",
+                    {"state": TrackState.PLAYING_AUDIO}))
         self.assertEqual(p._failed_uris, set())
         self.assertFalse(p._track_failed_spoken)
         p.handle_invalid_media()

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -10,60 +10,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Unit tests for ovos_media.utils — require_default_session."""
+"""Unit tests for ovos_media.utils — is_default_session."""
 import unittest
 
 
-class TestRequireDefaultSessionMalformedContext(unittest.TestCase):
+class TestIsDefaultSessionMalformedContext(unittest.TestCase):
     """A malformed session context (empty session_id, non-dict session)
     must never crash a gated handler — it must be refused (treated as
     NOT-default) and logged, not raised, so any peer cannot DoS a handler
     with context={"session": {"session_id": ""}}."""
 
-    def _make_handler(self):
-        from ovos_media.utils import require_default_session
-
-        calls = []
-
-        class _Svc:
-            validate_source = True
-
-            @require_default_session()
-            def handle(self, message=None):
-                calls.append(message)
-                return "ran"
-
-        return _Svc(), calls
-
     def test_empty_session_id_refused_no_exception(self):
         from ovos_bus_client.message import Message
-        svc, calls = self._make_handler()
+        from ovos_media.utils import is_default_session
         msg = Message("x", context={"session": {"session_id": ""}})
 
-        result = svc.handle(msg)  # must not raise
-
-        self.assertIsNone(result)
-        self.assertEqual(calls, [])
+        self.assertFalse(is_default_session(msg))  # must not raise
 
     def test_str_session_refused_no_exception(self):
         from ovos_bus_client.message import Message
-        svc, calls = self._make_handler()
+        from ovos_media.utils import is_default_session
         msg = Message("x", context={"session": "not_a_dict"})
 
-        result = svc.handle(msg)  # must not raise
-
-        self.assertIsNone(result)
-        self.assertEqual(calls, [])
+        self.assertFalse(is_default_session(msg))  # must not raise
 
     def test_valid_default_session_still_runs(self):
         from ovos_bus_client.message import Message
-        svc, calls = self._make_handler()
+        from ovos_media.utils import is_default_session
         msg = Message("x", context={"session": {"session_id": "default"}})
 
-        result = svc.handle(msg)
+        self.assertTrue(is_default_session(msg))
 
-        self.assertEqual(result, "ran")
-        self.assertEqual(len(calls), 1)
+    def test_named_session_refused(self):
+        from ovos_bus_client.message import Message
+        from ovos_media.utils import is_default_session
+        msg = Message("x", context={"session": {"session_id": "sat-1"}})
+
+        self.assertFalse(is_default_session(msg))
+
+    def test_named_session_allowed_when_source_not_validated(self):
+        from ovos_bus_client.message import Message
+        from ovos_media.utils import is_default_session
+        msg = Message("x", context={"session": {"session_id": "sat-1"}})
+
+        self.assertTrue(is_default_session(msg, validate_source=False))
+
+    def test_synthetic_call_allowed(self):
+        from ovos_media.utils import is_default_session
+
+        self.assertTrue(is_default_session(None))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Until now, finding out what `ovos-media` listens to on the bus meant reading three
constructors and a 90-line `register_bus_handlers` block, and each handler opened
with its own hand-rolled mix of payload checks and a session-gate decorator. This
moves the subscriptions of the player layer — `OCPMediaPlayer`, its
`NowPlaying`, its `OCPMediaCatalog`, and `MediaService` — into one bus-edge
class, `OCPBusApi` in `ovos_media/bus/api.py`. It holds a registration table:
one entry per topic,
naming the payload decoder to run, whether the topic is gated to the local
session, and the player / `NowPlaying` / catalog / service method to call. The
same table drives teardown, so what is registered and what is removed can no
longer drift apart.

Two things stay outside the table, deliberately. Each of the three backend
services binds its own `ovos.common_play.media.state` listener in
`BaseMediaService.__init__` (they act on `LOADED_MEDIA` only, to start playback
on the loaded backend), and the workshop skill base class the catalog inherits
registers the OCP intents and keyword plumbing itself. So the table is the
player layer's contract, not an inventory of every listener in the process —
four listeners sit on `media.state` and 84 registrations exist in total at
startup. Moving the backend services behind the edge belongs with the adapters
step.

`OCPMediaPlayer`, `NowPlaying`, `OCPMediaCatalog` and `MediaService` keep their
handler methods, names and behaviour, but no longer bind anything themselves —
`NowPlaying` ends up with zero subscriptions and no `shutdown()`. The player
builds the edge for itself, its catalog and its `NowPlaying`; the service builds
one for its own two topics and tears it down after the player. Registration order
is preserved where it matters: `NowPlaying.handle_external_play` still runs
before `handle_play_request` on `ovos.common_play.play`, and `NowPlaying` still
does not subscribe to `ovos.common_play.media.state` — the player stays the only
consumer of `END_OF_MEDIA` on that topic, so nothing races the reset it performs
after capturing the pre-reset playback type and uri. Each entry gets its own closure,
which is what keeps the migrated legacy topics (`ovos.audio.output.started`/
`.ended`, `recognizer_loop:record_begin`/`record_end`, `mycroft.stop`) removable:
ovos-bus-client keys its dedup guard by handler object, so a bound method shared
between a migrated and a plain topic makes the plain one un-removable.

The payload decodes that were still written inline moved into
`ovos_media/bus/schemas.py`, where the rest already lived: the `TrackState`/
`MediaState` int-to-enum triplicate, the play request's dict-track check, the
playlist list-or-tuple check, and the two seek numeric checks. The handlers call
the same decoders, so a direct, out-of-tree call still validates its own input;
the difference is that a payload arriving over the bus is now refused before any
handler runs. `require_default_session()` becomes the plain predicate
`is_default_session()`, which the edge and the catalog's shuffle intents share
instead of restating the rule.

One deliberate behaviour fix rides along. `handle_seek_request` and
`handle_set_track_position_request` used the weak `is_number` predicate, which
accepts `NaN` and `±inf` — both are real `float` instances, both survive a
standard messagebus round trip (`json.dumps` emits `NaN`/`Infinity` and
`json.loads` reads them back), and both then reach the backend, where a NaN
position poisons the seek arithmetic and an inf raises `OverflowError` out of
`int()` in the MPRIS and GUI paths. Both paths now use `is_real_number`, and
`is_number` is gone since nothing else needed the weaker check.

A seek carries two independent fields, so `decode_seek` decodes them
independently rather than refusing the message as a whole. An absolute
`seekValue` (the GUI seekbar; `0` is a position, not a missing field) wins and
is honoured whatever `seconds` holds, so a junk relative offset in the same
payload no longer cancels a perfectly good absolute seek. A `seekValue` that is
present but not finite refuses the request outright instead of degrading into a
relative seek to somewhere nobody asked for. Only when `seekValue` is absent
does the relative `seconds` path run, and a non-finite offset there refuses that
path.

Fail-before evidence: reverting the two-field split (single-field decode, the
whole message dropped on a bad `seconds`, `seekValue` unguarded) turns the three
new seek-field tests red; reverting only the `is_number` convergence turns the
five non-finite tests red; both leave the finite-value controls green.

Two gating details are worth a reviewer's attention. `recognizer_loop:record_end`
and `ovos.utterance.handled` were ungated topics whose entire effect was a call
into the gated uncork/unduck handlers, so a satellite-session message reached
them and then did nothing; they are gated on the topic itself now, which reaches
the same outcome without the intervening 8-second `speak` wait. And skill
announcements are dropped when they carry no usable `skill_id`, instead of
registering a `None` key that nothing could ever detach.

The suite is the contract oracle here: the unit and end-to-end tests were left
alone except where they reached for machinery this PR moves. `test_bus_api.py`
adds 37 tests. Both of the table's columns get a contract test: the topic
inventory per owner as an explicit list, and the exact gated/ungated split
asserted as sets in both directions, so a lost gate (a satellite driving the
local player) and a spurious one (a dropped local command) each fail here rather
than in a deployment. The rest covers gate enforcement at dispatch,
decode-rejection, the seek fixes, and teardown including the shared-listener and
migrated-topic discipline. Test arithmetic: unit 709 (+85 subtests) → 747 (+68
subtests) — +37 new, +3 for the predicate rewrite, −1 for the deleted `is_number`
class (−17 subtests), −1 for the deleted `NowPlaying.shutdown` test; end-to-end
68 → 68 unchanged.
