### PR TITLE
refactor: player adapter roster over backend services

### DIFF
--- a/ovos_media/player/__init__.py
+++ b/ovos_media/player/__init__.py
@@ -18,6 +18,8 @@ from ovos_media.bus.schemas import (decode_media_state, decode_playlist_tracks,
 from ovos_media.player.queue import (AllFailed, KeepCurrent, PlayQueue,
                                      QueueEnd)
 from ovos_media.player.now_playing import NowPlaying
+from ovos_media.player.adapters import OPMBackendAdapter, SkillPlayerAdapter
+from ovos_media.player.roster import PlayerRoster
 from ovos_plugin_manager.ocp import load_stream_extractors
 from ovos_plugin_manager.templates.media import MediaBackend
 from ovos_utils.log import LOG
@@ -476,6 +478,17 @@ class OCPMediaPlayer:
         # of this player — spoken only at the very first play attempt that
         # finds zero backends loaded, never again
         self._no_backend_dialog_spoken: bool = False
+        # every concrete player this virtual player drives, behind one
+        # interface. The backend services stay exactly what they were; the
+        # adapters wrap them, they do not replace them, and they resolve
+        # their service through this player so a player assembled piecemeal
+        # (services supplied after the fact) gets a working roster too.
+        self.roster: PlayerRoster = PlayerRoster([
+            OPMBackendAdapter("opm:audio", self, "audio_service"),
+            OPMBackendAdapter("opm:video", self, "video_service"),
+            OPMBackendAdapter("opm:web", self, "web_service"),
+            SkillPlayerAdapter(self),
+        ])
 
     # views on the owned queue's bookkeeping
     @property
@@ -1009,18 +1022,8 @@ class OCPMediaPlayer:
         # switching playback types must not leave the previously active
         # backend's BaseMediaService.current set — otherwise a later,
         # unrelated global LOADED_MEDIA event revives the stale backend and
-        # two backends end up playing at once. Stop/clear every backend that
-        # is not the one about to be used.
-        for svc, ptype in ((self.audio_service, PlaybackType.AUDIO),
-                           (self.video_service, PlaybackType.VIDEO),
-                           (self.web_service, PlaybackType.WEBVIEW)):
-            if self.playback_type != ptype and svc.current is not None:
-                try:
-                    svc.current.stop()
-                except Exception as e:
-                    LOG.exception(f"Failed to stop inactive {svc.namespace} "
-                                  f"backend on playback-type switch: {e}")
-                svc.current = None
+        # two backends end up playing at once.
+        self.roster.deactivate_others(self.playback_type)
 
         # track play count - store() does a json.dump that iterates the
         # dict, and handle_like()/handle_unlike() can mutate it concurrently
@@ -1041,58 +1044,17 @@ class OCPMediaPlayer:
         self.track_history.setdefault(self.now_playing.uri, 0)
         self.track_history[self.now_playing.uri] += 1
 
-        if self.playback_type == PlaybackType.AUDIO:
-            LOG.debug("Requesting playback: PlaybackType.AUDIO")
-            preferred = self._resolve_preferred_service(self.audio_service)
-            self.audio_service.play(self.now_playing.uri, preferred_service=preferred)
-
-        elif self.playback_type == PlaybackType.SKILL:
-            # skill wants to handle playback
-            LOG.debug("Requesting playback: PlaybackType.SKILL")
-            self.bus.emit(Message(f'ovos.common_play.{self.now_playing.skill_id}.play',
-                                  self.now_playing.infocard))
-            self.bus.emit(Message("ovos.common_play.track.state",
-                                  {"state": TrackState.PLAYING_SKILL}))
-
-        elif self.playback_type in (PlaybackType.VIDEO, PlaybackType.WEBVIEW):
-            svc = self.video_service if self.playback_type == PlaybackType.VIDEO else self.web_service
-            LOG.debug(f"Requesting playback: {self.playback_type}")
-            preferred = self._resolve_preferred_service(svc)
-            if svc.can_play(self.now_playing.uri, preferred_service=preferred):
-                svc.play(self.now_playing.uri, preferred_service=preferred)
-            else:
-                # No installed video/web backend claims this uri (eg. a
-                # headless install with only audio backends configured).
-                # Degrade to audio instead of dead-ending in
-                # MediaState.INVALID_MEDIA — the same fallback the old
-                # GUI-presence heuristic used to trigger, now driven by
-                # actual backend availability instead of GUI detection.
-                LOG.warning(f"No {svc.namespace} backend can play "
-                           f"{self.now_playing.uri!r}; falling back to audio")
-                # The playback-type switch loop above ran while
-                # self.playback_type was still VIDEO/WEBVIEW, so it left
-                # this service's `current` alone (it was, at that point,
-                # the intended backend). Now that we're abandoning it for
-                # AUDIO, stop and clear it ourselves — same idiom as that
-                # loop — or a still-playing prior track on this service
-                # keeps running alongside the new audio stream.
-                if svc.current is not None:
-                    try:
-                        svc.current.stop()
-                    except Exception as e:
-                        LOG.exception(f"Failed to stop abandoned {svc.namespace} "
-                                      f"backend on audio fallback: {e}")
-                    svc.current = None
-                self.now_playing.playback = PlaybackType.AUDIO
-                preferred = self._resolve_preferred_service(self.audio_service)
-                if self.audio_service.can_play(self.now_playing.uri, preferred_service=preferred):
-                    self.audio_service.play(self.now_playing.uri, preferred_service=preferred)
-                else:
-                    self.bus.emit(Message("ovos.common_play.media.state",
-                                          {"state": MediaState.INVALID_MEDIA}))
-
+        LOG.debug(f"Requesting playback: {self.playback_type}")
+        adapter, playback_type = self.roster.select(self.playback_type,
+                                                    self.now_playing.uri)
+        if playback_type != self.playback_type:
+            # demoted to audio because no video/web backend claimed the uri
+            self.now_playing.playback = playback_type
+        if adapter is None:
+            self.bus.emit(Message("ovos.common_play.media.state",
+                                  {"state": MediaState.INVALID_MEDIA}))
         else:
-            raise ValueError("invalid playback request")
+            adapter.play(self.now_playing.uri)
 
         if self.mpris:
             self.mpris.update_props({"CanGoNext": self.can_next})
@@ -1155,7 +1117,7 @@ class OCPMediaPlayer:
             return
         elif self.playback_type in [PlaybackType.SKILL]:
             LOG.debug(f"Defer playing next track to skill")
-            self.bus.emit(Message(f'ovos.common_play.{self.now_playing.skill_id}.next'))
+            self.roster.get("skill").next()
             return
 
         if self.loop_state == LoopState.REPEAT_TRACK:
@@ -1258,8 +1220,7 @@ class OCPMediaPlayer:
                 LOG.warning("MPRIS external player control is disabled; install ovos-media-plugin-mpris to enable it")
             return
         elif self.playback_type in [PlaybackType.SKILL]:
-            self.bus.emit(Message(
-                f'ovos.common_play.{self.now_playing.skill_id}.prev'))
+            self.roster.get("skill").prev()
             return
 
         if self.shuffle:
@@ -1283,17 +1244,12 @@ class OCPMediaPlayer:
         Ask the current playback to pause.
         """
         LOG.debug(f"Pausing playback: {self.playback_type}")
-        if self.playback_type in [PlaybackType.AUDIO,
-                                  PlaybackType.UNDEFINED]:
-            self.audio_service.pause()
-        if self.playback_type in [PlaybackType.VIDEO,
-                                  PlaybackType.UNDEFINED]:
-            self.video_service.pause()
-        if self.playback_type in [PlaybackType.SKILL,
-                                  PlaybackType.UNDEFINED]:
-            self.bus.emit(Message(f'ovos.common_play.{self.active_skill}.pause'))
-        if self.playback_type in [PlaybackType.MPRIS] and self.mpris and self.mpris.manage_players:
-            self.mpris.pause()
+        if self.playback_type in [PlaybackType.MPRIS]:
+            if self.mpris and self.mpris.manage_players:
+                self.mpris.pause()
+        else:
+            for adapter in self.roster.route("pause", self.playback_type):
+                adapter.pause()
         self.set_player_state(PlayerState.PAUSED)
         self._paused_on_duck = False
 
@@ -1302,19 +1258,12 @@ class OCPMediaPlayer:
         Ask any paused or stopped playback to resume.
         """
         LOG.debug(f"Resuming playback: {self.playback_type}")
-        if self.playback_type in [PlaybackType.AUDIO,
-                                  PlaybackType.UNDEFINED]:
-            self.audio_service.resume()
-
-        if self.playback_type in [PlaybackType.SKILL,
-                                  PlaybackType.UNDEFINED]:
-            self.bus.emit(Message(f'ovos.common_play.{self.active_skill}.resume'))
-
-        if self.playback_type in [PlaybackType.VIDEO]:
-            self.video_service.resume()
-
-        if self.playback_type in [PlaybackType.MPRIS] and self.mpris and self.mpris.manage_players:
-            self.mpris.resume()
+        if self.playback_type in [PlaybackType.MPRIS]:
+            if self.mpris and self.mpris.manage_players:
+                self.mpris.resume()
+        else:
+            for adapter in self.roster.route("resume", self.playback_type):
+                adapter.resume()
 
         self.set_player_state(PlayerState.PLAYING)
 
@@ -1328,17 +1277,14 @@ class OCPMediaPlayer:
         doing nothing.
         @param position: milliseconds position to seek to
         """
-        if self.playback_type in [PlaybackType.AUDIO,
-                                  PlaybackType.UNDEFINED]:
-            # audio_service.set_track_position expects milliseconds,
-            # matching the milliseconds contract documented on this
-            # method and on MediaBackend.set_track_position
-            self.audio_service.set_track_position(position)
-        elif self.playback_type == PlaybackType.VIDEO:
-            self.video_service.set_track_position(position)
-        else:
+        # adapters take milliseconds, matching the contract documented on
+        # this method and on MediaBackend.set_track_position
+        adapters = self.roster.route("seek", self.playback_type)
+        if not adapters:
             LOG.warning(f"seek() is not supported for playback_type "
                         f"{self.playback_type}, ignoring")
+        for adapter in adapters:
+            adapter.seek(position)
 
     def stop(self):
         """
@@ -1354,20 +1300,12 @@ class OCPMediaPlayer:
         self.bus.emit(Message("ovos.common_play.search.stop"))
 
         LOG.debug("Stopping playback")
-        if self.playback_type in [PlaybackType.AUDIO,
-                                  PlaybackType.UNDEFINED]:
-            self.audio_service.stop()
-        if self.playback_type in [PlaybackType.SKILL,
-                                  PlaybackType.UNDEFINED]:
-            self.stop_skill()
-        if self.playback_type in [PlaybackType.VIDEO,
-                                  PlaybackType.UNDEFINED]:
-            self.video_service.stop()
-        if self.playback_type in [PlaybackType.WEBVIEW,
-                                  PlaybackType.UNDEFINED]:
-            self.web_service.stop()
-        if self.mpris and self.playback_type in [PlaybackType.MPRIS]:
-            self.mpris.pause()
+        if self.playback_type in [PlaybackType.MPRIS]:
+            if self.mpris:
+                self.mpris.pause()
+        else:
+            for adapter in self.roster.route("stop", self.playback_type):
+                adapter.stop()
         self.set_player_state(PlayerState.STOPPED)
         if self._paused_on_duck:
             # _paused_on_duck is shared by cork (pause-based) and duck
@@ -1377,23 +1315,21 @@ class OCPMediaPlayer:
             # services unconditionally is a no-op for whichever one wasn't
             # ducking (or for the cork path, where volume was never
             # touched in the first place).
-            self.video_service.restore_volume()
-            self.audio_service.restore_volume()
+            self.roster.get("opm:video").restore_volume()
+            self.roster.get("opm:audio").restore_volume()
         self._paused_on_duck = False
 
     def handle_MPRIS_takeover(self):
         """ Called when a MPRIS external player becomes active"""
-        self.audio_service.stop()
-        self.video_service.stop()
-        self.web_service.stop()
-        self.stop_skill()
+        for adapter in self.roster.adapters:
+            adapter.stop()
         self.now_playing.original_uri = ""
 
     def stop_skill(self):
         """
         Emit a Message notifying self.active_skill to stop
         """
-        self.bus.emit(Message(f'ovos.common_play.{self.active_skill}.stop'))
+        self.roster.get("skill").stop()
 
     def reset(self):
         """
@@ -1587,9 +1523,8 @@ class OCPMediaPlayer:
             return
         # relative offset, from the bus api
         position = self.now_playing.position or 0
-        if self.playback_type in [PlaybackType.AUDIO,
-                                  PlaybackType.UNDEFINED]:
-            position = self.audio_service.get_track_position() or position
+        for adapter in self.roster.route("position_offset", self.playback_type):
+            position = adapter.position() or position
         self.seek(position + seek["seconds"] * 1000)
 
     def handle_next_request(self, message):
@@ -1671,10 +1606,8 @@ class OCPMediaPlayer:
         @param message: Message associated with event
         """
         if self.state == PlayerState.PLAYING:
-            if self.playback_type in [PlaybackType.VIDEO]:
-                self.video_service.lower_volume()
-            elif self.playback_type in [PlaybackType.AUDIO]:
-                self.audio_service.lower_volume()
+            for adapter in self.roster.route("volume", self.playback_type):
+                adapter.lower_volume()
             self._paused_on_duck = True
 
     def handle_unduck_request(self, message):
@@ -1690,10 +1623,8 @@ class OCPMediaPlayer:
         @param message: Message associated with event
         """
         if self._paused_on_duck:
-            if self.playback_type in [PlaybackType.VIDEO]:
-                self.video_service.restore_volume()
-            elif self.playback_type in [PlaybackType.AUDIO]:
-                self.audio_service.restore_volume()
+            for adapter in self.roster.route("volume", self.playback_type):
+                adapter.restore_volume()
             self._paused_on_duck = False
 
     def handle_record_end(self, message):
@@ -1754,15 +1685,15 @@ class OCPMediaPlayer:
     # track data
     def handle_track_length_request(self, message):
         l = self.now_playing.length
-        if self.playback_type == PlaybackType.AUDIO:
-            l = self.audio_service.get_track_length() or l
+        for adapter in self.roster.route("position", self.playback_type):
+            l = adapter.length() or l
         data = {"length": l}
         self.bus.emit(message.response(data))
 
     def handle_track_position_request(self, message):
         pos = self.now_playing.position
-        if self.playback_type == PlaybackType.AUDIO:
-            pos = self.audio_service.get_track_position() or pos
+        for adapter in self.roster.route("position", self.playback_type):
+            pos = adapter.position() or pos
         data = {"position": pos}
         self.bus.emit(message.response(data))
 

--- a/ovos_media/player/adapters.py
+++ b/ovos_media/player/adapters.py
@@ -1,0 +1,214 @@
+"""Player adapters — one uniform interface over everything that can play media.
+
+``ovos-media`` is the abstract OVOS media player: a single virtual player that
+tracks whatever is actually playing, wherever it plays. The concrete players are
+not uniform — an OPM media plugin is driven through :class:`BaseMediaService`,
+while a OCP skill is driven by bus messages it subscribes to itself — so the
+player used to branch on :class:`PlaybackType` in every transport verb.
+
+A :class:`PlayerAdapter` wraps one concrete player behind the verbs the virtual
+player needs (play/pause/resume/stop/seek, position/length, duck/restore).
+Adapters are an internal detail: the OPM
+``MediaBackend`` template stays the plugin contract, and
+:class:`OPMBackendAdapter` speaks to it through the service layer exactly as
+before.
+"""
+import abc
+from typing import Optional
+
+from ovos_bus_client.message import Message
+from ovos_plugin_manager.templates.media import MediaBackend
+from ovos_utils.log import LOG
+from ovos_utils.ocp import TrackState
+
+
+class PlayerAdapter(metaclass=abc.ABCMeta):
+    """One concrete player, behind the verbs the virtual player speaks."""
+
+    def __init__(self, player_id: str):
+        self._id = player_id
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._id})"
+
+    @abc.abstractmethod
+    def can_play(self, uri: str) -> bool:
+        """Whether this player would claim *uri*."""
+
+    @abc.abstractmethod
+    def play(self, uri: str) -> None:
+        """Start playing *uri*."""
+
+    @abc.abstractmethod
+    def pause(self) -> None:
+        ...
+
+    @abc.abstractmethod
+    def resume(self) -> None:
+        ...
+
+    @abc.abstractmethod
+    def stop(self) -> None:
+        ...
+
+    @abc.abstractmethod
+    def seek(self, milliseconds: int) -> None:
+        ...
+
+    @abc.abstractmethod
+    def position(self) -> Optional[int]:
+        """Current playback position in milliseconds, or None."""
+
+    @abc.abstractmethod
+    def length(self) -> Optional[int]:
+        """Current track duration in milliseconds, or None."""
+
+    def lower_volume(self) -> None:
+        """Duck. Players that cannot duck ignore this."""
+
+    def restore_volume(self) -> None:
+        """Unduck. Players that cannot duck ignore this."""
+
+    def deactivate(self) -> None:
+        """Give up whatever this player still holds.
+
+        Called when the virtual player switches to a different concrete
+        player: whatever this one is still playing must not keep running
+        alongside the new track.
+        """
+
+
+class OPMBackendAdapter(PlayerAdapter):
+    """Adapter over one OPM media-plugin family (audio, video or web).
+
+    Wraps the :class:`~ovos_media.media_backends.base.BaseMediaService`
+    instance that owns that family. Backend selection, the supported_uris
+    isolation and the stop guard window all stay in the service layer; this
+    adapter only resolves the configured preference before each request.
+
+    The service is looked up on the owning player by attribute name on every
+    call, so the adapter tracks whichever service instance the player holds.
+    """
+
+    def __init__(self, player_id: str, player, service_attr: str):
+        super().__init__(player_id)
+        self.player = player
+        self.service_attr = service_attr
+
+    @property
+    def service(self):
+        return getattr(self.player, self.service_attr)
+
+    @property
+    def namespace(self) -> str:
+        return self.service.namespace
+
+    def _preferred(self) -> Optional[MediaBackend]:
+        return self.player._resolve_preferred_service(self.service)
+
+    def can_play(self, uri: str) -> bool:
+        return self.service.can_play(uri, preferred_service=self._preferred())
+
+    def play(self, uri: str) -> None:
+        self.service.play(uri, preferred_service=self._preferred())
+
+    def pause(self) -> None:
+        self.service.pause()
+
+    def resume(self) -> None:
+        self.service.resume()
+
+    def stop(self) -> None:
+        self.service.stop()
+
+    def seek(self, milliseconds: int) -> None:
+        self.service.set_track_position(milliseconds)
+
+    def position(self) -> Optional[int]:
+        return self.service.get_track_position()
+
+    def length(self) -> Optional[int]:
+        return self.service.get_track_length()
+
+    def lower_volume(self) -> None:
+        self.service.lower_volume()
+
+    def restore_volume(self) -> None:
+        self.service.restore_volume()
+
+    def deactivate(self) -> None:
+        # a leftover `current` is enough for a later, unrelated LOADED_MEDIA
+        # event to revive this backend and leave two backends playing at once
+        if self.service.current is None:
+            return
+        try:
+            self.service.current.stop()
+        except Exception as e:
+            LOG.exception(f"Failed to stop inactive {self.namespace} backend: {e}")
+        self.service.current = None
+
+
+class SkillPlayerAdapter(PlayerAdapter):
+    """Adapter over an OCP skill that handles its own playback.
+
+    The skill is driven entirely by ``ovos.common_play.{skill_id}.*`` messages
+    it subscribes to, and reports nothing back except through the shared OCP
+    state events, so position and length come from ``now_playing``.
+    """
+
+    def __init__(self, player, player_id: str = "skill"):
+        super().__init__(player_id)
+        self.player = player
+
+    @property
+    def bus(self):
+        return self.player.bus
+
+    @property
+    def now_playing(self):
+        return self.player.now_playing
+
+    @property
+    def skill_id(self) -> Optional[str]:
+        return self.now_playing.skill_id
+
+    def _emit(self, verb: str, data: dict = None) -> None:
+        self.bus.emit(Message(f"ovos.common_play.{self.skill_id}.{verb}",
+                              data or {}))
+
+    def can_play(self, uri: str) -> bool:
+        # the skill offered this track in the first place
+        return True
+
+    def play(self, uri: str = None) -> None:
+        self._emit("play", self.now_playing.infocard)
+        self.bus.emit(Message("ovos.common_play.track.state",
+                              {"state": TrackState.PLAYING_SKILL}))
+
+    def pause(self) -> None:
+        self._emit("pause")
+
+    def resume(self) -> None:
+        self._emit("resume")
+
+    def stop(self) -> None:
+        self._emit("stop")
+
+    def next(self) -> None:
+        self._emit("next")
+
+    def prev(self) -> None:
+        self._emit("prev")
+
+    def seek(self, milliseconds: int) -> None:
+        LOG.warning("seek is not supported for skill playback, ignoring")
+
+    def position(self) -> Optional[int]:
+        return self.now_playing.position
+
+    def length(self) -> Optional[int]:
+        return self.now_playing.length

--- a/ovos_media/player/roster.py
+++ b/ovos_media/player/roster.py
@@ -1,0 +1,137 @@
+"""The roster of concrete players known to the virtual player.
+
+:class:`PlayerRoster` holds every :class:`~ovos_media.player.adapters.PlayerAdapter`
+and answers the only two questions the virtual player has about them: which one
+plays the current track, and which ones a given transport verb reaches.
+
+The second question is not the same as the first. ``PlaybackType.UNDEFINED``
+means "nothing is loaded, so make sure nothing is playing anywhere", and a stop
+or a pause on it fans out to every player that could be holding audio. The
+routing table below records that, one row per verb, and is the single place the
+old per-verb ``if playback_type in [...]`` ladders used to live.
+"""
+from typing import Dict, List, Tuple
+
+from ovos_utils.log import LOG
+from ovos_utils.ocp import PlaybackType
+
+AUDIO = "opm:audio"
+VIDEO = "opm:video"
+WEB = "opm:web"
+SKILL = "skill"
+
+# which concrete players each verb reaches, per playback type, in call order.
+# A playback type absent from a row means the verb reaches nobody (and, for
+# seek, is reported as unsupported).
+_ROUTES: Dict[str, Dict[PlaybackType, Tuple[str, ...]]] = {
+    "pause": {
+        PlaybackType.AUDIO: (AUDIO,),
+        PlaybackType.VIDEO: (VIDEO,),
+        PlaybackType.SKILL: (SKILL,),
+        PlaybackType.UNDEFINED: (AUDIO, VIDEO, SKILL),
+    },
+    "resume": {
+        PlaybackType.AUDIO: (AUDIO,),
+        PlaybackType.VIDEO: (VIDEO,),
+        PlaybackType.SKILL: (SKILL,),
+        PlaybackType.UNDEFINED: (AUDIO, SKILL),
+    },
+    "stop": {
+        PlaybackType.AUDIO: (AUDIO,),
+        PlaybackType.VIDEO: (VIDEO,),
+        PlaybackType.WEBVIEW: (WEB,),
+        PlaybackType.SKILL: (SKILL,),
+        PlaybackType.UNDEFINED: (AUDIO, SKILL, VIDEO, WEB),
+    },
+    "seek": {
+        PlaybackType.AUDIO: (AUDIO,),
+        PlaybackType.VIDEO: (VIDEO,),
+        PlaybackType.UNDEFINED: (AUDIO,),
+    },
+    # ducking only applies where there is a volume to lower
+    "volume": {
+        PlaybackType.AUDIO: (AUDIO,),
+        PlaybackType.VIDEO: (VIDEO,),
+    },
+    # the seekbar/track-info queries read the backend only where the backend
+    # reports a meaningful position; everywhere else now_playing is the source
+    "position": {
+        PlaybackType.AUDIO: (AUDIO,),
+    },
+    "position_offset": {
+        PlaybackType.AUDIO: (AUDIO,),
+        PlaybackType.UNDEFINED: (AUDIO,),
+    },
+}
+
+# which player starts a track of each playback type
+_PLAYBACK_OWNER: Dict[PlaybackType, str] = {
+    PlaybackType.AUDIO: AUDIO,
+    PlaybackType.VIDEO: VIDEO,
+    PlaybackType.WEBVIEW: WEB,
+    PlaybackType.SKILL: SKILL,
+}
+
+
+class PlayerRoster:
+    """Every concrete player the virtual player can drive."""
+
+    def __init__(self, adapters):
+        self.adapters = list(adapters)
+        self._by_id = {a.id: a for a in self.adapters}
+
+    def get(self, player_id: str):
+        return self._by_id.get(player_id)
+
+    def owner(self, playback_type: PlaybackType):
+        """The player that starts tracks of *playback_type*, or None."""
+        return self.get(_PLAYBACK_OWNER.get(playback_type, ""))
+
+    def route(self, verb: str, playback_type: PlaybackType) -> List[object]:
+        """The players *verb* reaches for *playback_type*, in call order."""
+        ids = _ROUTES.get(verb, {}).get(playback_type, ())
+        return [self._by_id[i] for i in ids if i in self._by_id]
+
+    def select(self, playback_type: PlaybackType, uri: str):
+        """Pick the player that will start the track about to play.
+
+        A video/web track no installed backend claims is demoted to audio
+        rather than dead-ending in ``MediaState.INVALID_MEDIA`` — a headless
+        install with only audio backends still plays the soundtrack.
+
+        Returns:
+            (adapter, playback_type): the selected player and the playback
+            type it will play the track as, which differs from the requested
+            one when the track was demoted to audio. The adapter is None when
+            no player can play the track at all.
+
+        Raises:
+            ValueError: on a playback type no player owns.
+        """
+        adapter = self.owner(playback_type)
+        if adapter is None:
+            raise ValueError("invalid playback request")
+
+        if playback_type in (PlaybackType.VIDEO, PlaybackType.WEBVIEW) and \
+                not adapter.can_play(uri):
+            LOG.warning(f"No {adapter.id} backend can play {uri!r}; "
+                        f"falling back to audio")
+            # deactivate_others() ran while this was still the intended
+            # player, so it left this one alone. Now that we abandon it, it
+            # must give up its track or it keeps playing under the new one.
+            adapter.deactivate()
+            playback_type = PlaybackType.AUDIO
+            adapter = self.get(AUDIO)
+            if adapter is None or not adapter.can_play(uri):
+                return None, playback_type
+
+        return adapter, playback_type
+
+    def deactivate_others(self, playback_type: PlaybackType) -> None:
+        """Make every player that does not own *playback_type* give up its track."""
+        for ptype, player_id in _PLAYBACK_OWNER.items():
+            if ptype == playback_type:
+                continue
+            adapter = self.get(player_id)
+            if adapter is not None:
+                adapter.deactivate()

--- a/test/unittests/test_player_adapters.py
+++ b/test/unittests/test_player_adapters.py
@@ -1,0 +1,235 @@
+"""Contract tests for the player adapters.
+
+Each adapter must speak the same verbs while driving a very different concrete
+player: an OPM backend family through its BaseMediaService, or an OCP skill
+through the bus.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import TrackState
+
+from ovos_media.media_backends.audio import AudioService
+from ovos_media.player.adapters import (OPMBackendAdapter, PlayerAdapter,
+                                        SkillPlayerAdapter)
+
+
+class _FakePlayer:
+    """The bits of OCPMediaPlayer an adapter reads."""
+
+    def __init__(self, bus=None, service=None, preferred=None):
+        self.bus = bus or FakeBus()
+        self.audio_service = service or MagicMock()
+        self.now_playing = MagicMock()
+        self.now_playing.skill_id = "skill.test"
+        self.now_playing.infocard = {"uri": "file://track.mp3"}
+        self.now_playing.position = 1000
+        self.now_playing.length = 180000
+        self._preferred = preferred
+        self.preferred_calls = []
+
+    def _resolve_preferred_service(self, service):
+        self.preferred_calls.append(service)
+        return self._preferred
+
+
+class _Backend:
+    """Minimal stand-in for an OPM MediaBackend."""
+
+    def __init__(self, name, uris, raises=False):
+        self.name = name
+        self.aliases = [name]
+        self._uris = uris
+        self._raises = raises
+        self.stopped = False
+
+    def supported_uris(self):
+        if self._raises:
+            raise RuntimeError("plugin is broken")
+        return self._uris
+
+    def stop(self):
+        self.stopped = True
+        return True
+
+    def set_track_start_callback(self, cb):
+        pass
+
+
+def _audio_service(*backends):
+    svc = AudioService(FakeBus(), config={}, autoload=False)
+    svc.services = list(backends)
+    return svc
+
+
+class TestOPMBackendAdapter(unittest.TestCase):
+    def setUp(self):
+        self.service = MagicMock()
+        self.player = _FakePlayer(service=self.service, preferred="preferred-backend")
+        self.adapter = OPMBackendAdapter("opm:audio", self.player, "audio_service")
+
+    def test_identity(self):
+        self.assertEqual(self.adapter.id, "opm:audio")
+
+    def test_service_is_resolved_on_every_call(self):
+        replacement = MagicMock()
+        self.player.audio_service = replacement
+        self.adapter.stop()
+        replacement.stop.assert_called_once_with()
+        self.service.stop.assert_not_called()
+
+    def test_play_passes_the_resolved_preference(self):
+        self.adapter.play("file://track.mp3")
+        self.service.play.assert_called_once_with(
+            "file://track.mp3", preferred_service="preferred-backend")
+        self.assertEqual(self.player.preferred_calls, [self.service])
+
+    def test_can_play_passes_the_resolved_preference(self):
+        self.service.can_play.return_value = True
+        self.assertTrue(self.adapter.can_play("file://track.mp3"))
+        self.service.can_play.assert_called_once_with(
+            "file://track.mp3", preferred_service="preferred-backend")
+
+    def test_transport_verbs_delegate(self):
+        self.adapter.pause()
+        self.adapter.resume()
+        self.adapter.stop()
+        self.adapter.seek(4200)
+        self.service.pause.assert_called_once_with()
+        self.service.resume.assert_called_once_with()
+        self.service.stop.assert_called_once_with()
+        self.service.set_track_position.assert_called_once_with(4200)
+
+    def test_position_and_length_delegate(self):
+        self.service.get_track_position.return_value = 5
+        self.service.get_track_length.return_value = 7
+        self.assertEqual(self.adapter.position(), 5)
+        self.assertEqual(self.adapter.length(), 7)
+
+    def test_volume_verbs_delegate(self):
+        self.adapter.lower_volume()
+        self.adapter.restore_volume()
+        self.service.lower_volume.assert_called_once_with()
+        self.service.restore_volume.assert_called_once_with()
+
+    def test_deactivate_stops_and_clears_the_held_backend(self):
+        backend = _Backend("vlc", ["file"])
+        self.player.audio_service = _audio_service(backend)
+        self.player.audio_service.current = backend
+        self.adapter.deactivate()
+        self.assertTrue(backend.stopped)
+        self.assertIsNone(self.player.audio_service.current)
+
+    def test_deactivate_is_a_noop_without_a_held_backend(self):
+        self.player.audio_service = _audio_service()
+        self.player.audio_service.current = None
+        self.adapter.deactivate()  # must not raise
+        self.assertIsNone(self.player.audio_service.current)
+
+    def test_deactivate_clears_even_when_the_backend_raises(self):
+        backend = _Backend("vlc", ["file"])
+        backend.stop = MagicMock(side_effect=RuntimeError("boom"))
+        self.player.audio_service = _audio_service(backend)
+        self.player.audio_service.current = backend
+        self.adapter.deactivate()
+        self.assertIsNone(self.player.audio_service.current)
+
+
+class TestOPMBackendAdapterRouting(unittest.TestCase):
+    """can_play routing goes through the service layer, keeping a raising
+    plugin from taking the healthy ones with it."""
+
+    def setUp(self):
+        self.broken = _Backend("broken", [], raises=True)
+        self.good = _Backend("vlc", ["file"])
+        self.player = _FakePlayer(service=_audio_service(self.broken, self.good))
+        self.adapter = OPMBackendAdapter("opm:audio", self.player, "audio_service")
+
+    def test_a_raising_backend_does_not_hide_a_healthy_one(self):
+        self.assertTrue(self.adapter.can_play("file://track.mp3"))
+
+    def test_unclaimed_uri_is_reported_unplayable(self):
+        self.assertFalse(self.adapter.can_play("magnet://whatever"))
+
+    def test_preferred_backend_claims_the_uri_first(self):
+        preferred = _Backend("mpv", ["magnet"])
+        self.player._preferred = preferred
+        self.assertTrue(self.adapter.can_play("magnet://whatever"))
+
+
+class TestSkillPlayerAdapter(unittest.TestCase):
+    def setUp(self):
+        self.bus = FakeBus()
+        self.emitted = []
+        self.bus.on("message", lambda m: self.emitted.append(Message.deserialize(m)))
+        self.player = _FakePlayer(bus=self.bus)
+        self.adapter = SkillPlayerAdapter(self.player)
+
+    def _types(self):
+        return [m.msg_type for m in self.emitted]
+
+    def test_play_emits_the_skill_play_and_track_state(self):
+        self.adapter.play("file://track.mp3")
+        self.assertEqual(self._types(),
+                         ["ovos.common_play.skill.test.play",
+                          "ovos.common_play.track.state"])
+        self.assertEqual(self.emitted[0].data, {"uri": "file://track.mp3"})
+        self.assertEqual(self.emitted[1].data["state"], TrackState.PLAYING_SKILL)
+
+    def test_transport_verbs_emit_per_skill_messages(self):
+        self.adapter.pause()
+        self.adapter.resume()
+        self.adapter.stop()
+        self.adapter.next()
+        self.adapter.prev()
+        self.assertEqual(self._types(), ["ovos.common_play.skill.test.pause",
+                                         "ovos.common_play.skill.test.resume",
+                                         "ovos.common_play.skill.test.stop",
+                                         "ovos.common_play.skill.test.next",
+                                         "ovos.common_play.skill.test.prev"])
+
+    def test_verbs_follow_the_current_skill(self):
+        self.player.now_playing.skill_id = "other.skill"
+        self.adapter.stop()
+        self.assertEqual(self._types(), ["ovos.common_play.other.skill.stop"])
+
+    def test_seek_is_dropped_rather_than_emitted(self):
+        self.adapter.seek(1000)
+        self.assertEqual(self._types(), [])
+
+    def test_can_play_always_claims_the_track(self):
+        self.assertTrue(self.adapter.can_play("anything://at.all"))
+
+    def test_position_and_length_come_from_now_playing(self):
+        self.assertEqual(self.adapter.position(), 1000)
+        self.assertEqual(self.adapter.length(), 180000)
+
+    def test_volume_verbs_are_silent_noops(self):
+        self.adapter.lower_volume()
+        self.adapter.restore_volume()
+        self.adapter.deactivate()
+        self.assertEqual(self._types(), [])
+
+
+class TestAdapterContract(unittest.TestCase):
+    def test_every_verb_is_implemented_by_every_adapter(self):
+        player = _FakePlayer()
+        adapters = [OPMBackendAdapter("opm:audio", player, "audio_service"),
+                    SkillPlayerAdapter(player)]
+        verbs = ["can_play", "play", "pause", "resume", "stop", "seek",
+                 "position", "length", "lower_volume", "restore_volume",
+                 "deactivate"]
+        for adapter in adapters:
+            for verb in verbs:
+                self.assertTrue(callable(getattr(adapter, verb)),
+                                f"{adapter!r} is missing {verb}")
+
+    def test_the_interface_cannot_be_instantiated(self):
+        with self.assertRaises(TypeError):
+            PlayerAdapter("nope")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_player_handlers.py
+++ b/test/unittests/test_player_handlers.py
@@ -743,6 +743,59 @@ class TestStopVariousPlaybackTypes(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# UNDEFINED playback type — "nothing is loaded, make sure nothing is playing"
+# ---------------------------------------------------------------------------
+
+class TestUndefinedPlaybackFanOut(unittest.TestCase):
+    """With no media loaded, pause and stop must reach every player that
+    could still be holding audio, not just the audio one."""
+
+    def _skill_topic(self, p, verb):
+        return f"ovos.common_play.{p.now_playing.skill_id}.{verb}"
+
+    def test_pause_reaches_audio_video_and_the_skill(self):
+        p = _make_player(PlaybackType.UNDEFINED)
+        p.state = PlayerState.PLAYING
+        p.handle_status = MagicMock()
+        emitted = []
+        p.bus.emit = lambda m: emitted.append(m.msg_type)
+        p.pause()
+        p.audio_service.pause.assert_called_once()
+        p.video_service.pause.assert_called_once()
+        self.assertIn(self._skill_topic(p, "pause"), emitted)
+
+    def test_resume_reaches_audio_and_the_skill_but_not_video(self):
+        p = _make_player(PlaybackType.UNDEFINED)
+        p.state = PlayerState.PAUSED
+        p.handle_status = MagicMock()
+        emitted = []
+        p.bus.emit = lambda m: emitted.append(m.msg_type)
+        p.resume()
+        p.audio_service.resume.assert_called_once()
+        p.video_service.resume.assert_not_called()
+        self.assertIn(self._skill_topic(p, "resume"), emitted)
+
+    def test_stop_reaches_every_player_in_order(self):
+        p = _make_player(PlaybackType.UNDEFINED)
+        p.state = PlayerState.PLAYING
+        p.handle_status = MagicMock()
+        manager = MagicMock()
+        p.audio_service.stop = manager.audio_stop
+        p.video_service.stop = manager.video_stop
+        p.web_service.stop = manager.web_stop
+        skill_stop = self._skill_topic(p, "stop")
+
+        def emit(message):
+            if message.msg_type == skill_stop:
+                manager.skill_stop()
+
+        p.bus.emit = emit
+        p.stop()
+        self.assertEqual([name for name, _, _ in manager.mock_calls],
+                         ["audio_stop", "skill_stop", "video_stop", "web_stop"])
+
+
+# ---------------------------------------------------------------------------
 # handle_play_request — sets loop_state when repeat=True
 # ---------------------------------------------------------------------------
 

--- a/test/unittests/test_player_roster.py
+++ b/test/unittests/test_player_roster.py
@@ -1,0 +1,246 @@
+"""Selection tests for the player roster.
+
+Two questions are asked of the roster: which player starts the current track,
+and which players a transport verb reaches. The second is not derived from the
+first — PlaybackType.UNDEFINED means "nothing is loaded", so a stop or a pause
+on it must reach every player that could still be holding audio.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_utils.ocp import PlaybackType
+
+from ovos_media.player.adapters import PlayerAdapter
+from ovos_media.player.roster import PlayerRoster
+
+
+class _FakeAdapter(PlayerAdapter):
+    def __init__(self, player_id, playable=True):
+        super().__init__(player_id)
+        self.playable = playable
+        self.calls = []
+
+    def can_play(self, uri):
+        self.calls.append(("can_play", uri))
+        return self.playable
+
+    def play(self, uri):
+        self.calls.append(("play", uri))
+
+    def pause(self):
+        self.calls.append(("pause",))
+
+    def resume(self):
+        self.calls.append(("resume",))
+
+    def stop(self):
+        self.calls.append(("stop",))
+
+    def seek(self, milliseconds):
+        self.calls.append(("seek", milliseconds))
+
+    def position(self):
+        return None
+
+    def length(self):
+        return None
+
+    def lower_volume(self):
+        self.calls.append(("lower_volume",))
+
+    def restore_volume(self):
+        self.calls.append(("restore_volume",))
+
+    def deactivate(self):
+        self.calls.append(("deactivate",))
+
+
+def _roster(**playable):
+    adapters = {i: _FakeAdapter(i, playable.get(i.replace(":", "_"), True))
+                for i in ("opm:audio", "opm:video", "opm:web", "skill")}
+    roster = PlayerRoster(adapters.values())
+    return roster, adapters
+
+
+class TestRosterLookup(unittest.TestCase):
+    def setUp(self):
+        self.roster, self.adapters = _roster()
+
+    def test_lookup_by_id(self):
+        self.assertIs(self.roster.get("opm:audio"), self.adapters["opm:audio"])
+        self.assertIsNone(self.roster.get("opm:nothing"))
+
+    def test_owner_per_playback_type(self):
+        for ptype, player_id in ((PlaybackType.AUDIO, "opm:audio"),
+                                 (PlaybackType.VIDEO, "opm:video"),
+                                 (PlaybackType.WEBVIEW, "opm:web"),
+                                 (PlaybackType.SKILL, "skill")):
+            with self.subTest(ptype=ptype):
+                self.assertIs(self.roster.owner(ptype), self.adapters[player_id])
+
+    def test_unowned_playback_types_have_no_owner(self):
+        self.assertIsNone(self.roster.owner(PlaybackType.MPRIS))
+        self.assertIsNone(self.roster.owner(PlaybackType.UNDEFINED))
+
+
+class TestVerbRouting(unittest.TestCase):
+    def setUp(self):
+        self.roster, _ = _roster()
+
+    def _ids(self, verb, ptype):
+        return [a.id for a in self.roster.route(verb, ptype)]
+
+    def test_pause_routing(self):
+        self.assertEqual(self._ids("pause", PlaybackType.AUDIO), ["opm:audio"])
+        self.assertEqual(self._ids("pause", PlaybackType.VIDEO), ["opm:video"])
+        self.assertEqual(self._ids("pause", PlaybackType.SKILL), ["skill"])
+        self.assertEqual(self._ids("pause", PlaybackType.WEBVIEW), [])
+        self.assertEqual(self._ids("pause", PlaybackType.UNDEFINED),
+                         ["opm:audio", "opm:video", "skill"])
+
+    def test_resume_routing(self):
+        self.assertEqual(self._ids("resume", PlaybackType.AUDIO), ["opm:audio"])
+        self.assertEqual(self._ids("resume", PlaybackType.VIDEO), ["opm:video"])
+        self.assertEqual(self._ids("resume", PlaybackType.SKILL), ["skill"])
+        self.assertEqual(self._ids("resume", PlaybackType.WEBVIEW), [])
+        self.assertEqual(self._ids("resume", PlaybackType.UNDEFINED),
+                         ["opm:audio", "skill"])
+
+    def test_stop_reaches_every_player_when_nothing_is_loaded(self):
+        self.assertEqual(self._ids("stop", PlaybackType.UNDEFINED),
+                         ["opm:audio", "skill", "opm:video", "opm:web"])
+
+    def test_stop_routing_per_type(self):
+        self.assertEqual(self._ids("stop", PlaybackType.AUDIO), ["opm:audio"])
+        self.assertEqual(self._ids("stop", PlaybackType.VIDEO), ["opm:video"])
+        self.assertEqual(self._ids("stop", PlaybackType.WEBVIEW), ["opm:web"])
+        self.assertEqual(self._ids("stop", PlaybackType.SKILL), ["skill"])
+
+    def test_seek_reaches_nobody_where_seeking_is_unsupported(self):
+        self.assertEqual(self._ids("seek", PlaybackType.AUDIO), ["opm:audio"])
+        self.assertEqual(self._ids("seek", PlaybackType.UNDEFINED), ["opm:audio"])
+        self.assertEqual(self._ids("seek", PlaybackType.VIDEO), ["opm:video"])
+        self.assertEqual(self._ids("seek", PlaybackType.SKILL), [])
+        self.assertEqual(self._ids("seek", PlaybackType.WEBVIEW), [])
+        self.assertEqual(self._ids("seek", PlaybackType.MPRIS), [])
+
+    def test_ducking_only_reaches_players_with_a_volume(self):
+        self.assertEqual(self._ids("volume", PlaybackType.AUDIO), ["opm:audio"])
+        self.assertEqual(self._ids("volume", PlaybackType.VIDEO), ["opm:video"])
+        self.assertEqual(self._ids("volume", PlaybackType.SKILL), [])
+        self.assertEqual(self._ids("volume", PlaybackType.UNDEFINED), [])
+
+    def test_position_queries_only_read_the_audio_backend(self):
+        self.assertEqual(self._ids("position", PlaybackType.AUDIO), ["opm:audio"])
+        self.assertEqual(self._ids("position", PlaybackType.VIDEO), [])
+        self.assertEqual(self._ids("position_offset", PlaybackType.UNDEFINED),
+                         ["opm:audio"])
+        self.assertEqual(self._ids("position_offset", PlaybackType.VIDEO), [])
+
+    def test_an_unknown_verb_routes_nowhere(self):
+        self.assertEqual(self._ids("teleport", PlaybackType.AUDIO), [])
+
+    def test_a_missing_adapter_is_skipped_rather_than_raising(self):
+        roster = PlayerRoster([_FakeAdapter("opm:audio")])
+        self.assertEqual([a.id for a in roster.route("stop", PlaybackType.UNDEFINED)],
+                         ["opm:audio"])
+
+
+class TestSelection(unittest.TestCase):
+    def setUp(self):
+        self.roster, self.adapters = _roster()
+
+    def test_audio_is_selected_without_asking_can_play(self):
+        adapter, ptype = self.roster.select(PlaybackType.AUDIO, "file://a.mp3")
+        self.assertIs(adapter, self.adapters["opm:audio"])
+        self.assertEqual(ptype, PlaybackType.AUDIO)
+        self.assertEqual(self.adapters["opm:audio"].calls, [])
+
+    def test_skill_is_selected_for_skill_playback(self):
+        adapter, ptype = self.roster.select(PlaybackType.SKILL, "file://a.mp3")
+        self.assertIs(adapter, self.adapters["skill"])
+        self.assertEqual(ptype, PlaybackType.SKILL)
+
+    def test_video_with_a_claiming_backend_stays_video(self):
+        adapter, ptype = self.roster.select(PlaybackType.VIDEO, "file://a.mp4")
+        self.assertIs(adapter, self.adapters["opm:video"])
+        self.assertEqual(ptype, PlaybackType.VIDEO)
+        self.assertNotIn(("deactivate",), self.adapters["opm:video"].calls)
+
+    def test_unowned_playback_type_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self.roster.select(PlaybackType.MPRIS, "file://a.mp3")
+        with self.assertRaises(ValueError):
+            self.roster.select(PlaybackType.UNDEFINED, "file://a.mp3")
+
+    def test_video_without_a_backend_is_demoted_to_audio(self):
+        roster, adapters = _roster(opm_video=False)
+        adapter, ptype = roster.select(PlaybackType.VIDEO, "file://a.mp4")
+        self.assertIs(adapter, adapters["opm:audio"])
+        self.assertEqual(ptype, PlaybackType.AUDIO)
+
+    def test_demotion_stops_the_abandoned_backend(self):
+        roster, adapters = _roster(opm_video=False)
+        roster.select(PlaybackType.VIDEO, "file://a.mp4")
+        self.assertIn(("deactivate",), adapters["opm:video"].calls)
+
+    def test_webview_without_a_backend_is_demoted_to_audio(self):
+        roster, adapters = _roster(opm_web=False)
+        adapter, ptype = roster.select(PlaybackType.WEBVIEW, "file://a.html")
+        self.assertIs(adapter, adapters["opm:audio"])
+        self.assertEqual(ptype, PlaybackType.AUDIO)
+        self.assertIn(("deactivate",), adapters["opm:web"].calls)
+
+    def test_no_player_at_all_reports_the_demotion_and_no_adapter(self):
+        roster, adapters = _roster(opm_video=False, opm_audio=False)
+        adapter, ptype = roster.select(PlaybackType.VIDEO, "file://a.mp4")
+        self.assertIsNone(adapter)
+        self.assertEqual(ptype, PlaybackType.AUDIO)
+        self.assertIn(("deactivate",), adapters["opm:video"].calls)
+
+
+class TestDeactivateOthers(unittest.TestCase):
+    def test_every_other_player_gives_up_its_track(self):
+        roster, adapters = _roster()
+        roster.deactivate_others(PlaybackType.AUDIO)
+        self.assertEqual(adapters["opm:audio"].calls, [])
+        for player_id in ("opm:video", "opm:web", "skill"):
+            self.assertIn(("deactivate",), adapters[player_id].calls, player_id)
+
+    def test_an_unowned_playback_type_deactivates_everyone(self):
+        roster, adapters = _roster()
+        roster.deactivate_others(PlaybackType.MPRIS)
+        for adapter in adapters.values():
+            self.assertIn(("deactivate",), adapter.calls, adapter.id)
+
+    def test_selection_does_not_deactivate_on_its_own(self):
+        # the player deactivates before validating the stream, so a stream
+        # that fails validation still leaves no backend holding a track
+        roster, adapters = _roster()
+        roster.select(PlaybackType.AUDIO, "file://a.mp3")
+        self.assertEqual(adapters["opm:video"].calls, [])
+
+
+class TestRosterOverRealAdapters(unittest.TestCase):
+    """The roster works over the adapters the player actually builds."""
+
+    def test_opm_and_skill_adapters_route_together(self):
+        from ovos_media.player.adapters import (OPMBackendAdapter,
+                                                SkillPlayerAdapter)
+        player = MagicMock()
+        player.audio_service.can_play.return_value = True
+        roster = PlayerRoster([
+            OPMBackendAdapter("opm:audio", player, "audio_service"),
+            OPMBackendAdapter("opm:video", player, "video_service"),
+            OPMBackendAdapter("opm:web", player, "web_service"),
+            SkillPlayerAdapter(player),
+        ])
+        self.assertEqual([a.id for a in roster.route("stop", PlaybackType.UNDEFINED)],
+                         ["opm:audio", "skill", "opm:video", "opm:web"])
+        adapter, ptype = roster.select(PlaybackType.AUDIO, "file://a.mp3")
+        self.assertEqual(adapter.id, "opm:audio")
+        self.assertEqual(ptype, PlaybackType.AUDIO)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-media is the abstract OVOS media player: one virtual player that tracks whatever is actually playing. The concrete players it drives are not uniform — an OPM media plugin is driven through a `BaseMediaService`, an OCP skill is driven by bus messages it subscribes to itself — and the player carried that difference in every transport verb as an `if self.playback_type in [...]` ladder. Adding a third kind of player (external MPRIS players) meant adding another branch to each of them.

This adds one internal interface, `PlayerAdapter`, with the verbs the virtual player actually speaks: `can_play`, `play`, `pause`, `resume`, `stop`, `seek`, `position`, `length`, and the duck pair. `OPMBackendAdapter` wraps one backend family through its service — backend selection, the supported_uris isolation and the stop guard window all stay in the service layer, which this change deliberately does not dissolve. `SkillPlayerAdapter` emits the same per-skill `ovos.common_play.{skill_id}.*` messages the SKILL branches emitted and reports its position and length from now_playing. `AudioService`, `VideoService` and `WebService` are constructed exactly as before; the adapters wrap them afterwards and look their service up on the player at call time.

`PlayerRoster` holds the adapters and answers the two questions the player has about them. Which player starts this track: that is `select()`, which also keeps the video/web to audio demotion, including stopping the abandoned backend so a still-playing video does not run underneath the new audio stream. And which players does this verb reach: that is `route()`, a table with one row per verb. The second question is not derived from the first, because `PlaybackType.UNDEFINED` means nothing is loaded, so a stop or a pause on it has to reach every player that could still be holding audio. That fan-out was the real content of the old ladders, and the table is now the single place it is written down — including which players a verb does not reach at all, which is recorded as absence from the row rather than as a second, parallel encoding on the adapters.

The transport verbs lost their ladders: pause, resume, stop, seek, duck and unduck, the position and length queries, the seek offset read, the MPRIS-takeover stop sweep, and the playback dispatch in `play()`. The MPRIS branches stay, factored as early-outs ahead of the adapter call, because converting external players to adapters is the next step and not this one.

Behavior is unchanged. The full unit suite (821 tests, 68 subtests) and the end-to-end suite (68 tests) pass unmodified, with the end-to-end suite serving as the oracle; the ovoscope harness patches `ovos_media.player.AudioService`/`VideoService`/`WebService`/`OcpMprisExporter`, and those names remain importable from that module and remain the constructors the player uses. Two new test files cover the new layer directly: the adapter contract per implementation (verb delegation, can_play routing including a raising plugin not hiding a healthy one) and roster selection (playback-type routing, preferred resolution, the demotion path and its abandoned-backend stop). Three tests drive the UNDEFINED fan-out through the player itself, one of them asserting the stop call sequence across the services, so the routing table is pinned by behavior and not only by a test of its own contents. Totals go from 821 to 870 tests and 68 to 72 subtests.
