### PR TITLE
refactor: owned play queue and player package

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ The rest of this document focuses on the daemon itself.
    as a `Thread`, owns the `MessageBusClient` connection, instantiates
    `OCPMediaPlayer`, and answers a small set of top-level bus topics.
 
-2. **`OCPMediaPlayer`** (`ovos_media/player.py`), the virtual media player. It is
+2. **`OCPMediaPlayer`** (`ovos_media/player/`), the virtual media player. It is
    a plain bus-connected class (it is *not* a skill or an `OVOSAbstractApplication`)
    that manages the playback state machine (`PlayerState`, `MediaState`), owns the
    `NowPlaying` tracker and three backend service objects (`AudioService`,
@@ -61,6 +61,15 @@ The rest of this document focuses on the daemon itself.
    `BaseMediaService` subclasses (`AudioService`, `VideoService`, `WebService`).
    Each loads OPM plugins at startup and delegates actual playback to the selected
    plugin instance.
+
+The player package splits along the state it owns: `OCPMediaPlayer` and the
+catalog skill in `ovos_media/player/__init__.py`, the queue in
+`ovos_media/player/queue.py`, the now-playing tracker in
+`ovos_media/player/now_playing.py`, and stream extraction in
+`ovos_media/player/streams.py`. `PlayQueue` owns the user queue, the identity
+of the selected entry and the uris that failed to load, and answers which
+track comes next; what to do with that answer — repeat, autoplay, stop —
+stays with the player.
 
 Every subscription `MediaService`, `OCPMediaPlayer`, `NowPlaying` and
 `OCPMediaCatalog` make lives in the bus edge, `ovos_media/bus/api.py`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -176,7 +176,7 @@ bus.emit(Message("ovos.common_play.play", {
 }))
 ```
 
-`media` is required (`handle_play_request` in `ovos_media/player.py` logs a
+`media` is required (`handle_play_request` in `ovos_media/player/` logs a
 warning and ignores the message if it is missing). `media_type` and
 `playback` are the integer values of the `ovos_utils.ocp.MediaType` and
 `ovos_utils.ocp.PlaybackType` enums; common ones are `MediaType.AUDIO` (1),
@@ -214,7 +214,7 @@ Every reply on the bus uses the `.response` suffix convention: the reply to
 `<msg_type>` is emitted as `<msg_type>.response` (see `Message.response` in
 `ovos-bus-client`). To query full player status, send
 `ovos.common_play.status` and wait for `ovos.common_play.status.response`
-(handled by `OCPMediaPlayer.handle_status` in `ovos_media/player.py`):
+(handled by `OCPMediaPlayer.handle_status` in `ovos_media/player/`):
 
 ```python
 from ovos_bus_client import MessageBusClient, Message

--- a/docs/ocp-skills.md
+++ b/docs/ocp-skills.md
@@ -22,7 +22,7 @@ OCP (OpenVoiceOS Common Play) is the media pipeline that routes voice utterances
 
 1. **OCP pipeline plugin** (`ovos-ocp-pipeline-plugin`), an intent pipeline stage that classifies utterances as media queries, determines the `MediaType`, and broadcasts search requests to registered OCP skills.
 2. **OCP skills**, domain-specific skills (YouTube, Spotify, local music, radio, etc.) that respond to search requests by returning lists of `MediaEntry` objects ranked by confidence.
-3. **`ovos-media`**, receives the winning `MediaEntry`, resolves the appropriate audio/video/web backend, and drives playback. The central class is `OCPMediaPlayer` (`ovos_media/player.py`).
+3. **`ovos-media`**, receives the winning `MediaEntry`, resolves the appropriate audio/video/web backend, and drives playback. The central class is `OCPMediaPlayer` (`ovos_media/player/`).
 
 ## The OCP query flow
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -52,8 +52,8 @@ Gated topics (the ones that change playback or persistent state):
 
 | Target | Topics |
 |---|---|
-| `OCPMediaPlayer` (`player.py`) | play, pause, resume, stop, play/pause toggle, next, previous, seek, set track position, playlist set/queue/clear, shuffle set/unset/toggle, repeat set/unset/toggle, duck, cork, uncork (and unduck restore), like, unlike, record begin/end, utterance handled |
-| `NowPlaying` (`player.py`) | `handle_external_play` (so a non-default play does not bleed metadata into the local now-playing) |
+| `OCPMediaPlayer` (`player/__init__.py`) | play, pause, resume, stop, play/pause toggle, next, previous, seek, set track position, playlist set/queue/clear, shuffle set/unset/toggle, repeat set/unset/toggle, duck, cork, uncork (and unduck restore), like, unlike, record begin/end, utterance handled |
+| `NowPlaying` (`player/now_playing.py`) | `handle_external_play` (so a non-default play does not bleed metadata into the local now-playing) |
 
 `recognizer_loop:record_end` and `ovos.utterance.handled` do nothing except
 resume or unduck, both of which are gated, so the gate sits on the topic

--- a/ovos_media/player/__init__.py
+++ b/ovos_media/player/__init__.py
@@ -1,8 +1,5 @@
-import dataclasses
-import random
 import threading
-import time
-from os.path import join, dirname
+from os.path import dirname
 from threading import RLock
 from typing import List, Optional, Union
 
@@ -15,11 +12,12 @@ from ovos_media.media_backends import AudioService, VideoService, WebService
 from ovos_media.mpris import OcpMprisExporter
 from ovos_media.bus.api import OCPBusApi
 from ovos_media.utils import is_default_session
-from ovos_media.bus.schemas import (decode_media, decode_media_state,
-                                    decode_playback_time, decode_playlist_tracks,
+from ovos_media.bus.schemas import (decode_media_state, decode_playlist_tracks,
                                     decode_seek, decode_track_position,
-                                    decode_track_state, flatten_media_types,
-                                    is_injection_char, validated_entries)
+                                    flatten_media_types, validated_entries)
+from ovos_media.player.queue import (AllFailed, KeepCurrent, PlayQueue,
+                                     QueueEnd)
+from ovos_media.player.now_playing import NowPlaying
 from ovos_plugin_manager.ocp import load_stream_extractors
 from ovos_plugin_manager.templates.media import MediaBackend
 from ovos_utils.log import LOG
@@ -31,14 +29,20 @@ from ovos_workshop.decorators.ocp import ocp_search
 from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill
 
 
+# locale/ and qt5/ live in the ovos_media package, one level above this
+# subpackage; the catalog skill reads its dialogs, intents and icons from there
+RESOURCES_DIR = dirname(dirname(__file__))
+
+
 class OCPMediaCatalog(OVOSCommonPlaybackSkill):
     def __init__(self, *args, validate_source: bool = True, **kwargs):
+        kwargs.setdefault("resources_dir", RESOURCES_DIR)
         super().__init__(*args, **kwargs)
         # mirrors the bus edge's session gate: keeps playback-affecting
         # intent handlers (shuffle on/off) on the local/"default" session, unless the owning service was configured
         # with media.validate_source: false (satellite acting on everything)
         self.validate_source = validate_source
-        self.skill_icon = f"{dirname(__file__)}/qt5/images/liked.svg"
+        self.skill_icon = f"{RESOURCES_DIR}/qt5/images/liked.svg"
 
         self.liked_songs = JsonStorageXDG("OCP_liked_songs",
                                           subfolder=get_xdg_base())
@@ -361,211 +365,6 @@ class OCPMediaCatalog(OVOSCommonPlaybackSkill):
         self.search_playlist.replace(playlist)
 
 
-class NowPlaying(MediaEntry):
-    """ Live Tracking of currently playing media via bus events """
-
-    def __init__(self, bus, player: "Optional[OCPMediaPlayer]" = None, *args, **kwargs):
-        self.bus = bus
-        self._player: "Optional[OCPMediaPlayer]" = player
-        self.stream_xtract = load_stream_extractors()
-        self.position = 0
-        super().__init__(*args, **kwargs)
-        self.original_uri = self.uri
-
-    def as_entry(self) -> MediaEntry:
-        """
-        Return a MediaEntry representation of this object
-        """
-        return MediaEntry(**self.as_dict)
-
-    @property
-    def as_dict(self) -> dict:
-        """
-        Return a dict representation of this object's MediaEntry fields.
-
-        NowPlaying is not itself decorated with @dataclass and carries plain
-        instance attributes (bus, _player, stream_xtract, ...) alongside the
-        MediaEntry dataclass fields it inherits. orjson only recognizes a
-        type as a dataclass via that exact class's own __dict__, not an
-        inherited one, so serializing a NowPlaying instance directly (as the
-        inherited MediaEntry.as_dict does) raises
-        "TypeError: Type is not JSON serializable: NowPlaying".
-
-        Build a genuine MediaEntry from just the declared dataclass fields
-        and delegate serialization to it; fields added to MediaEntry keep
-        surviving the round-trip automatically since they are read from
-        `dataclasses.fields(MediaEntry)` rather than a hand-maintained list.
-        """
-        fields = {f.name: getattr(self, f.name) for f in dataclasses.fields(MediaEntry)}
-        return MediaEntry(**fields).as_dict
-
-    def reset(self):
-        """
-        Reset the NowPlaying MediaEntry to default parameters
-        """
-        self.title = ""
-        self.artist = ""
-        self.skill_id = ""
-        self.position = 0
-        self.length = 0
-        self.javascript = ""
-        self.playback = PlaybackType.UNDEFINED
-        self.status = TrackState.DISAMBIGUATION
-        self.media_type = MediaType.GENERIC
-        self.skill_icon = ""
-        self.image = ""
-        # Without clearing these, a stopped/home'd player still reports
-        # the previous track's uri via now_playing.as_dict / GUI payload
-        self.uri = ""
-        self.original_uri = ""
-
-    def update(self, entry: MediaEntry, skipkeys: list = None, newonly: bool = False):
-        """
-        Update this MediaEntry
-        @param entry: dict or MediaEntry object to update this object with
-        @param skipkeys: list of keys to not change
-        @param newonly: if True, only adds new keys; existing keys are unchanged
-        """
-        if isinstance(entry, MediaEntry):
-            entry = entry.as_dict
-        super().update(entry, skipkeys, newonly)
-        # uri updates should not be skipped
-        if newonly and entry.get("uri"):
-            super().update({"uri": entry["uri"]})
-
-    def extract_stream(self):
-        """
-        Get metadata from ocp_plugins and add it to this MediaEntry
-        """
-        uri = self.uri
-        if not uri:
-            raise ValueError("No URI to extract stream from")
-        if self.playback == PlaybackType.VIDEO:
-            video = True
-        else:
-            video = False
-        meta = self.stream_xtract.extract_stream(uri, video)
-        # validate the extractor-returned uri BEFORE mutating any state -
-        # a non-string uri (int/list/dict) or a whitespace-only string must
-        # never poison self.uri/title, it must refuse the same way a
-        # missing uri does. An empty string is left alone: it is falsy, so
-        # update(newonly=True) below does not overwrite the existing uri
-        # with it anyway.
-        if meta:
-            extracted_uri = meta.get("uri")
-            if extracted_uri is not None and not isinstance(extracted_uri, str):
-                raise ValueError(f"invalid stream: {extracted_uri!r}")
-            if isinstance(extracted_uri, str) and extracted_uri and not extracted_uri.strip():
-                raise ValueError(f"invalid stream: {extracted_uri!r}")
-            if isinstance(extracted_uri, str) and any(
-                    is_injection_char(c) for c in extracted_uri):
-                # a uri that otherwise looks fine (eg. a valid http prefix)
-                # may still smuggle control characters/newlines - refuse
-                # before mutating state, same as the non-string/whitespace
-                # checks above (log/header-injection surface downstream)
-                raise ValueError(f"invalid stream: {extracted_uri!r}")
-            LOG.info(f"OCP plugins metadata: {meta}")
-            self.update(meta, newonly=True)
-            self.original_uri = uri
-
-        # validate extracted uri
-        if not any((self.uri.startswith(s) for s in ["http", "file", "/"])):
-            raise ValueError(f"invalid stream: {self.uri!r}")
-        # a uri passing the prefix check above may still smuggle control
-        # characters (eg. embedded newlines for header/log injection) -
-        # refuse those too
-        if any(is_injection_char(c) for c in self.uri):
-            raise ValueError(f"invalid stream: {self.uri!r}")
-
-    # bus api
-    def handle_external_play(self, message):
-        """
-        Handle 'ovos.common_play.play' Messages. Update the metadata with new
-        data received unconditionally, otherwise previous song keys might
-        bleed into the new track
-        @param message: Message associated with request
-        """
-        media = decode_media(message.data)
-        if media is None:
-            return
-        self.update(media, newonly=False)
-
-    # events from media services
-    def handle_track_state_change(self, message):
-        """
-        Handle 'ovos.common_play.track.state' Messages. Update status
-        @param message: Message with updated `state` data
-        @return:
-        """
-        state = decode_track_state(message.data)
-        if state == self.status:
-            return
-        LOG.info(f"TrackState changed: {repr(self.status)} -> {repr(state)}")
-        self.status = state
-
-        if state in (TrackState.PLAYING_AUDIO, TrackState.PLAYING_VIDEO,
-                     TrackState.PLAYING_WEBVIEW, TrackState.PLAYING_SKILL,
-                     TrackState.PLAYING_AUDIOSERVICE, TrackState.PLAYING_MPRIS):
-            # backend confirmed playback started — mark player as PLAYING
-            if hasattr(self, '_player') and self._player is not None:
-                self._player.set_player_state(PlayerState.PLAYING)
-                # W4-followup: reset the per-queue failure guards on evidence
-                # of PLAYBACK, not on LOADED_MEDIA. base.py's
-                # handle_media_state_change emits LOADED_MEDIA and THEN, for
-                # a track that loads fine but raises out of current.play(),
-                # INVALID_MEDIA — with the guard reset on LOADED_MEDIA that
-                # sequence reset both _failed_uris and _track_failed_spoken
-                # on every single failing track (rate limit degraded to
-                # per-track chatter, and a REPEAT queue where every track
-                # loads-ok-but-fails-to-play never accumulated enough of
-                # _failed_uris to trip _all_tracks_failed(), looping without
-                # bound). This TrackState.PLAYING_* branch only fires after
-                # current.play() returns without raising, ie. real evidence
-                # of playback — see base.py's handle_media_state_change.
-                self._player._failed_uris.clear()
-                self._player._track_failed_spoken = False
-        elif state in (TrackState.QUEUED_SKILL, TrackState.QUEUED_VIDEO,
-                       TrackState.QUEUED_AUDIO, TrackState.QUEUED_AUDIOSERVICE,
-                       TrackState.QUEUED_WEBVIEW):
-            # audio service is handling playback and this is queued in playlist
-            pass
-        elif state == TrackState.DISAMBIGUATION:
-            # alternative results list — no playback state change
-            pass
-        # NOTE: pause is a PlayerState/MediaState concern, never a TrackState —
-        # there is no TrackState.PAUSED_* member, so no pause branch belongs here.
-
-    def on_end_of_media(self):
-        """
-        End-of-media reset, invoked as a plain method call by
-        OCPMediaPlayer.handle_player_media_update (the only consumer of
-        END_OF_MEDIA on 'ovos.common_play.media.state') AFTER it has captured
-        the pre-reset playback type and uri. Playback ended, so allow the next track to
-        change metadata again.
-        """
-        self.reset()
-
-    def handle_media_state_change(self, message):
-        """
-        Handle 'ovos.common_play.media.state' Messages. If ended, reset.
-
-        NOT registered on the bus (see __init__): kept as a callable entry
-        point for out-of-tree callers that drive NowPlaying directly.
-        @param message: Message with updated MediaState
-        """
-        state = decode_media_state(message.data)
-        if state == MediaState.END_OF_MEDIA:
-            self.on_end_of_media()
-
-    def handle_sync_seekbar(self, message):
-        """
-        Handle 'ovos.common_play.playback_time' Messages sent by audio backend
-        @param message: Message with 'length' and 'position' data
-        """
-        for field, value in decode_playback_time(message.data).items():
-            setattr(self, field, value)
-
-
 class OCPMediaPlayer:
     """OCP Virtual Media Player
 
@@ -587,12 +386,14 @@ class OCPMediaPlayer:
         self.state: PlayerState = PlayerState.STOPPED
         self.loop_state: LoopState = LoopState.NONE
         self.media_state: MediaState = MediaState.NO_MEDIA
-        self.playlist: Playlist = Playlist(title="Search Results")
         self.shuffle: bool = False
         self.track_history: dict = {}  # Dict of track URI to play count
         self.media: OCPMediaCatalog = OCPMediaCatalog(bus=bus, skill_id=OCP_ID + ".favorites",
                                                        validate_source=self.validate_source)
         self._init_runtime_state()
+        # the owned queue, also the container the rest of the world reads as
+        # "the playlist" (bus status, MPRIS track list)
+        self.playlist: PlayQueue = self._queue
 
         self.now_playing: NowPlaying = NowPlaying(bus, player=self)
         # BaseMediaService.stop() calls this on_stop callback to flag the
@@ -660,15 +461,10 @@ class OCPMediaPlayer:
         # ocp_stop(), so a stop is indistinguishable from a natural track end at
         # the media.state level without this flag.
         self._stop_requested: bool = False
-        # The exact MediaEntry object currently selected. Located by
-        # identity in _queue_index(), which makes duplicate uris in a playlist
-        # (eg. [a, b, a]) advance correctly instead of ping-ponging, and
-        # survives the END_OF_MEDIA reset that clears now_playing.uri.
-        self._current_entry: Optional[MediaEntry] = None
-        # Uris that failed to load since the last successful load. Used to
-        # stop LoopState.REPEAT from restarting a queue in which every track is
-        # broken (unbounded hot loop).
-        self._failed_uris: set = set()
+        # owns the user queue, the identity of the selected entry and the
+        # failed-uri bookkeeping, and answers every "which track is next"
+        # question; what to DO with the answer stays player policy
+        self._queue: PlayQueue = PlayQueue(title="Search Results")
         self._invalid_timer: Optional[threading.Timer] = None
         # retry delay after an invalid stream, seconds (overridable in tests)
         self.invalid_stream_delay: float = 3.0
@@ -680,6 +476,19 @@ class OCPMediaPlayer:
         # of this player — spoken only at the very first play attempt that
         # finds zero backends loaded, never again
         self._no_backend_dialog_spoken: bool = False
+
+    # views on the owned queue's bookkeeping
+    @property
+    def _current_entry(self) -> Optional[MediaEntry]:
+        return self._queue.current
+
+    @_current_entry.setter
+    def _current_entry(self, entry: Optional[MediaEntry]):
+        self._queue.current = entry
+
+    @property
+    def _failed_uris(self) -> set:
+        return self._queue.failed
 
     def handle_status(self, message):
         self.bus.emit(message.response({
@@ -777,21 +586,11 @@ class OCPMediaPlayer:
         return self.media.search_playlist.entries
 
     def _merged_queue(self) -> List[MediaEntry]:
-        """Return the merged, deduplicated playback queue.
-
-        User-playlist entries come first (strict priority).  Search results
-        are appended afterwards, skipping any URI already present in the user
-        playlist.  Deduplication is O(n) via a URI set — no O(n²) scanning.
-
-        If ``merge_search`` is disabled in config only the user playlist is
-        returned.
-        """
-        user_entries = list(self.playlist.entries)
-        if not self.ocp_config.get("merge_search", True):
-            return user_entries
-        seen: set = {e.uri for e in user_entries}
-        extra = [e for e in self.media.search_playlist.entries if e.uri not in seen]
-        return user_entries + extra
+        """Return the merged, deduplicated playback queue: the user queue plus
+        the search results, unless ``merge_search`` is disabled in config."""
+        return self._queue.merged(self.search_results,
+                                  self.ocp_config.get("merge_search", True),
+                                  user_entries=self.tracks)
 
     def _mark_stop_requested(self):
         """Flag that the current playback is ending because it was stopped.
@@ -811,38 +610,20 @@ class OCPMediaPlayer:
                 self._invalid_timer.cancel()
                 self._invalid_timer = None
 
+    def _locator_uri(self, uri: str = None) -> Optional[str]:
+        """The uri to locate the current track by, when entry identity does
+        not resolve it: an explicitly given one, else the now-playing uri."""
+        return uri or (self.now_playing.uri if self.now_playing else None)
+
+    def _locator_position(self) -> Optional[int]:
+        """The queue pointer, used as a locator hint when it agrees with the
+        uri being looked for."""
+        return getattr(self.playlist, "position", None)
+
     def _queue_index(self, queue: List[MediaEntry], uri: str = None) -> int:
-        """Return the index of the currently selected track in *queue*, or -1.
-
-        Resolution order:
-
-        1. **Entry identity** — the exact MediaEntry object last handed to
-           ``set_now_playing``. This is the only reliable locator when the same
-           uri appears more than once in a queue (``[a, b, a]``), and it
-           survives the END_OF_MEDIA reset that clears ``now_playing.uri``.
-        2. **Playlist position** — ``self.playlist.position``, accepted only if
-           it points at an entry whose uri matches the one we are looking for.
-        3. **URI lookup** — first entry with a matching uri.
-        """
-        cur = self._current_entry
-        if cur is not None:
-            for i, entry in enumerate(queue):
-                if entry is cur:
-                    return i
-
-        uri = uri or (self.now_playing.uri if self.now_playing else None) or \
-              (cur.uri if cur is not None else None)
-        if not uri:
-            return -1
-
-        pos = getattr(self.playlist, "position", None)
-        if isinstance(pos, int) and 0 <= pos < len(queue) and queue[pos].uri == uri:
-            return pos
-
-        for i, entry in enumerate(queue):
-            if entry.uri == uri:
-                return i
-        return -1
+        """Return the index of the currently selected track in *queue*, or -1."""
+        return self._queue.index(queue, uri=self._locator_uri(uri),
+                                 position=self._locator_position())
 
     @property
     def can_prev(self) -> bool:
@@ -851,9 +632,9 @@ class OCPMediaPlayer:
         """
         if self.playback_type == PlaybackType.MPRIS:
             return True
-        queue = self._merged_queue()
-        idx = self._queue_index(queue)
-        return idx > 0
+        return self._queue.has_prev(self._merged_queue(),
+                                    uri=self._locator_uri(),
+                                    position=self._locator_position())
 
     @property
     def can_next(self) -> bool:
@@ -864,9 +645,9 @@ class OCPMediaPlayer:
                 self.shuffle or \
                 self.playback_type == PlaybackType.MPRIS:
             return True
-        queue = self._merged_queue()
-        idx = self._queue_index(queue)
-        return idx >= 0 and idx + 1 < len(queue)
+        return self._queue.has_next(self._merged_queue(),
+                                    uri=self._locator_uri(),
+                                    position=self._locator_position())
 
     # state
     def set_media_state(self, state: MediaState):
@@ -1113,9 +894,7 @@ class OCPMediaPlayer:
         # remember this uri as broken so LoopState.REPEAT cannot restart a
         # queue whose every track has failed (that was an unbounded hot loop:
         # 1-track repeat playlist + a backend that always reports INVALID_MEDIA).
-        uri = self.now_playing.uri if self.now_playing else None
-        if uri:
-            self._failed_uris.add(uri)
+        self._queue.mark_failed(self.now_playing.uri if self.now_playing else None)
         # Use a timer so the bus event loop is not blocked during the pause
         self._schedule_play_next()
 
@@ -1341,30 +1120,14 @@ class OCPMediaPlayer:
             sequential path's "no more tracks" end-of-queue case instead of
             replaying forever.
         """
-        queue = self._merged_queue()
-        if not queue:
-            current_uri = self.now_playing.uri if self.now_playing else None
-            if current_uri is not None and current_uri in self._failed_uris:
-                LOG.debug("Shuffle: queue is empty and current track failed")
-                return False
-            LOG.debug("Shuffle: queue is empty, replaying current track")
-            return True
-        current_uri = self.now_playing.uri if self.now_playing else None
-        candidates = [e for e in queue
-                      if e.uri != current_uri and e.uri not in self._failed_uris]
-        if not candidates:
-            if self.loop_state == LoopState.REPEAT and current_uri and \
-                    current_uri not in self._failed_uris:
-                # nothing else to shuffle to, but repeat is on and the
-                # current track itself hasn't failed - keep it playing
-                # instead of stopping (mirrors play_next's sequential
-                # end-of-queue-with-repeat restart)
-                LOG.debug("Shuffle: no other viable tracks, repeat is on "
-                          "— keeping current track")
-                return True
+        pick = self._queue.select_shuffle(
+            self._merged_queue(),
+            current_uri=self.now_playing.uri if self.now_playing else None,
+            repeat=self.loop_state == LoopState.REPEAT)
+        if isinstance(pick, QueueEnd):
             return False
-        pick = random.choice(candidates)
-        LOG.debug(f"Shuffle pick: {pick.title!r}")
+        if isinstance(pick, KeepCurrent):
+            return True
         self.set_now_playing(pick)
         return True
 
@@ -1372,7 +1135,7 @@ class OCPMediaPlayer:
         """True if every track in *queue* has failed to load since the last
         successful load. Used to break the repeat cycle instead of retrying a
         wholly broken queue forever."""
-        return bool(queue) and all(e.uri in self._failed_uris for e in queue)
+        return self._queue.all_failed(queue)
 
     def play_next(self, finished_uri: str = None):
         """
@@ -1440,23 +1203,21 @@ class OCPMediaPlayer:
             return
 
         queue = self._merged_queue()
-        idx = self._queue_index(queue, uri=finished_uri)
+        selection = self._queue.select_next(
+            queue, uri=self._locator_uri(finished_uri),
+            position=self._locator_position(),
+            repeat=self.loop_state == LoopState.REPEAT)
 
-        if idx >= 0 and idx + 1 < len(queue):
-            next_track = queue[idx + 1]
-            LOG.info(f"Next track: {next_track.title!r} (queue index {idx + 1}/{len(queue) - 1})")
-            self.set_now_playing(next_track)
-        elif self.loop_state == LoopState.REPEAT and queue:
+        if isinstance(selection, AllFailed):
             # never restart a queue in which every track has already failed
             # to load since the last successful one — that is an unbounded hot
             # loop, not a repeat.
-            if self._all_tracks_failed(queue):
-                LOG.warning("End of queue with repeat == True, but every track "
-                            "failed to load — stopping instead of looping")
-                self.set_player_state(PlayerState.STOPPED)
-                return
-            LOG.info("End of queue, repeat == True — restarting from beginning")
-            self.set_now_playing(queue[0])
+            LOG.warning("End of queue with repeat == True, but every track "
+                        "failed to load — stopping instead of looping")
+            self.set_player_state(PlayerState.STOPPED)
+            return
+        elif not isinstance(selection, QueueEnd):
+            self.set_now_playing(selection)
         else:
             LOG.info("Requested next, but there are no more tracks in the queue")
             # end of queue with repeat off previously left the player
@@ -1507,16 +1268,15 @@ class OCPMediaPlayer:
             self.play()
             return
 
-        queue = self._merged_queue()
-        idx = self._queue_index(queue)
+        selection = self._queue.select_prev(
+            self._merged_queue(), uri=self._locator_uri(),
+            position=self._locator_position())
 
-        if idx > 0:
-            prev_track = queue[idx - 1]
-            LOG.debug(f"Previous track: {prev_track.title!r} (queue index {idx - 1}/{len(queue) - 1})")
-            self.set_now_playing(prev_track)
-            self.play()
-        else:
+        if isinstance(selection, QueueEnd):
             LOG.debug("Requested previous, but already at the first track")
+        else:
+            self.set_now_playing(selection)
+            self.play()
 
     def pause(self):
         """

--- a/ovos_media/player/now_playing.py
+++ b/ovos_media/player/now_playing.py
@@ -1,0 +1,178 @@
+"""Live tracking of the media the player currently has loaded."""
+import dataclasses
+
+from ovos_plugin_manager.ocp import load_stream_extractors
+from ovos_utils.log import LOG
+from ovos_utils.ocp import (MediaEntry, MediaState, MediaType, PlaybackType,
+                            PlayerState, TrackState)
+
+from ovos_media.bus.schemas import (decode_media, decode_media_state,
+                                    decode_playback_time, decode_track_state)
+from ovos_media.player import streams
+
+
+class NowPlaying(MediaEntry):
+    """ Live Tracking of currently playing media via bus events """
+
+    def __init__(self, bus, player=None, *args, **kwargs):
+        self.bus = bus
+        self._player = player
+        self.stream_xtract = load_stream_extractors()
+        self.position = 0
+        super().__init__(*args, **kwargs)
+        self.original_uri = self.uri
+
+    def as_entry(self) -> MediaEntry:
+        """
+        Return a MediaEntry representation of this object
+        """
+        return MediaEntry(**self.as_dict)
+
+    @property
+    def as_dict(self) -> dict:
+        """
+        Return a dict representation of this object's MediaEntry fields.
+
+        NowPlaying is not itself decorated with @dataclass and carries plain
+        instance attributes (bus, _player, stream_xtract, ...) alongside the
+        MediaEntry dataclass fields it inherits. orjson only recognizes a
+        type as a dataclass via that exact class's own __dict__, not an
+        inherited one, so serializing a NowPlaying instance directly (as the
+        inherited MediaEntry.as_dict does) raises
+        "TypeError: Type is not JSON serializable: NowPlaying".
+
+        Build a genuine MediaEntry from just the declared dataclass fields
+        and delegate serialization to it; fields added to MediaEntry keep
+        surviving the round-trip automatically since they are read from
+        `dataclasses.fields(MediaEntry)` rather than a hand-maintained list.
+        """
+        fields = {f.name: getattr(self, f.name) for f in dataclasses.fields(MediaEntry)}
+        return MediaEntry(**fields).as_dict
+
+    def reset(self):
+        """
+        Reset the NowPlaying MediaEntry to default parameters
+        """
+        self.title = ""
+        self.artist = ""
+        self.skill_id = ""
+        self.position = 0
+        self.length = 0
+        self.javascript = ""
+        self.playback = PlaybackType.UNDEFINED
+        self.status = TrackState.DISAMBIGUATION
+        self.media_type = MediaType.GENERIC
+        self.skill_icon = ""
+        self.image = ""
+        # Without clearing these, a stopped/home'd player still reports
+        # the previous track's uri via now_playing.as_dict / GUI payload
+        self.uri = ""
+        self.original_uri = ""
+
+    def update(self, entry: MediaEntry, skipkeys: list = None, newonly: bool = False):
+        """
+        Update this MediaEntry
+        @param entry: dict or MediaEntry object to update this object with
+        @param skipkeys: list of keys to not change
+        @param newonly: if True, only adds new keys; existing keys are unchanged
+        """
+        if isinstance(entry, MediaEntry):
+            entry = entry.as_dict
+        super().update(entry, skipkeys, newonly)
+        # uri updates should not be skipped
+        if newonly and entry.get("uri"):
+            super().update({"uri": entry["uri"]})
+
+    def extract_stream(self):
+        """
+        Get metadata from ocp_plugins and add it to this MediaEntry
+        """
+        streams.extract_stream(self, self.playback == PlaybackType.VIDEO,
+                               self.stream_xtract)
+
+    # bus api
+    def handle_external_play(self, message):
+        """
+        Handle 'ovos.common_play.play' Messages. Update the metadata with new
+        data received unconditionally, otherwise previous song keys might
+        bleed into the new track
+        @param message: Message associated with request
+        """
+        media = decode_media(message.data)
+        if media is None:
+            return
+        self.update(media, newonly=False)
+
+    # events from media services
+    def handle_track_state_change(self, message):
+        """
+        Handle 'ovos.common_play.track.state' Messages. Update status
+        @param message: Message with updated `state` data
+        @return:
+        """
+        state = decode_track_state(message.data)
+        if state == self.status:
+            return
+        LOG.info(f"TrackState changed: {repr(self.status)} -> {repr(state)}")
+        self.status = state
+
+        if state in (TrackState.PLAYING_AUDIO, TrackState.PLAYING_VIDEO,
+                     TrackState.PLAYING_WEBVIEW, TrackState.PLAYING_SKILL,
+                     TrackState.PLAYING_AUDIOSERVICE, TrackState.PLAYING_MPRIS):
+            # backend confirmed playback started — mark player as PLAYING
+            if hasattr(self, '_player') and self._player is not None:
+                self._player.set_player_state(PlayerState.PLAYING)
+                # reset the per-queue failure guards on evidence of PLAYBACK,
+                # not on LOADED_MEDIA. base.py's handle_media_state_change
+                # emits LOADED_MEDIA and THEN, for a track that loads fine but
+                # raises out of current.play(), INVALID_MEDIA — with the guard
+                # reset on LOADED_MEDIA that sequence reset both _failed_uris
+                # and _track_failed_spoken on every single failing track (rate
+                # limit degraded to per-track chatter, and a REPEAT queue where
+                # every track loads-ok-but-fails-to-play never accumulated
+                # enough of _failed_uris to trip all_failed(), looping without
+                # bound). This TrackState.PLAYING_* branch only fires after
+                # current.play() returns without raising, ie. real evidence of
+                # playback — see base.py's handle_media_state_change.
+                self._player._failed_uris.clear()
+                self._player._track_failed_spoken = False
+        elif state in (TrackState.QUEUED_SKILL, TrackState.QUEUED_VIDEO,
+                       TrackState.QUEUED_AUDIO, TrackState.QUEUED_AUDIOSERVICE,
+                       TrackState.QUEUED_WEBVIEW):
+            # audio service is handling playback and this is queued in playlist
+            pass
+        elif state == TrackState.DISAMBIGUATION:
+            # alternative results list — no playback state change
+            pass
+        # NOTE: pause is a PlayerState/MediaState concern, never a TrackState —
+        # there is no TrackState.PAUSED_* member, so no pause branch belongs here.
+
+    def on_end_of_media(self):
+        """
+        End-of-media reset, invoked as a plain method call by
+        OCPMediaPlayer.handle_player_media_update (the only consumer of
+        END_OF_MEDIA on 'ovos.common_play.media.state') AFTER it has captured
+        the pre-reset playback type and uri. Playback ended, so allow the next track to
+        change metadata again.
+        """
+        self.reset()
+
+    def handle_media_state_change(self, message):
+        """
+        Handle 'ovos.common_play.media.state' Messages. If ended, reset.
+
+        NOT registered on the bus (see ovos_media.bus.api): kept as a callable
+        entry point for out-of-tree callers that drive NowPlaying directly.
+        @param message: Message with updated MediaState
+        """
+        state = decode_media_state(message.data)
+        if state == MediaState.END_OF_MEDIA:
+            self.on_end_of_media()
+
+    def handle_sync_seekbar(self, message):
+        """
+        Handle 'ovos.common_play.playback_time' Messages sent by audio backend
+        @param message: Message with 'length' and 'position' data
+        """
+        for field, value in decode_playback_time(message.data).items():
+            setattr(self, field, value)

--- a/ovos_media/player/queue.py
+++ b/ovos_media/player/queue.py
@@ -1,0 +1,304 @@
+"""The playback queue owned by :class:`~ovos_media.player.OCPMediaPlayer`.
+
+:class:`PlayQueue` holds the user queue (the entries the player was asked to
+play), the identity of the entry currently selected, and the uris that failed
+to load since the last successful one. It also answers every "which track
+comes next" question — merging in search results, locating the current entry,
+picking a shuffle candidate — but it never decides what to *do* with the
+answer: repeat, autoplay and stop remain player policy.
+"""
+import random
+from typing import List, Optional, Union
+
+from ovos_utils.log import LOG
+from ovos_utils.ocp import MediaEntry, Playlist, PluginStream, dict2entry
+
+
+class QueueEnd:
+    """Returned by a selection when the queue has no further track."""
+
+
+class AllFailed:
+    """Returned by a selection when every track in the queue failed to load.
+
+    Distinct from :class:`QueueEnd` because a repeat cycle must break on it
+    instead of restarting an entirely broken queue.
+    """
+
+
+class KeepCurrent:
+    """Returned by a shuffle pick when the current track should keep playing.
+
+    There is nothing meaningful to shuffle to (empty/singleton queue, or
+    repeat is on and only the current, unfailed track remains).
+    """
+
+
+QUEUE_END = QueueEnd()
+ALL_FAILED = AllFailed()
+KEEP_CURRENT = KeepCurrent()
+
+Selection = Union[MediaEntry, QueueEnd, AllFailed, KeepCurrent]
+
+
+class PlayQueue:
+    """The player's own queue of :class:`MediaEntry` objects."""
+
+    def __init__(self, entries: List[MediaEntry] = None, title: str = ""):
+        self.title = title
+        self.position = 0
+        self._entries: List[MediaEntry] = []
+        # The exact MediaEntry object currently selected. Located by identity
+        # in index(), which makes duplicate uris in a queue (eg. [a, b, a])
+        # advance correctly instead of ping-ponging, and survives the
+        # END_OF_MEDIA reset that clears now_playing.uri.
+        self.current: Optional[MediaEntry] = None
+        # Uris that failed to load since the last successful load. Used to
+        # stop LoopState.REPEAT from restarting a queue in which every track
+        # is broken (unbounded hot loop).
+        self.failed: set = set()
+        for entry in entries or []:
+            self.add_entry(entry)
+
+    # container
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def __iter__(self):
+        return iter(self._entries)
+
+    def __getitem__(self, idx):
+        return self._entries[idx]
+
+    def __contains__(self, entry) -> bool:
+        return entry in self._entries
+
+    def __repr__(self) -> str:
+        return f"PlayQueue({self._entries!r})"
+
+    @property
+    def entries(self) -> List[Union[MediaEntry, PluginStream]]:
+        """The playable members of the queue.
+
+        A track that is itself a playlist is a legitimate queue member (that
+        is how a playlist result arrives over the wire, see bus.schemas) and
+        stays in the backing list, where sanitization reaches it. It has no
+        uri of its own, though, so every uri-based consumer — merging,
+        locating the current track, advancing — reads this view instead.
+        """
+        return [e for e in self._entries
+                if isinstance(e, (MediaEntry, PluginStream))]
+
+    @property
+    def length(self) -> int:
+        """Total duration of the queue; -1 stands for a live stream."""
+        return max(-1, sum(e.length for e in self.entries))
+
+    @property
+    def is_first_track(self) -> bool:
+        if not self._entries:
+            return True
+        return self.position == 0
+
+    @property
+    def is_last_track(self) -> bool:
+        if not self._entries:
+            return True
+        return self.position == len(self._entries) - 1
+
+    def set_position(self, idx: int) -> None:
+        self.position = idx
+        self._validate_position()
+
+    def _validate_position(self) -> None:
+        if self.position < 0 or self.position >= len(self._entries):
+            LOG.error(f"Queue pointer is in an invalid position "
+                      f"({self.position})! Going to start of queue")
+            self.position = 0
+
+    def add_entry(self, entry: Union[dict, MediaEntry, PluginStream],
+                  index: int = -1) -> None:
+        """Add an entry at *index* (-1 appends)."""
+        assert isinstance(index, int)
+        if index > len(self._entries):
+            raise ValueError(f"Invalid index {index} requested, "
+                             f"queue only has {len(self._entries)} entries")
+        if isinstance(entry, dict):
+            entry = dict2entry(entry)
+        # a nested Playlist is a legitimate entry: that is how a playlist
+        # result arrives over the wire (see bus.schemas)
+        assert isinstance(entry, (MediaEntry, PluginStream, Playlist))
+        if index == -1:
+            index = len(self._entries)
+        had_current_track = len(self._entries) > 0
+        self._entries.insert(index, entry)
+        if had_current_track and index <= self.position:
+            self.set_position(self.position + 1)
+
+    def replace(self, new_list: List[Union[dict, MediaEntry]]) -> None:
+        self.clear()
+        for entry in new_list:
+            self.add_entry(entry)
+
+    def clear(self) -> None:
+        self._entries.clear()
+        self.position = 0
+
+    def goto_track(self, track: Union[dict, MediaEntry, PluginStream]) -> None:
+        """Move the position pointer to *track*, matched by uri."""
+        if isinstance(track, dict):
+            track = dict2entry(track)
+        assert isinstance(track, (MediaEntry, Playlist, PluginStream))
+        requested_uri = self._uri_of(track)
+        for idx, entry in enumerate(self._entries):
+            if self._uri_of(entry) == requested_uri:
+                self.set_position(idx)
+                LOG.debug(f"New queue position: {self.position}")
+                return
+        LOG.error(f"requested track not in the queue: {track}")
+
+    @staticmethod
+    def _uri_of(track) -> str:
+        """What a track is matched on: its uri, the stream of a plugin
+        entry, or the title of a nested playlist, which has neither."""
+        if isinstance(track, MediaEntry):
+            return track.uri
+        if isinstance(track, PluginStream):
+            return track.stream
+        return track.title
+
+    # failed-uri bookkeeping
+    def mark_failed(self, uri: str) -> None:
+        if uri:
+            self.failed.add(uri)
+
+    def clear_failed(self) -> None:
+        self.failed.clear()
+
+    def all_failed(self, queue: List[MediaEntry]) -> bool:
+        """True if every track in *queue* has failed since the last
+        successful load."""
+        return bool(queue) and all(e.uri in self.failed for e in queue)
+
+    # queue algebra
+    def merged(self, search_entries: List[MediaEntry],
+               merge_search: bool = True,
+               user_entries: List[MediaEntry] = None) -> List[MediaEntry]:
+        """Return the merged, deduplicated playback queue.
+
+        User entries come first (strict priority). Search results are appended
+        afterwards, skipping any uri already present among the user entries.
+        Deduplication is O(n) via a uri set. With *merge_search* disabled only
+        the user entries are returned.
+        """
+        user_entries = list(self.entries if user_entries is None else user_entries)
+        if not merge_search:
+            return user_entries
+        seen = {e.uri for e in user_entries}
+        return user_entries + [e for e in search_entries if e.uri not in seen]
+
+    def index(self, queue: List[MediaEntry], uri: str = None,
+              position: int = None) -> int:
+        """Return the index of the currently selected track in *queue*, or -1.
+
+        Resolution order:
+
+        1. **Entry identity** — the exact MediaEntry object last selected.
+           This is the only reliable locator when the same uri appears more
+           than once in a queue (``[a, b, a]``), and it survives the
+           END_OF_MEDIA reset that clears the now-playing uri.
+        2. **Queue position** — *position*, accepted only if it points at an
+           entry whose uri matches the one we are looking for.
+        3. **URI lookup** — first entry with a matching uri.
+        """
+        if self.current is not None:
+            for i, entry in enumerate(queue):
+                if entry is self.current:
+                    return i
+
+        uri = uri or (self.current.uri if self.current is not None else None)
+        if not uri:
+            return -1
+
+        if isinstance(position, int) and 0 <= position < len(queue) and \
+                queue[position].uri == uri:
+            return position
+
+        for i, entry in enumerate(queue):
+            if entry.uri == uri:
+                return i
+        return -1
+
+    def has_prev(self, queue: List[MediaEntry], uri: str = None,
+                 position: int = None) -> bool:
+        """True if there is a track before the current one in *queue*."""
+        return self.index(queue, uri=uri, position=position) > 0
+
+    def has_next(self, queue: List[MediaEntry], uri: str = None,
+                 position: int = None) -> bool:
+        """True if there is a track after the current one in *queue*."""
+        idx = self.index(queue, uri=uri, position=position)
+        return idx >= 0 and idx + 1 < len(queue)
+
+    def select_next(self, queue: List[MediaEntry], uri: str = None,
+                    position: int = None, repeat: bool = False) -> Selection:
+        """Select the track that follows the current one.
+
+        Returns the MediaEntry to play, ``ALL_FAILED`` when *repeat* would
+        restart a queue whose every track is broken, or ``QUEUE_END``.
+        """
+        idx = self.index(queue, uri=uri, position=position)
+        if idx >= 0 and idx + 1 < len(queue):
+            next_track = queue[idx + 1]
+            LOG.info(f"Next track: {next_track.title!r} "
+                     f"(queue index {idx + 1}/{len(queue) - 1})")
+            return next_track
+        if repeat and queue:
+            if self.all_failed(queue):
+                return ALL_FAILED
+            LOG.info("End of queue, repeat == True — restarting from beginning")
+            return queue[0]
+        return QUEUE_END
+
+    def select_prev(self, queue: List[MediaEntry], uri: str = None,
+                    position: int = None) -> Selection:
+        """Select the track before the current one, or ``QUEUE_END``."""
+        idx = self.index(queue, uri=uri, position=position)
+        if idx > 0:
+            prev_track = queue[idx - 1]
+            LOG.debug(f"Previous track: {prev_track.title!r} "
+                      f"(queue index {idx - 1}/{len(queue) - 1})")
+            return prev_track
+        return QUEUE_END
+
+    def select_shuffle(self, queue: List[MediaEntry], current_uri: str = None,
+                       repeat: bool = False) -> Selection:
+        """Pick a random track from *queue*, excluding the current one and
+        every uri already known to be broken.
+
+        Returns the MediaEntry to play, ``KEEP_CURRENT`` when there is nothing
+        meaningful to shuffle to and the current track should keep playing, or
+        ``QUEUE_END`` when no viable track remains.
+        """
+        if not queue:
+            if current_uri is not None and current_uri in self.failed:
+                LOG.debug("Shuffle: queue is empty and current track failed")
+                return QUEUE_END
+            LOG.debug("Shuffle: queue is empty, replaying current track")
+            return KEEP_CURRENT
+
+        candidates = [e for e in queue
+                      if e.uri != current_uri and e.uri not in self.failed]
+        if not candidates:
+            if repeat and current_uri and current_uri not in self.failed:
+                # nothing else to shuffle to, but repeat is on and the current
+                # track itself hasn't failed - keep it playing instead of
+                # stopping (mirrors the sequential end-of-queue restart)
+                LOG.debug("Shuffle: no other viable tracks, repeat is on "
+                          "— keeping current track")
+                return KEEP_CURRENT
+            return QUEUE_END
+
+        pick = random.choice(candidates)
+        LOG.debug(f"Shuffle pick: {pick.title!r}")
+        return pick

--- a/ovos_media/player/streams.py
+++ b/ovos_media/player/streams.py
@@ -1,0 +1,63 @@
+"""Stream extraction for a media entry.
+
+OCP plugins turn a ``{SEI}//{uri}`` reference into a real stream plus extra
+metadata at playback time. This module runs that extraction against an entry
+and validates whatever comes back before any of it reaches the entry.
+"""
+from typing import Optional
+
+from ovos_plugin_manager.ocp import load_stream_extractors
+from ovos_utils.log import LOG
+
+from ovos_media.bus.schemas import is_injection_char
+
+
+def extract_stream(entry, video: bool, stream_xtract=None) -> None:
+    """Resolve the stream of *entry* and merge the extractor metadata into it.
+
+    @param entry: MediaEntry (or NowPlaying) to resolve and update in place
+    @param video: whether a video stream is wanted
+    @param stream_xtract: stream extractor collection; loaded on demand
+    @raise ValueError: the entry has no uri, or the resolved uri is not a
+        playable stream
+    """
+    uri = entry.uri
+    if not uri:
+        raise ValueError("No URI to extract stream from")
+    if stream_xtract is None:
+        stream_xtract = load_stream_extractors()
+    meta = stream_xtract.extract_stream(uri, video)
+    # validate the extractor-returned uri BEFORE mutating any state - a
+    # non-string uri (int/list/dict) or a whitespace-only string must never
+    # poison the entry's uri/title, it must refuse the same way a missing uri
+    # does. An empty string is left alone: it is falsy, so update(newonly=True)
+    # below does not overwrite the existing uri with it anyway.
+    if meta:
+        _validate_extracted_uri(meta.get("uri"))
+        LOG.info(f"OCP plugins metadata: {meta}")
+        entry.update(meta, newonly=True)
+        entry.original_uri = uri
+
+    # validate extracted uri
+    if not any(entry.uri.startswith(s) for s in ["http", "file", "/"]):
+        raise ValueError(f"invalid stream: {entry.uri!r}")
+    # a uri passing the prefix check above may still smuggle control
+    # characters (eg. embedded newlines for header/log injection) - refuse
+    # those too
+    if any(is_injection_char(c) for c in entry.uri):
+        raise ValueError(f"invalid stream: {entry.uri!r}")
+
+
+def _validate_extracted_uri(extracted_uri: Optional[str]) -> None:
+    if extracted_uri is None:
+        return
+    if not isinstance(extracted_uri, str):
+        raise ValueError(f"invalid stream: {extracted_uri!r}")
+    if extracted_uri and not extracted_uri.strip():
+        raise ValueError(f"invalid stream: {extracted_uri!r}")
+    if any(is_injection_char(c) for c in extracted_uri):
+        # a uri that otherwise looks fine (eg. a valid http prefix) may still
+        # smuggle control characters/newlines - refuse before mutating state,
+        # same as the non-string/whitespace checks above (log/header-injection
+        # surface downstream)
+        raise ValueError(f"invalid stream: {extracted_uri!r}")

--- a/test/unittests/test_media_entry_shape.py
+++ b/test/unittests/test_media_entry_shape.py
@@ -29,7 +29,7 @@ class TestNowPlayingSerializesAllFields(unittest.TestCase):
 
     def _make_now_playing(self):
         from ovos_media.player import NowPlaying
-        with patch("ovos_media.player.load_stream_extractors"):
+        with patch("ovos_media.player.now_playing.load_stream_extractors"):
             return NowPlaying(FakeBus())
 
     def test_as_dict_covers_every_dataclass_field(self):

--- a/test/unittests/test_play_queue.py
+++ b/test/unittests/test_play_queue.py
@@ -1,0 +1,449 @@
+"""Tests for the player's owned queue, ovos_media.player.queue.PlayQueue.
+
+The queue answers "which track comes next"; it never decides what to do with
+the answer. Every selection therefore returns either a MediaEntry or one of
+the QueueEnd / AllFailed / KeepCurrent results the player branches on.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import MediaEntry, PlaybackType, Playlist
+
+from ovos_media.bus.schemas import validated_entries
+from ovos_media.player.queue import (AllFailed, KeepCurrent, PlayQueue,
+                                     QueueEnd)
+
+
+def _entry(uri, title="") -> MediaEntry:
+    return MediaEntry(uri=uri, title=title or uri,
+                      playback=PlaybackType.AUDIO)
+
+
+A = _entry("http://a.mp3")
+B = _entry("http://b.mp3")
+C = _entry("http://c.mp3")
+
+
+class TestContainer(unittest.TestCase):
+
+    def test_entries_are_owned_not_shared_with_the_caller(self):
+        seed = [A, B]
+        q = PlayQueue(seed)
+        seed.clear()
+        self.assertEqual(len(q), 2)
+
+    def test_add_entry_appends_by_default(self):
+        q = PlayQueue()
+        q.add_entry(A)
+        q.add_entry(B)
+        self.assertEqual([e.uri for e in q], [A.uri, B.uri])
+
+    def test_add_entry_from_dict_is_deserialized(self):
+        q = PlayQueue()
+        q.add_entry({"uri": "http://d.mp3", "title": "D"})
+        self.assertIsInstance(q[0], MediaEntry)
+        self.assertEqual(q[0].title, "D")
+
+    def test_insert_before_the_pointer_moves_the_pointer_along(self):
+        q = PlayQueue([A, B])
+        q.set_position(1)
+        q.add_entry(C, index=0)
+        self.assertEqual(q.position, 2)
+        self.assertEqual(q[q.position].uri, B.uri)
+
+    def test_index_beyond_the_end_is_refused(self):
+        q = PlayQueue([A])
+        with self.assertRaises(ValueError):
+            q.add_entry(B, index=5)
+
+    def test_clear_resets_the_pointer(self):
+        q = PlayQueue([A, B])
+        q.set_position(1)
+        q.clear()
+        self.assertEqual(len(q), 0)
+        self.assertEqual(q.position, 0)
+
+    def test_replace_swaps_the_contents(self):
+        q = PlayQueue([A])
+        q.replace([B, C])
+        self.assertEqual([e.uri for e in q], [B.uri, C.uri])
+
+    def test_goto_track_matches_by_uri(self):
+        q = PlayQueue([A, B, C])
+        q.goto_track(MediaEntry(uri=C.uri))
+        self.assertEqual(q.position, 2)
+
+    def test_goto_track_matches_an_empty_uri_against_an_empty_uri(self):
+        # a MediaEntry is matched on its uri unconditionally, empty or not,
+        # so two untitled empty-uri entries both resolve to the first one
+        q = PlayQueue([MediaEntry(uri="", title="first"),
+                       MediaEntry(uri="", title="second")])
+        q.goto_track(MediaEntry(uri="", title="second"))
+        self.assertEqual(q.position, 0)
+
+    def test_goto_track_matches_a_nested_playlist_by_title(self):
+        q = PlayQueue([A, Playlist(title="nested")])
+        q.goto_track(Playlist(title="nested"))
+        self.assertEqual(q.position, 1)
+
+    def test_goto_track_refuses_a_track_that_is_not_a_media_object(self):
+        q = PlayQueue([A])
+        with self.assertRaises(AssertionError):
+            q.goto_track("http://a.mp3")
+
+    def test_add_entry_refuses_a_track_that_is_not_a_media_object(self):
+        q = PlayQueue()
+        with self.assertRaises(AssertionError):
+            q.add_entry("http://a.mp3")
+
+    def test_goto_track_leaves_the_pointer_on_an_unknown_track(self):
+        q = PlayQueue([A, B])
+        q.set_position(1)
+        q.goto_track(MediaEntry(uri="http://nope.mp3"))
+        self.assertEqual(q.position, 1)
+
+    def test_out_of_range_position_falls_back_to_the_start(self):
+        q = PlayQueue([A, B])
+        q.set_position(7)
+        self.assertEqual(q.position, 0)
+
+    def test_first_and_last_track_flags_track_the_pointer(self):
+        q = PlayQueue([A, B])
+        self.assertTrue(q.is_first_track)
+        self.assertFalse(q.is_last_track)
+        q.set_position(1)
+        self.assertFalse(q.is_first_track)
+        self.assertTrue(q.is_last_track)
+
+    def test_empty_queue_is_both_first_and_last(self):
+        q = PlayQueue()
+        self.assertTrue(q.is_first_track)
+        self.assertTrue(q.is_last_track)
+
+    def test_length_sums_the_entries(self):
+        q = PlayQueue([MediaEntry(uri="a", length=1000),
+                       MediaEntry(uri="b", length=500)])
+        self.assertEqual(q.length, 1500)
+
+
+class TestNestedPlaylistMembers(unittest.TestCase):
+    """A ``playlist.set`` payload may carry a track that is itself a playlist.
+
+    ``validated_entries`` accepts those, so they reach the queue as nested
+    Playlist objects. They are kept in the backing list — sanitization walks
+    them there — but they have no uri, so every uri-based consumer reads the
+    filtered ``entries`` view instead.
+    """
+
+    def _queue_with_nested(self):
+        entries = validated_entries([
+            {"uri": "http://a.mp3", "title": "A"},
+            {"title": "nested", "playlist": [{"uri": "http://b.mp3",
+                                              "title": "B"}]}])
+        self.assertEqual([type(e).__name__ for e in entries],
+                         ["MediaEntry", "Playlist"])
+        q = PlayQueue()
+        for entry in entries:
+            q.add_entry(entry)
+        return q
+
+    def test_the_nested_playlist_stays_in_the_backing_list(self):
+        q = self._queue_with_nested()
+        self.assertEqual(len(q), 2)
+        self.assertIsInstance(q[1], Playlist)
+
+    def test_entries_offers_only_playable_members(self):
+        q = self._queue_with_nested()
+        self.assertEqual([e.uri for e in q.entries], ["http://a.mp3"])
+
+    def test_merging_search_results_survives_a_nested_playlist(self):
+        q = self._queue_with_nested()
+        merged = q.merged([MediaEntry(uri="http://c.mp3")])
+        self.assertEqual([e.uri for e in merged],
+                         ["http://a.mp3", "http://c.mp3"])
+
+    def test_advancing_survives_a_nested_playlist(self):
+        q = self._queue_with_nested()
+        merged = q.merged([MediaEntry(uri="http://c.mp3")])
+        self.assertTrue(q.has_next(merged, uri="http://a.mp3"))
+        self.assertEqual(q.select_next(merged, uri="http://a.mp3").uri,
+                         "http://c.mp3")
+
+    def test_length_ignores_a_nested_playlist(self):
+        q = self._queue_with_nested()
+        self.assertIsInstance(q.length, (int, float))
+
+
+class TestPlayerWithNestedPlaylistPayload(unittest.TestCase):
+    """The same payload, arriving over the bus edge on
+    'ovos.common_play.playlist.set', must leave the player able to advance."""
+
+    def _player(self):
+        from ovos_media.player import OCPMediaPlayer
+        bus = FakeBus()
+        with patch("ovos_media.player.AudioService"), \
+             patch("ovos_media.player.VideoService"), \
+             patch("ovos_media.player.WebService"), \
+             patch("ovos_media.player.OcpMprisExporter"), \
+             patch("ovos_media.player.Configuration", return_value={"media": {}}), \
+             patch("ovos_media.player.OCPMediaCatalog"):
+            player = OCPMediaPlayer(bus, config={})
+        player.media.search_playlist.entries = []
+        bus.emit(Message("ovos.common_play.playlist.set",
+                         {"tracks": [{"uri": "http://a.mp3", "title": "A"},
+                                     {"title": "nested",
+                                      "playlist": [{"uri": "http://b.mp3",
+                                                    "title": "B"}]},
+                                     {"uri": "http://c.mp3", "title": "C"}]}))
+        return player
+
+    def test_the_payload_reaches_the_queue(self):
+        player = self._player()
+        self.assertEqual(len(player.playlist), 3)
+        player.shutdown()
+
+    def test_next_and_prev_still_work(self):
+        player = self._player()
+        player.now_playing.uri = "http://a.mp3"
+        with patch.object(player, "play"):
+            player.play_next()
+            self.assertEqual(player.now_playing.uri, "http://c.mp3")
+            player.play_prev()
+            self.assertEqual(player.now_playing.uri, "http://a.mp3")
+        player.shutdown()
+
+    def test_can_next_still_answers(self):
+        player = self._player()
+        player.now_playing.uri = "http://a.mp3"
+        self.assertTrue(player.can_next)
+        player.shutdown()
+
+
+class TestMerge(unittest.TestCase):
+
+    def test_user_entries_come_first_and_search_results_follow(self):
+        q = PlayQueue([A])
+        self.assertEqual([e.uri for e in q.merged([B, C])],
+                         [A.uri, B.uri, C.uri])
+
+    def test_a_search_result_already_queued_is_not_repeated(self):
+        q = PlayQueue([A, B])
+        self.assertEqual([e.uri for e in q.merged([B, C])],
+                         [A.uri, B.uri, C.uri])
+
+    def test_merge_search_off_returns_the_user_queue_alone(self):
+        q = PlayQueue([A])
+        self.assertEqual([e.uri for e in q.merged([B], merge_search=False)],
+                         [A.uri])
+
+    def test_explicit_user_entries_override_the_owned_ones(self):
+        q = PlayQueue([A])
+        self.assertEqual([e.uri for e in q.merged([], user_entries=[C])],
+                         [C.uri])
+
+
+class TestIndex(unittest.TestCase):
+
+    def test_nothing_selected_and_no_uri_resolves_to_nothing(self):
+        q = PlayQueue()
+        self.assertEqual(q.index([A, B]), -1)
+
+    def test_the_selected_entry_is_located_by_identity(self):
+        q = PlayQueue()
+        dup = _entry(A.uri)
+        queue = [A, B, dup]
+        q.current = dup
+        self.assertEqual(q.index(queue), 2)
+
+    def test_a_duplicate_uri_does_not_ping_pong_between_positions(self):
+        # [a, b, a]: advancing from the second 'a' must run off the end,
+        # not jump back to the first one
+        q = PlayQueue()
+        second_a = _entry(A.uri)
+        queue = [A, B, second_a]
+        q.current = second_a
+        self.assertIsInstance(q.select_next(queue), QueueEnd)
+
+    def test_the_selected_entry_survives_a_cleared_uri(self):
+        q = PlayQueue()
+        q.current = B
+        # the now-playing uri is gone (end-of-media reset), identity remains
+        self.assertEqual(q.index([A, B], uri=None), 1)
+
+    def test_the_position_is_used_when_it_agrees_with_the_uri(self):
+        q = PlayQueue()
+        queue = [A, B, _entry(B.uri)]
+        self.assertEqual(q.index(queue, uri=B.uri, position=2), 2)
+
+    def test_a_position_pointing_elsewhere_is_ignored(self):
+        q = PlayQueue()
+        self.assertEqual(q.index([A, B], uri=B.uri, position=0), 1)
+
+    def test_an_out_of_range_position_is_ignored(self):
+        q = PlayQueue()
+        self.assertEqual(q.index([A, B], uri=B.uri, position=99), 1)
+
+    def test_a_uri_absent_from_the_queue_resolves_to_nothing(self):
+        q = PlayQueue()
+        self.assertEqual(q.index([A, B], uri="http://gone.mp3"), -1)
+
+    def test_the_selected_entry_uri_is_the_last_resort_locator(self):
+        q = PlayQueue()
+        q.current = _entry(B.uri)  # a different object with the same uri
+        self.assertEqual(q.index([A, B]), 1)
+
+
+class TestNeighbours(unittest.TestCase):
+
+    def test_no_previous_track_at_the_start(self):
+        q = PlayQueue()
+        self.assertFalse(q.has_prev([A, B], uri=A.uri))
+
+    def test_a_previous_track_after_the_start(self):
+        q = PlayQueue()
+        self.assertTrue(q.has_prev([A, B], uri=B.uri))
+
+    def test_a_next_track_before_the_end(self):
+        q = PlayQueue()
+        self.assertTrue(q.has_next([A, B], uri=A.uri))
+
+    def test_no_next_track_on_the_last_one(self):
+        q = PlayQueue()
+        self.assertFalse(q.has_next([A, B], uri=B.uri))
+
+    def test_an_unlocatable_track_has_no_next(self):
+        q = PlayQueue()
+        self.assertFalse(q.has_next([A, B], uri="http://gone.mp3"))
+
+
+class TestSelectNext(unittest.TestCase):
+
+    def test_the_following_track_is_selected(self):
+        q = PlayQueue()
+        self.assertIs(q.select_next([A, B], uri=A.uri), B)
+
+    def test_the_end_of_the_queue_is_reported(self):
+        q = PlayQueue()
+        self.assertIsInstance(q.select_next([A, B], uri=B.uri), QueueEnd)
+
+    def test_repeat_restarts_from_the_first_track(self):
+        q = PlayQueue()
+        self.assertIs(q.select_next([A, B], uri=B.uri, repeat=True), A)
+
+    def test_repeat_on_an_empty_queue_is_still_the_end(self):
+        q = PlayQueue()
+        self.assertIsInstance(q.select_next([], repeat=True), QueueEnd)
+
+    def test_repeat_refuses_to_restart_a_wholly_broken_queue(self):
+        q = PlayQueue()
+        q.mark_failed(A.uri)
+        q.mark_failed(B.uri)
+        self.assertIsInstance(q.select_next([A, B], uri=B.uri, repeat=True),
+                              AllFailed)
+
+    def test_repeat_restarts_while_one_track_still_works(self):
+        q = PlayQueue()
+        q.mark_failed(A.uri)
+        self.assertIs(q.select_next([A, B], uri=B.uri, repeat=True), A)
+
+    def test_a_failed_track_is_still_advanced_past(self):
+        # failures bound the repeat cycle; they do not filter the sequence
+        q = PlayQueue()
+        q.mark_failed(B.uri)
+        self.assertIs(q.select_next([A, B], uri=A.uri), B)
+
+
+class TestSelectPrev(unittest.TestCase):
+
+    def test_the_preceding_track_is_selected(self):
+        q = PlayQueue()
+        self.assertIs(q.select_prev([A, B], uri=B.uri), A)
+
+    def test_the_start_of_the_queue_is_reported(self):
+        q = PlayQueue()
+        self.assertIsInstance(q.select_prev([A, B], uri=A.uri), QueueEnd)
+
+    def test_an_unlocatable_track_reports_the_start(self):
+        q = PlayQueue()
+        self.assertIsInstance(q.select_prev([A, B], uri="http://gone.mp3"),
+                              QueueEnd)
+
+
+class TestSelectShuffle(unittest.TestCase):
+
+    def test_the_current_track_is_never_picked(self):
+        q = PlayQueue()
+        for _ in range(20):
+            self.assertIs(q.select_shuffle([A, B], current_uri=A.uri), B)
+
+    def test_a_failed_track_is_never_picked(self):
+        q = PlayQueue()
+        q.mark_failed(C.uri)
+        for _ in range(20):
+            self.assertIs(q.select_shuffle([A, B, C], current_uri=A.uri), B)
+
+    def test_the_pick_comes_from_random_choice_over_the_candidates(self):
+        q = PlayQueue()
+        with patch("ovos_media.player.queue.random.choice",
+                   side_effect=lambda c: c[-1]) as choice:
+            pick = q.select_shuffle([A, B, C], current_uri=A.uri)
+        self.assertIs(pick, C)
+        self.assertEqual([e.uri for e in choice.call_args[0][0]],
+                         [B.uri, C.uri])
+
+    def test_an_empty_queue_keeps_the_current_track(self):
+        q = PlayQueue()
+        self.assertIsInstance(q.select_shuffle([], current_uri=A.uri),
+                              KeepCurrent)
+
+    def test_an_empty_queue_whose_current_track_failed_is_the_end(self):
+        q = PlayQueue()
+        q.mark_failed(A.uri)
+        self.assertIsInstance(q.select_shuffle([], current_uri=A.uri), QueueEnd)
+
+    def test_a_lone_track_with_repeat_off_is_the_end(self):
+        q = PlayQueue()
+        self.assertIsInstance(q.select_shuffle([A], current_uri=A.uri), QueueEnd)
+
+    def test_a_lone_track_with_repeat_on_keeps_playing(self):
+        q = PlayQueue()
+        self.assertIsInstance(q.select_shuffle([A], current_uri=A.uri,
+                                               repeat=True), KeepCurrent)
+
+    def test_repeat_does_not_keep_a_failed_current_track(self):
+        q = PlayQueue()
+        q.mark_failed(A.uri)
+        self.assertIsInstance(q.select_shuffle([A], current_uri=A.uri,
+                                               repeat=True), QueueEnd)
+
+
+class TestFailedBookkeeping(unittest.TestCase):
+
+    def test_an_empty_uri_is_not_recorded(self):
+        q = PlayQueue()
+        q.mark_failed("")
+        q.mark_failed(None)
+        self.assertEqual(q.failed, set())
+
+    def test_all_failed_needs_every_track_to_have_failed(self):
+        q = PlayQueue()
+        q.mark_failed(A.uri)
+        self.assertFalse(q.all_failed([A, B]))
+        q.mark_failed(B.uri)
+        self.assertTrue(q.all_failed([A, B]))
+
+    def test_an_empty_queue_never_counts_as_wholly_failed(self):
+        q = PlayQueue()
+        self.assertFalse(q.all_failed([]))
+
+    def test_clearing_forgets_earlier_failures(self):
+        q = PlayQueue()
+        q.mark_failed(A.uri)
+        q.clear_failed()
+        self.assertFalse(q.all_failed([A]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_player_coverage.py
+++ b/test/unittests/test_player_coverage.py
@@ -121,7 +121,7 @@ class TestNowPlayingInit(unittest.TestCase):
     def _make_now_playing(self):
         from ovos_media.player import NowPlaying
         bus = FakeBus()
-        with patch("ovos_media.player.load_stream_extractors"):
+        with patch("ovos_media.player.now_playing.load_stream_extractors"):
             np = NowPlaying(bus)
         return np, bus
 
@@ -243,112 +243,6 @@ class TestNowPlayingInit(unittest.TestCase):
         np.handle_sync_seekbar(msg)
         self.assertEqual(np.length, 180000)  # valid field applied
         self.assertEqual(np.position, 999)   # invalid field left untouched
-
-    def test_extract_stream_whitespace_uri_raises_with_bad_value_quoted(self):
-        np, _ = self._make_now_playing()
-        np.uri = "ocp://original"
-        np.title = "original title"
-        np.stream_xtract = MagicMock()
-        np.stream_xtract.extract_stream.return_value = {"uri": "   ",
-                                                         "title": "poisoned"}
-        with self.assertRaises(ValueError) as cm:
-            np.extract_stream()
-        # the raised message quotes the BAD value, not the original uri
-        self.assertIn("'   '", str(cm.exception))
-        # state must be untouched - no poisoning before the refusal
-        self.assertEqual(np.uri, "ocp://original")
-        self.assertEqual(np.title, "original title")
-
-    def test_extract_stream_non_string_uri_raises_and_leaves_uri_untouched(self):
-        np, _ = self._make_now_playing()
-        np.uri = "ocp://original"
-        np.stream_xtract = MagicMock()
-        # extractor plugin returns a garbage non-string uri
-        np.stream_xtract.extract_stream.return_value = {"uri": ["not", "a", "str"]}
-        with self.assertRaises(ValueError):
-            np.extract_stream()
-        # self.uri must not have been poisoned by the garbage value
-        self.assertEqual(np.uri, "ocp://original")
-
-    def test_extract_stream_valid_uri_updates_normally(self):
-        np, _ = self._make_now_playing()
-        np.uri = "ocp://original"
-        np.stream_xtract = MagicMock()
-        np.stream_xtract.extract_stream.return_value = {"uri": "http://example.com/x.mp3"}
-        np.extract_stream()  # must not raise
-        self.assertEqual(np.uri, "http://example.com/x.mp3")
-
-    def test_extract_stream_control_char_uri_raises_and_leaves_uri_untouched(self):
-        # a uri that passes the prefix check may still embed control
-        # characters (eg. a newline for header/log injection) - it must be
-        # refused, same as a non-string or whitespace-only uri
-        np, _ = self._make_now_playing()
-        np.uri = "ocp://original"
-        np.title = "original title"
-        np.stream_xtract = MagicMock()
-        np.stream_xtract.extract_stream.return_value = {
-            "uri": "http://evil.example/\nSet-Cookie: x=1",
-            "title": "poisoned"}
-        with self.assertRaises(ValueError) as cm:
-            np.extract_stream()
-        self.assertIn("Set-Cookie", str(cm.exception))
-        self.assertEqual(np.uri, "ocp://original")
-        self.assertEqual(np.title, "original title")
-
-    def test_extract_stream_line_separator_uri_raises_and_leaves_uri_untouched(self):
-        # U+2028 (LINE SEPARATOR) is not < 0x20 or 0x7f but acts as a
-        # newline-equivalent in log viewers/some HTTP stacks - must be
-        # refused like the ASCII control-character case above
-        np, _ = self._make_now_playing()
-        np.uri = "ocp://original"
-        np.title = "original title"
-        np.stream_xtract = MagicMock()
-        np.stream_xtract.extract_stream.return_value = {
-            "uri": "http://evil.example/ Set-Cookie: x=1",
-            "title": "poisoned"}
-        with self.assertRaises(ValueError) as cm:
-            np.extract_stream()
-        self.assertIn("Set-Cookie", str(cm.exception))
-        self.assertEqual(np.uri, "ocp://original")
-        self.assertEqual(np.title, "original title")
-
-    def test_extract_stream_next_line_uri_raises_and_leaves_uri_untouched(self):
-        # U+0085 (NEXT LINE) is the same class of newline-equivalent
-        np, _ = self._make_now_playing()
-        np.uri = "ocp://original"
-        np.title = "original title"
-        np.stream_xtract = MagicMock()
-        np.stream_xtract.extract_stream.return_value = {
-            "uri": "http://evil.example/Set-Cookie: x=1",
-            "title": "poisoned"}
-        with self.assertRaises(ValueError) as cm:
-            np.extract_stream()
-        self.assertIn("Set-Cookie", str(cm.exception))
-        self.assertEqual(np.uri, "ocp://original")
-        self.assertEqual(np.title, "original title")
-
-    def test_extract_stream_normal_http_uri_still_passes(self):
-        # control: a normal http uri must not be rejected by the widened
-        # unicode-category check
-        np, _ = self._make_now_playing()
-        np.uri = "ocp://original"
-        np.stream_xtract = MagicMock()
-        np.stream_xtract.extract_stream.return_value = {
-            "uri": "http://example.com/song.mp3"}
-        np.extract_stream()  # must not raise
-        self.assertEqual(np.uri, "http://example.com/song.mp3")
-
-    def test_extract_stream_soft_hyphen_and_zwj_uri_still_passes(self):
-        # D5: U+00AD (SOFT HYPHEN) and U+200D (ZERO WIDTH JOINER) are
-        # category Cf and appear in real-world filenames - a file:// uri
-        # containing them must be accepted, not refused as "injection".
-        uri = "file:///music/so­ft‍join.mp3"
-        np, _ = self._make_now_playing()
-        np.uri = "ocp://original"
-        np.stream_xtract = MagicMock()
-        np.stream_xtract.extract_stream.return_value = {"uri": uri}
-        np.extract_stream()  # must not raise
-        self.assertEqual(np.uri, uri)
 
     def test_on_invalid_stream_after_bad_extract_does_not_raise(self):
         p = _make_player()

--- a/test/unittests/test_player_coverage2.py
+++ b/test/unittests/test_player_coverage2.py
@@ -69,7 +69,7 @@ class TestNowPlayingTrackStateChange(unittest.TestCase):
     def _make_now_playing(self):
         from ovos_media.player import NowPlaying
         bus = FakeBus()
-        with patch("ovos_media.player.load_stream_extractors"):
+        with patch("ovos_media.player.now_playing.load_stream_extractors"):
             np = NowPlaying(bus)
         return np, bus
 

--- a/test/unittests/test_player_handlers.py
+++ b/test/unittests/test_player_handlers.py
@@ -617,7 +617,7 @@ class TestNowPlayingAsDict(unittest.TestCase):
         """Create a real NowPlaying instance with a fake bus."""
         from ovos_media.player import NowPlaying
         bus = FakeBus()
-        with patch("ovos_media.player.load_stream_extractors"):
+        with patch("ovos_media.player.now_playing.load_stream_extractors"):
             np = NowPlaying(bus)
         return np
 

--- a/test/unittests/test_streams.py
+++ b/test/unittests/test_streams.py
@@ -1,0 +1,215 @@
+"""Tests for ovos_media.player.streams.extract_stream.
+
+The extractor turns a ``{SEI}//{uri}`` reference into a real stream. Whatever
+it returns is validated BEFORE any of it reaches the entry, so a hostile or
+broken plugin cannot poison the uri or the metadata that was already there.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import MediaEntry, PlaybackType
+
+from ovos_media.player import streams
+
+
+class _Entry(MediaEntry):
+    """A MediaEntry with the two NowPlaying traits extract_stream relies on:
+    an original_uri, and an update() that lets a resolved uri through even in
+    newonly mode."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.original_uri = self.uri
+
+    def update(self, entry, skipkeys=None, newonly=False):
+        super().update(entry, skipkeys, newonly)
+        if newonly and entry.get("uri"):
+            super().update({"uri": entry["uri"]})
+
+
+def _extract(entry, returns, video=False):
+    xtract = MagicMock()
+    xtract.extract_stream.return_value = returns
+    streams.extract_stream(entry, video, xtract)
+    return xtract
+
+
+class TestExtractStream(unittest.TestCase):
+    """The module level function, called without a NowPlaying."""
+
+    def test_missing_uri_refuses_before_calling_the_extractor(self):
+        xtract = MagicMock()
+        with self.assertRaises(ValueError):
+            streams.extract_stream(_Entry(uri=""), False, xtract)
+        xtract.extract_stream.assert_not_called()
+
+    def test_video_flag_is_forwarded_to_the_extractor(self):
+        entry = _Entry(uri="ocp://original", playback=PlaybackType.VIDEO)
+        xtract = _extract(entry, {"uri": "http://example.com/x.mp4"}, video=True)
+        xtract.extract_stream.assert_called_once_with("ocp://original", True)
+
+    def test_resolved_uri_replaces_the_reference_and_is_remembered(self):
+        entry = _Entry(uri="ocp://original")
+        _extract(entry, {"uri": "http://example.com/x.mp3", "title": "Song"})
+        self.assertEqual(entry.uri, "http://example.com/x.mp3")
+        self.assertEqual(entry.original_uri, "ocp://original")
+        self.assertEqual(entry.title, "Song")
+
+    def test_empty_extractor_result_keeps_the_entry_and_validates_its_uri(self):
+        entry = _Entry(uri="http://example.com/direct.mp3", title="kept")
+        _extract(entry, {})
+        self.assertEqual(entry.uri, "http://example.com/direct.mp3")
+        self.assertEqual(entry.title, "kept")
+
+    def test_entry_uri_without_a_playable_prefix_is_refused(self):
+        entry = _Entry(uri="ocp://original")
+        with self.assertRaises(ValueError):
+            _extract(entry, {})
+
+    def test_metadata_is_not_applied_when_the_resolved_uri_is_refused(self):
+        entry = _Entry(uri="http://example.com/ok.mp3", title="original title")
+        with self.assertRaises(ValueError):
+            _extract(entry, {"uri": ["not", "a", "str"], "title": "poisoned"})
+        self.assertEqual(entry.uri, "http://example.com/ok.mp3")
+        self.assertEqual(entry.title, "original title")
+
+    def test_resolved_uri_carrying_a_newline_is_refused(self):
+        entry = _Entry(uri="http://example.com/ok.mp3")
+        with self.assertRaises(ValueError):
+            _extract(entry, {"uri": "http://evil.example/\nSet-Cookie: x=1"})
+        self.assertEqual(entry.uri, "http://example.com/ok.mp3")
+
+    def test_entry_uri_carrying_a_newline_is_refused_without_an_extractor_result(self):
+        entry = _Entry(uri="http://example.com/\nSet-Cookie: x=1")
+        with self.assertRaises(ValueError):
+            _extract(entry, None)
+
+    def test_extractor_loaded_on_demand_when_none_is_given(self):
+        entry = _Entry(uri="ocp://original")
+        with patch("ovos_media.player.streams.load_stream_extractors") as loader:
+            loader.return_value.extract_stream.return_value = {
+                "uri": "http://example.com/x.mp3"}
+            streams.extract_stream(entry, False)
+        loader.assert_called_once()
+        self.assertEqual(entry.uri, "http://example.com/x.mp3")
+
+
+class TestNowPlayingExtractStream(unittest.TestCase):
+    """NowPlaying delegates to the module function and keeps its contract."""
+
+    def _make_now_playing(self):
+        from ovos_media.player import NowPlaying
+        bus = FakeBus()
+        with patch("ovos_media.player.now_playing.load_stream_extractors"):
+            np = NowPlaying(bus)
+        return np, bus
+
+    def test_extract_stream_whitespace_uri_raises_with_bad_value_quoted(self):
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.title = "original title"
+        np.stream_xtract = MagicMock()
+        np.stream_xtract.extract_stream.return_value = {"uri": "   ",
+                                                         "title": "poisoned"}
+        with self.assertRaises(ValueError) as cm:
+            np.extract_stream()
+        # the raised message quotes the BAD value, not the original uri
+        self.assertIn("'   '", str(cm.exception))
+        # state must be untouched - no poisoning before the refusal
+        self.assertEqual(np.uri, "ocp://original")
+        self.assertEqual(np.title, "original title")
+
+    def test_extract_stream_non_string_uri_raises_and_leaves_uri_untouched(self):
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.stream_xtract = MagicMock()
+        # extractor plugin returns a garbage non-string uri
+        np.stream_xtract.extract_stream.return_value = {"uri": ["not", "a", "str"]}
+        with self.assertRaises(ValueError):
+            np.extract_stream()
+        # self.uri must not have been poisoned by the garbage value
+        self.assertEqual(np.uri, "ocp://original")
+
+    def test_extract_stream_valid_uri_updates_normally(self):
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.stream_xtract = MagicMock()
+        np.stream_xtract.extract_stream.return_value = {"uri": "http://example.com/x.mp3"}
+        np.extract_stream()  # must not raise
+        self.assertEqual(np.uri, "http://example.com/x.mp3")
+
+    def test_extract_stream_control_char_uri_raises_and_leaves_uri_untouched(self):
+        # a uri that passes the prefix check may still embed control
+        # characters (eg. a newline for header/log injection) - it must be
+        # refused, same as a non-string or whitespace-only uri
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.title = "original title"
+        np.stream_xtract = MagicMock()
+        np.stream_xtract.extract_stream.return_value = {
+            "uri": "http://evil.example/\nSet-Cookie: x=1",
+            "title": "poisoned"}
+        with self.assertRaises(ValueError) as cm:
+            np.extract_stream()
+        self.assertIn("Set-Cookie", str(cm.exception))
+        self.assertEqual(np.uri, "ocp://original")
+        self.assertEqual(np.title, "original title")
+
+    def test_extract_stream_line_separator_uri_raises_and_leaves_uri_untouched(self):
+        # U+2028 (LINE SEPARATOR) is not < 0x20 or 0x7f but acts as a
+        # newline-equivalent in log viewers/some HTTP stacks - must be
+        # refused like the ASCII control-character case above
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.title = "original title"
+        np.stream_xtract = MagicMock()
+        np.stream_xtract.extract_stream.return_value = {
+            "uri": "http://evil.example/ Set-Cookie: x=1",
+            "title": "poisoned"}
+        with self.assertRaises(ValueError) as cm:
+            np.extract_stream()
+        self.assertIn("Set-Cookie", str(cm.exception))
+        self.assertEqual(np.uri, "ocp://original")
+        self.assertEqual(np.title, "original title")
+
+    def test_extract_stream_next_line_uri_raises_and_leaves_uri_untouched(self):
+        # U+0085 (NEXT LINE) is the same class of newline-equivalent
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.title = "original title"
+        np.stream_xtract = MagicMock()
+        np.stream_xtract.extract_stream.return_value = {
+            "uri": "http://evil.example/Set-Cookie: x=1",
+            "title": "poisoned"}
+        with self.assertRaises(ValueError) as cm:
+            np.extract_stream()
+        self.assertIn("Set-Cookie", str(cm.exception))
+        self.assertEqual(np.uri, "ocp://original")
+        self.assertEqual(np.title, "original title")
+
+    def test_extract_stream_normal_http_uri_still_passes(self):
+        # control: a normal http uri must not be rejected by the widened
+        # unicode-category check
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.stream_xtract = MagicMock()
+        np.stream_xtract.extract_stream.return_value = {
+            "uri": "http://example.com/song.mp3"}
+        np.extract_stream()  # must not raise
+        self.assertEqual(np.uri, "http://example.com/song.mp3")
+
+    def test_extract_stream_soft_hyphen_and_zwj_uri_still_passes(self):
+        # D5: U+00AD (SOFT HYPHEN) and U+200D (ZERO WIDTH JOINER) are
+        # category Cf and appear in real-world filenames - a file:// uri
+        # containing them must be accepted, not refused as "injection".
+        uri = "file:///music/so­ft‍join.mp3"
+        np, _ = self._make_now_playing()
+        np.uri = "ocp://original"
+        np.stream_xtract = MagicMock()
+        np.stream_xtract.extract_stream.return_value = {"uri": uri}
+        np.extract_stream()  # must not raise
+        self.assertEqual(np.uri, uri)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`player.py` had grown to hold four unrelated jobs: the catalog skill, the now-playing tracker, stream extraction, and a queue algebra spread across `_merged_queue`, `_queue_index`, `can_prev`/`can_next`, `play_shuffle` and the two advance methods, all reading and writing loose player attributes. This turns `ovos_media/player.py` into the package `ovos_media/player/`, with the old module becoming `__init__.py` so that every external import path and patch target (`ovos_media.player.OCPMediaPlayer`, `.NowPlaying`, `.Playlist`, `.AudioService`, `.OCPMediaCatalog`, `.Configuration`, …) keeps working unchanged. No behaviour changes.

`PlayQueue` (`player/queue.py`) now owns the user queue itself — its own list of entries, its own position pointer, the identity of the entry currently selected, and the uris that failed to load since the last successful one. It answers every "which track comes next" question: merging in search results, locating the current entry by identity so a duplicate uri in `[a, b, a]` still advances, picking a shuffle candidate, and reporting whether a neighbour exists. Each selection returns either a `MediaEntry` or one of `QueueEnd` / `AllFailed` / `KeepCurrent`, so the player branches on data. What to do with the answer stays player policy: repeat, autoplay, stopping and speaking `queue.finished` are unchanged and still live in `play_next`/`play_prev`/`play_shuffle`. `_current_entry` and `_failed_uris` remain readable and writable on the player as views onto the queue's bookkeeping, so the repeat-hot-loop guard behaves exactly as before.

The queue keeps one distinction the old `Playlist` made implicitly, and it is load-bearing. A track in a `playlist.set` payload may itself be a playlist: `validated_entries` accepts a `{"playlist": [...]}` member and hands back a nested `Playlist` object, which has no uri of its own. Such a member stays in the backing list, where payload sanitization reaches it, but `entries` exposes only the playable members, so uri-based logic — the dedup set in `merged()`, locating the current track, advancing — never meets a member without a uri. Dropping that filter made a single ordinary JSON playlist payload break `next`, `previous` and `can_next` permanently for the life of the daemon; the tests below cover both the queue-level and the over-the-bus form of that payload. Note a pre-existing gap the filter deliberately does not paper over: a `PluginStream` member has a `stream` rather than a `uri` and still breaks the same uri-based logic, on `dev` exactly as here — worth a follow-up, but out of scope for a behaviour-preserving move.

`NowPlaying` moves to `player/now_playing.py` as-is; it still subclasses `MediaEntry`, since converting it to composition belongs with the dispatcher work rather than here. Stream extraction moves out of it into `player/streams.py` as a module-level `extract_stream(entry, video, stream_xtract=None)`, preserving the validation ordering exactly: the extractor's uri is checked for type, whitespace and control characters before any of the metadata reaches the entry, and the entry's own uri is prefix- and injection-checked afterwards.

One real trap surfaced and is fixed here. `OCPMediaCatalog` is an `OVOSCommonPlaybackSkill`, and ovos-workshop derives a skill's resource directory from the file its class is defined in. Left alone, the move would have pointed dialogs, intents and the skill icon at `ovos_media/player/` instead of `ovos_media/`, and the catalog would have spoken raw dialog names — thirteen tests caught it. The catalog now passes the package directory as its `resources_dir` explicitly.

Tests: `test_play_queue.py` covers `PlayQueue` directly (container semantics, merge and dedup, identity resolution, neighbours, the three selections and the failed-uri bookkeeping), and `test_streams.py` covers `extract_stream` at module level, taking over the extraction tests that used to sit inside `test_player_coverage.py`'s NowPlaying class. Nothing else was removed: every existing queue case drives the queue through `OCPMediaPlayer`, so it still tests the player's policy branches and stays where it is. The unit suite goes from 747 to 821 passing (65 new queue cases, 9 new stream cases, 68 subtests unchanged), and the end-to-end contract suite is unmodified at 68 passing. The ovoscope harness was also driven directly through a real playback round trip against this branch.
