### PR TITLE
refactor: single-threaded player dispatcher

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,6 +196,49 @@ ovos-core's OCP pipeline always has a current snapshot for the session.
 
 ---
 
+## Execution model
+
+Commands and queries reach the player from several threads: the bus client's
+dispatch pool, the MPRIS exporter's own thread, and the timer behind the
+delayed retry after a bad stream. Everything that *changes* the player runs
+instead on one worker thread, the `Dispatcher`
+(`ovos_media/player/dispatcher.py`), which drains a FIFO queue of commands.
+
+- The **bus edge** (`ovos_media/bus/api.py`) submits a command per accepted
+  message. Its arrival order on the bus is the order it is acted on.
+- The **MPRIS thread** submits at the boundary: a `Next` or a `Stop` from a
+  desktop widget becomes a queued command like any other.
+- The **delayed retry** after `INVALID_MEDIA` is submitted with a delay and
+  tagged with the dispatcher's current epoch. `play()`, `stop()` and
+  `reset()` bump that epoch, and a retry whose epoch no longer matches is
+  dropped when it comes up — a new play request cannot be skipped by a retry
+  scheduled for the track before it.
+
+Because the state machine has a single writer, it needs no locks: two
+`END_OF_MEDIA` events are two queued commands, and the second sees the state
+the first wrote. The same ordering is what makes an explicit stop safe — the
+stop command finishes, including the backend call whose `ocp_stop()` emits
+`END_OF_MEDIA`, before that event is acted on.
+
+Reads are not serialized. `PlayerSnapshot` is an immutable view of the
+player republished after every command, and the query topics
+(`ovos.common_play.status`, `.track_info`, `.get_track_length`,
+`.get_track_position`, `.list_backends`, `.SEI.get`) answer from it at the
+edge, so a status request never waits behind a playback command. The live
+track position and length are read straight from the backend plugin, which
+is the one sanctioned read from another thread: only the plugin knows them,
+and a queued answer would be stale by the time it was emitted.
+
+`Dispatcher.settle()` waits for the player to go idle, including work a
+command queues by emitting on the bus. Tests use it where they used to
+read the player immediately after an emit.
+
+Nothing on the dispatcher may block. The one handler that waits on the bus,
+`handle_record_end` (up to 8 s for a `speak` before it uncorks), stays at
+the edge and submits only the resume it decides on.
+
+---
+
 ## State Machine
 
 Two orthogonal state enums are tracked by `OCPMediaPlayer`, both defined in

--- a/ovos_media/bus/api.py
+++ b/ovos_media/bus/api.py
@@ -17,9 +17,11 @@ and what is removed can never drift apart.
 
 An entry names the topic, an optional payload decoder from
 :mod:`ovos_media.bus.schemas`, whether the topic is gated to the local
-session, and the method to call. The wrapper built around each entry
-decodes, gates, and then calls that method synchronously — the objects
-behind the edge see only payloads that already passed both checks.
+session, whether it mutates the player, and the method to call. The
+wrapper built around each entry decodes, gates, and then either submits
+the call to the player's dispatcher (mutating commands, which then run
+one at a time in arrival order) or runs it inline (queries, which answer
+from the published snapshot and must not wait behind a command).
 
 The backend services (:mod:`ovos_media.media_backends`) still bind their
 own 'ovos.common_play.media.state' listener in
@@ -49,11 +51,16 @@ class BusHandler:
         the target is then not called at all.
     gated: True when only the local/"default" session may trigger the
         target (see :func:`ovos_media.utils.is_default_session`).
+    dispatch: True when the target mutates the player and must therefore
+        run on its dispatcher. False for queries (answered from the
+        published snapshot or read live from a backend) and for the one
+        target that blocks on the bus, ``handle_record_end``.
     """
     topic: str
     target: Callable
     decoder: Optional[Callable] = None
     gated: bool = False
+    dispatch: bool = True
 
 
 class OCPBusApi:
@@ -125,13 +132,17 @@ class OCPBusApi:
 
     @staticmethod
     def _catalog_table(catalog) -> List[BusHandler]:
+        # the catalog owns its own bookkeeping (the skill roster, the
+        # search playlist) and touches no player state, so its handlers stay
+        # off the dispatcher: an announce must land inside the 200 ms
+        # settle window get_featured_skills waits, not behind a play command.
         return [
             BusHandler("ovos.common_play.skills.detach",
                        catalog.handle_ocp_skill_detach,
-                       decoder=decode_skill_id),
+                       decoder=decode_skill_id, dispatch=False),
             BusHandler("ovos.common_play.announce",
                        catalog.handle_skill_announce,
-                       decoder=decode_skill_id),
+                       decoder=decode_skill_id, dispatch=False),
         ]
 
     @staticmethod
@@ -167,16 +178,20 @@ class OCPBusApi:
             BusHandler("ovos.common_play.seek", player.handle_seek_request,
                        decoder=decode_seek, gated=True),
             BusHandler("ovos.common_play.get_track_length",
-                       player.handle_track_length_request),
+                       player.handle_track_length_request,
+                       dispatch=False),
             BusHandler("ovos.common_play.set_track_position",
                        player.handle_set_track_position_request,
                        decoder=decode_track_position, gated=True),
             BusHandler("ovos.common_play.get_track_position",
-                       player.handle_track_position_request),
+                       player.handle_track_position_request,
+                       dispatch=False),
             BusHandler("ovos.common_play.track_info",
-                       player.handle_track_info_request),
+                       player.handle_track_info_request,
+                       dispatch=False),
             BusHandler("ovos.common_play.list_backends",
-                       player.handle_list_backends_request),
+                       player.handle_list_backends_request,
+                       dispatch=False),
             BusHandler("ovos.common_play.playlist.set",
                        player.handle_playlist_set_request,
                        decoder=decode_playlist_tracks, gated=True),
@@ -211,8 +226,11 @@ class OCPBusApi:
             # record_end and utterance.handled do nothing except resume or
             # unduck, both of which are gated, so the gate sits on the
             # topic itself.
+            # waits up to 8s for a 'speak' before uncorking — that wait
+            # stays on the bus thread, and only the resume it decides on is
+            # submitted (see OCPMediaPlayer.handle_record_end)
             BusHandler("recognizer_loop:record_end", player.handle_record_end,
-                       gated=True),
+                       gated=True, dispatch=False),
             BusHandler("ovos.utterance.handled",
                        player.handle_utterance_handled, gated=True),
             BusHandler("mycroft.stop", player.handle_mycroft_stop),
@@ -228,12 +246,14 @@ class OCPBusApi:
                        player.handle_set_repeat, gated=True),
             BusHandler("ovos.common_play.repeat.unset",
                        player.handle_unset_repeat, gated=True),
-            BusHandler("ovos.common_play.SEI.get", player.handle_get_SEIs),
+            BusHandler("ovos.common_play.SEI.get", player.handle_get_SEIs,
+                       dispatch=False),
             BusHandler("ovos.common_play.like", player.handle_like,
                        gated=True),
             BusHandler("ovos.common_play.unlike", player.handle_unlike,
                        gated=True),
-            BusHandler("ovos.common_play.status", player.handle_status),
+            BusHandler("ovos.common_play.status", player.handle_status,
+                       dispatch=False),
             # external MPRIS player → reflect as OCP now_playing (no local
             # backend)
             BusHandler("ovos.common_play.mpris.now_playing",
@@ -262,6 +282,15 @@ class OCPBusApi:
         every registration a distinct object, so each remove() resolves on
         its own.
         """
+        # imported here: the player package imports this module
+        from ovos_media.player.dispatcher import Dispatcher
+        dispatcher = getattr(self.player, "dispatcher", None) \
+            if self.player is not None else None
+        if not isinstance(dispatcher, Dispatcher):
+            # a service-only edge, or a player assembled piecemeal: nothing
+            # to serialize against, so every target runs at the edge
+            dispatcher = None
+
         def listener(message):
             if entry.decoder is not None:
                 try:
@@ -275,7 +304,10 @@ class OCPBusApi:
                 LOG.debug(f"ignoring '{entry.topic}' message, not from the "
                           f"default/local session")
                 return
-            entry.target(message)
+            if entry.dispatch and dispatcher is not None:
+                dispatcher.submit(lambda: entry.target(message))
+            else:
+                entry.target(message)
 
         return listener
 

--- a/ovos_media/media_backends/base.py
+++ b/ovos_media/media_backends/base.py
@@ -47,13 +47,12 @@ class BaseMediaService:
         """
             Args:
                 bus: OVOS messagebus
-                on_stop: optional callback invoked at the start of stop(), in
-                    the calling thread, before the backend is asked to stop.
-                    OCPMediaPlayer uses it to flag that the END_OF_MEDIA the
-                    backend's ocp_stop() is about to emit was caused by a stop
-                    request and must not advance the queue. A callback rather
-                    than a second bus subscription because only a direct call
-                    is ordered before the event it needs to annotate.
+                on_stop: optional callback invoked at the start of stop(),
+                    in the calling thread. OCPMediaPlayer uses it to learn
+                    that a stop it did not itself request happened here (a
+                    skill stopping this service directly), so the
+                    END_OF_MEDIA the backend's ocp_stop() is about to emit
+                    does not advance the queue.
         """
         self.bus = bus
         self.namespace = namespace

--- a/ovos_media/mpris.py
+++ b/ovos_media/mpris.py
@@ -56,6 +56,23 @@ from ovos_utils.ocp import TrackState, PlaybackType, PlayerState, LoopState, Med
 from ovos_media.bus.schemas import is_real_number
 
 
+def _submit(player, fn):
+    """Run *fn* on the player's dispatcher.
+
+    The MPRIS watcher and the D-Bus interfaces live on their own threads.
+    Everything they change about the player goes through this boundary, so
+    the player still has a single writer. Reads (Metadata, PlaybackStatus,
+    Position, CanGoNext …) stay direct. A player without a dispatcher — a
+    stub, or one assembled piecemeal — is called inline.
+    """
+    from ovos_media.player.dispatcher import Dispatcher  # avoids an import cycle
+    dispatcher = getattr(player, "dispatcher", None)
+    if isinstance(dispatcher, Dispatcher):
+        dispatcher.submit(fn)
+    else:
+        fn()
+
+
 class OcpMprisExporter(Thread):
     """Exposes OCP as an MPRIS MediaPlayer2 on the D-Bus session bus.
 
@@ -127,7 +144,13 @@ class OcpMprisExporter(Thread):
             return
 
         if self._ocp_player and self.player_meta.get(self.main_player):
-            data = self.player_meta[self.main_player]
+            _submit(self._ocp_player, self._apply_external_player_state)
+
+    def _apply_external_player_state(self):
+        """Mirror the polled external player onto OCP. Runs as one
+        dispatcher command so no other command interleaves with it."""
+        data = self.player_meta.get(self.main_player)
+        if data:
 
             # reset ocp, it will display metadata of current track
             render = False
@@ -190,29 +213,32 @@ class OcpMprisExporter(Thread):
     async def handle_player_shuffle(self, shuffle):
         LOG.info(f"MPRIS Player Shuffle: {shuffle}")
         if self.manage_players:
-            self._ocp_player.shuffle = shuffle
+            _submit(self._ocp_player,
+                    lambda: setattr(self._ocp_player, "shuffle", shuffle))
 
     async def handle_player_loop_state(self, state):
         LOG.info(f"MPRIS Player Repeat: {state}")
         if self.manage_players:
-            if state == 1:
-                self._ocp_player.loop_state = LoopState.REPEAT
-            elif state == 2:
-                self._ocp_player.loop_state = LoopState.REPEAT_TRACK
-            else:
-                self._ocp_player.loop_state = LoopState.NONE
+            loop = {1: LoopState.REPEAT, 2: LoopState.REPEAT_TRACK}.get(
+                state, LoopState.NONE)
+            _submit(self._ocp_player,
+                    lambda: setattr(self._ocp_player, "loop_state", loop))
 
     async def handle_player_state(self, state):
         LOG.info(f"MPRIS Player State: {state}")
         if self.manage_players and self._ocp_player:
-            if state == "Paused":
-                self._ocp_player.set_player_state(PlayerState.PAUSED)
-            elif state == "Playing":
-                self._ocp_player.handle_MPRIS_takeover()
-                self._ocp_player.playback_type = PlaybackType.MPRIS
-                self._ocp_player.set_player_state(PlayerState.PLAYING)
-            else:
-                self._ocp_player.set_player_state(PlayerState.STOPPED)
+            _submit(self._ocp_player,
+                    lambda: self._apply_external_player_transport(state))
+
+    def _apply_external_player_transport(self, state):
+        if state == "Paused":
+            self._ocp_player.set_player_state(PlayerState.PAUSED)
+        elif state == "Playing":
+            self._ocp_player.handle_MPRIS_takeover()
+            self._ocp_player.playback_type = PlaybackType.MPRIS
+            self._ocp_player.set_player_state(PlayerState.PLAYING)
+        else:
+            self._ocp_player.set_player_state(PlayerState.STOPPED)
 
     async def handle_lost_player(self, name):
         LOG.info(f"Lost MPRIS Player: {name}")
@@ -827,11 +853,11 @@ class _MediaPlayer2PlayerInterface(ServiceInterface):
     @LoopStatus.setter
     def LoopStatus_setter(self, val: 's'):
         if val == "Track":
-            self._ocp_player.loop_state = LoopState.REPEAT_TRACK
+            _submit(self._ocp_player, lambda: setattr(self._ocp_player, "loop_state", LoopState.REPEAT_TRACK))
         elif val == "Playlist":
-            self._ocp_player.loop_state = LoopState.REPEAT
+            _submit(self._ocp_player, lambda: setattr(self._ocp_player, "loop_state", LoopState.REPEAT))
         else:
-            self._ocp_player.loop_state = LoopState.NONE
+            _submit(self._ocp_player, lambda: setattr(self._ocp_player, "loop_state", LoopState.NONE))
 
     @dbus_property()
     def Shuffle(self) -> 'b':
@@ -839,7 +865,7 @@ class _MediaPlayer2PlayerInterface(ServiceInterface):
 
     @Shuffle.setter
     def Shuffle_setter(self, val: 'b'):
-        self._ocp_player.shuffle = val
+        _submit(self._ocp_player, lambda: setattr(self._ocp_player, "shuffle", val))
 
     @dbus_property()
     def Volume(self) -> 'd':
@@ -917,26 +943,29 @@ class _MediaPlayer2PlayerInterface(ServiceInterface):
 
     @method()
     def Previous(self):
-        self._ocp_player.play_prev()
+        _submit(self._ocp_player, self._ocp_player.play_prev)
 
     @method()
     def Next(self):
-        self._ocp_player.play_next()
+        _submit(self._ocp_player, self._ocp_player.play_next)
 
     @method()
     def Stop(self):
-        self._ocp_player.stop()
+        _submit(self._ocp_player, self._ocp_player.stop)
 
     @method()
     def Play(self):
-        self._ocp_player.resume()
+        _submit(self._ocp_player, self._ocp_player.resume)
 
     @method()
     def Pause(self):
-        self._ocp_player.pause()
+        _submit(self._ocp_player, self._ocp_player.pause)
 
     @method()
     def PlayPause(self):
+        _submit(self._ocp_player, self._play_pause)
+
+    def _play_pause(self):
         if self._ocp_player.state == PlayerState.PAUSED:
             self._ocp_player.resume()
         else:

--- a/ovos_media/player/__init__.py
+++ b/ovos_media/player/__init__.py
@@ -20,6 +20,7 @@ from ovos_media.player.queue import (AllFailed, KeepCurrent, PlayQueue,
 from ovos_media.player.now_playing import NowPlaying
 from ovos_media.player.adapters import OPMBackendAdapter, SkillPlayerAdapter
 from ovos_media.player.roster import PlayerRoster
+from ovos_media.player.dispatcher import Dispatcher, PlayerSnapshot
 from ovos_plugin_manager.ocp import load_stream_extractors
 from ovos_plugin_manager.templates.media import MediaBackend
 from ovos_utils.log import LOG
@@ -398,13 +399,15 @@ class OCPMediaPlayer:
         self.playlist: PlayQueue = self._queue
 
         self.now_playing: NowPlaying = NowPlaying(bus, player=self)
-        # BaseMediaService.stop() calls this on_stop callback to flag the
-        # stop on the player BEFORE the backend's ocp_stop() emits
-        # END_OF_MEDIA, in the same thread. A bus subscription would have
-        # had no such ordering guarantee against the END_OF_MEDIA it causes.
-        self.audio_service = AudioService(bus, on_stop=self._mark_stop_requested)
-        self.video_service = VideoService(bus, on_stop=self._mark_stop_requested)
-        self.web_service = WebService(bus, on_stop=self._mark_stop_requested)
+        # A stop the player itself asked for needs no callback any more:
+        # stop() runs to completion on the dispatcher, so the END_OF_MEDIA
+        # the backend's ocp_stop() emits is a later queued command and
+        # already sees _stop_requested. on_stop covers the other caller —
+        # a skill stopping a backend service directly — whose stop the
+        # player would otherwise mistake for a track ending.
+        self.audio_service = AudioService(bus, on_stop=self._on_backend_stop)
+        self.video_service = VideoService(bus, on_stop=self._on_backend_stop)
+        self.web_service = WebService(bus, on_stop=self._on_backend_stop)
         self.current: Optional[MediaBackend] = None
         self.mpris: Optional[OcpMprisExporter] = None
 
@@ -420,6 +423,7 @@ class OCPMediaPlayer:
         # OCPMediaCatalog lives in one registration table (see
         # ovos_media.bus.api), which is also what shutdown() tears down.
         self.bus_api = OCPBusApi(bus, player=self)
+        self.publish_snapshot()
         self._report_to_core()
 
     def _report_to_core(self) -> None:
@@ -437,14 +441,15 @@ class OCPMediaPlayer:
         means.
         """
         self._paused_on_duck: bool = False
-        # Guards every read-modify-write of media_state/player_state
-        # (including the compare-and-set in set_media_state/set_player_state)
-        # so the END_OF_MEDIA compare-and-set cannot be executed twice
-        # concurrently (two racing END_OF_MEDIA events used to double-advance
-        # the queue). Reentrant because play() -> on_invalid_stream()
-        # re-enters, and because set_player_state() calls handle_status()
-        # which may itself touch player/media state.
-        self._state_lock = RLock()
+        # Every command that mutates this player runs here, one at a time,
+        # in submission order: the bus edge, the MPRIS thread and the
+        # delayed invalid-stream retry all submit instead of calling in
+        # from their own threads. Two END_OF_MEDIA events are two queued
+        # commands, so the second sees what the first did.
+        self.dispatcher: Dispatcher = Dispatcher()
+        self.dispatcher.post_hook = self.publish_snapshot
+        # what queries answer from; replaced wholesale after every command
+        self._snapshot: PlayerSnapshot = PlayerSnapshot()
         # Alias of self.media.liked_songs_lock: guards every liked_songs
         # mutation + store() together, and every unlocked read that
         # iterates the dict. store() does a json.dump that iterates the
@@ -467,7 +472,6 @@ class OCPMediaPlayer:
         # failed-uri bookkeeping, and answers every "which track is next"
         # question; what to DO with the answer stays player policy
         self._queue: PlayQueue = PlayQueue(title="Search Results")
-        self._invalid_timer: Optional[threading.Timer] = None
         # retry delay after an invalid stream, seconds (overridable in tests)
         self.invalid_stream_delay: float = 3.0
         # rate-limit "track.failed" to once per queue (cleared alongside
@@ -503,20 +507,26 @@ class OCPMediaPlayer:
     def _failed_uris(self) -> set:
         return self._queue.failed
 
+    def publish_snapshot(self) -> PlayerSnapshot:
+        """Republish the query view of this player. Called after every
+        dispatched command."""
+        self._snapshot = PlayerSnapshot.of(self)
+        return self._snapshot
+
+    @property
+    def snapshot(self) -> PlayerSnapshot:
+        """The view queries answer from.
+
+        A command already running on the dispatcher reads live state — the
+        published snapshot still describes the world before the command
+        started, and set_player_state() reports status from inside one.
+        """
+        if self.dispatcher.on_thread():
+            return PlayerSnapshot.of(self)
+        return self._snapshot
+
     def handle_status(self, message):
-        self.bus.emit(message.response({
-            "playback_type": self.playback_type,
-            "media_type": self.now_playing.media_type,
-            "player_state": self.state,
-            "loop_state": self.loop_state,
-            "media_state": self.media_state,
-            "shuffle": self.shuffle,
-            "playlist_position": self.playlist.position,
-            "playlist_size": len(self.playlist),
-            "title": self.now_playing.title,
-            "artist": self.now_playing.artist,
-            "image": self.now_playing.image
-        }))
+        self.bus.emit(message.response(self.snapshot.as_status_dict))
 
     def handle_like(self, message):
         # sent from GUI or intent
@@ -608,20 +618,31 @@ class OCPMediaPlayer:
     def _mark_stop_requested(self):
         """Flag that the current playback is ending because it was stopped.
 
-        Called from OCPMediaPlayer.stop() and, via the ``on_stop`` callback,
-        from BaseMediaService.stop() before the backend's ocp_stop() emits
+        Called from OCPMediaPlayer.stop(), before the adapters are asked to
+        stop and therefore before the backend's ocp_stop() emits
         END_OF_MEDIA.
 
-        Also cancels any pending invalid-stream retry timer. Without this,
-        a stop arriving during the post-INVALID_MEDIA retry window left the
-        timer armed, and it fired play_next() after the stop had already
-        settled the player into STOPPED — spontaneously resuming playback.
+        Also supersedes any pending invalid-stream retry. Without this, a
+        stop arriving during the post-INVALID_MEDIA retry window let the
+        retry run play_next() after the stop had already settled the player
+        into STOPPED — spontaneously resuming playback.
         """
-        with self._state_lock:
-            self._stop_requested = True
-            if self._invalid_timer is not None:
-                self._invalid_timer.cancel()
-                self._invalid_timer = None
+        self._stop_requested = True
+        self.dispatcher.bump_epoch()
+
+    def _on_backend_stop(self):
+        """A backend service was stopped by someone other than this player.
+
+        A stop this player itself commanded reaches here from the
+        dispatcher, having already flagged it — submitting a second write
+        would land after whatever command came next (a play arriving while
+        the stop ran), re-flagging a stop the user has already replaced.
+        Only a stop from another thread, a skill calling a backend
+        service's stop() directly, still has to be recorded.
+        """
+        if self.dispatcher.in_command():
+            return
+        self.dispatcher.submit(self._mark_stop_requested)
 
     def _locator_uri(self, uri: str = None) -> Optional[str]:
         """The uri to locate the current track by, when entry identity does
@@ -670,14 +691,9 @@ class OCPMediaPlayer:
         """
         if not isinstance(state, MediaState):
             raise TypeError(f"Expected MediaState and got: {state}")
-        # the compare-and-set must happen under _state_lock, same as
-        # every other read-modify-write of media_state; the emit stays
-        # outside the critical section to avoid lock-order risk with any
-        # bus handler that re-enters and takes the lock itself.
-        with self._state_lock:
-            if state == self.media_state:
-                return
-            self.media_state = state
+        if state == self.media_state:
+            return
+        self.media_state = state
         self.bus.emit(Message("ovos.common_play.media.state",
                               {"state": state}))
 
@@ -689,13 +705,9 @@ class OCPMediaPlayer:
         """
         if not isinstance(state, PlayerState):
             raise TypeError(f"Expected PlayerState and got: {state}")
-        # same rationale as set_media_state() — compare-and-set under
-        # _state_lock, emit (and the MPRIS/GUI/status side effects below)
-        # outside the critical section.
-        with self._state_lock:
-            if state == self.state:
-                return
-            self.state = state
+        if state == self.state:
+            return
+        self.state = state
         self.bus.emit(Message("ovos.common_play.player.state",
                               {"state": state}))
         state2str = {PlayerState.PLAYING: "Playing",
@@ -914,17 +926,13 @@ class OCPMediaPlayer:
     def _schedule_play_next(self):
         """Schedule the delayed skip-to-next-track used after a bad stream.
 
-        Replaces any still-pending retry so a burst of INVALID_MEDIA events
-        cannot pile up overlapping timers, and uses a daemon thread so a
-        pending retry never keeps the process alive past shutdown.
+        Tagged with the current epoch: a later play(), stop() or reset()
+        bumps it and this retry is dropped when it comes up, so a burst of
+        INVALID_MEDIA events cannot pile up overlapping skips and a stale
+        retry can never fire against a track it was not scheduled for.
         """
-        with self._state_lock:
-            if self._invalid_timer is not None:
-                self._invalid_timer.cancel()
-            timer = threading.Timer(self.invalid_stream_delay, self.play_next)
-            timer.daemon = True
-            self._invalid_timer = timer
-        timer.start()
+        self.dispatcher.call_later(self.invalid_stream_delay, self.play_next,
+                                   self.dispatcher.epoch)
 
     # media controls
     def play_media(self, track: Union[dict, MediaEntry],
@@ -1008,16 +1016,12 @@ class OCPMediaPlayer:
         # wedging the player mid-PLAYING. Resetting to LOADING_MEDIA at the
         # start of every play() attempt guarantees the next real state
         # (whatever it is) always differs from the just-reset value.
-        with self._state_lock:
-            self.media_state = MediaState.LOADING_MEDIA
-            # a new play attempt supersedes any earlier stop request
-            self._stop_requested = False
-            # a new play attempt supersedes any pending invalid-stream retry;
-            # otherwise the stale timer fires play_next() against this NEW
-            # track once the retry window elapses
-            if self._invalid_timer is not None:
-                self._invalid_timer.cancel()
-                self._invalid_timer = None
+        self.media_state = MediaState.LOADING_MEDIA
+        # a new play attempt supersedes any earlier stop request
+        self._stop_requested = False
+        # ...and any pending invalid-stream retry; otherwise a stale retry
+        # runs play_next() against this NEW track once its window elapses
+        self.dispatcher.bump_epoch()
 
         # switching playback types must not leave the previously active
         # backend's BaseMediaService.current set — otherwise a later,
@@ -1339,10 +1343,7 @@ class OCPMediaPlayer:
         self._current_entry = None
         self._failed_uris.clear()
         self._track_failed_spoken = False
-        with self._state_lock:
-            if self._invalid_timer is not None:
-                self._invalid_timer.cancel()
-                self._invalid_timer = None
+        self.dispatcher.bump_epoch()
         self.playlist.clear()
         self.media.clear()
         if self.playback_type != PlaybackType.MPRIS:
@@ -1358,10 +1359,6 @@ class OCPMediaPlayer:
         Shutdown this instance and its spawned objects. Remove events.
         """
         self.stop()
-        with self._state_lock:
-            if self._invalid_timer is not None:
-                self._invalid_timer.cancel()
-                self._invalid_timer = None
         if self.mpris:
             self.mpris.shutdown()
         # self.media.shutdown() is the no-op OVOSSkill.shutdown() hook — it
@@ -1377,6 +1374,8 @@ class OCPMediaPlayer:
         self.web_service.shutdown()
         # a shut-down player must stop answering status/like/duck/etc
         self.bus_api.shutdown()
+        # last: no command may outlive the objects it drives
+        self.dispatcher.shutdown()
 
     def handle_player_media_update(self, message):
         """
@@ -1387,27 +1386,24 @@ class OCPMediaPlayer:
 
         # this is the sole consumer of END_OF_MEDIA on
         # 'ovos.common_play.media.state' (the backend services subscribe too,
-        # but act on LOADED_MEDIA only).
-        # The compare-and-set below plus the end-of-media capture happen under
-        # one lock, so two concurrent END_OF_MEDIA events can only ever advance
-        # the queue once. Nothing that can re-enter the player (autoplay, GUI
-        # pushes) runs while the lock is held.
-        with self._state_lock:
-            if state == self.media_state:
-                return
-            LOG.info(f"MediaState changed: {repr(self.media_state)} -> {repr(state)}")
-            self.media_state = state
-            ended = state == MediaState.END_OF_MEDIA
-            invalid = state == MediaState.INVALID_MEDIA
-            playback_type = playback_uri = None
-            stop_requested = False
-            if ended:
-                # capture BEFORE the reset that clears both values
-                playback_type = self.now_playing.playback
-                playback_uri = self.now_playing.uri
-                stop_requested = self._stop_requested
-                self.now_playing.on_end_of_media()
-            # NOTE: _failed_uris/_track_failed_spoken are reset on evidence
+        # but act on LOADED_MEDIA only). Two END_OF_MEDIA events arrive as two
+        # queued commands, so the second one sees the media_state the first
+        # one set and returns here — the queue can only advance once.
+        if state == self.media_state:
+            return
+        LOG.info(f"MediaState changed: {repr(self.media_state)} -> {repr(state)}")
+        self.media_state = state
+        ended = state == MediaState.END_OF_MEDIA
+        invalid = state == MediaState.INVALID_MEDIA
+        playback_type = playback_uri = None
+        stop_requested = False
+        if ended:
+            # capture BEFORE the reset that clears both values
+            playback_type = self.now_playing.playback
+            playback_uri = self.now_playing.uri
+            stop_requested = self._stop_requested
+            self.now_playing.on_end_of_media()
+        # NOTE: _failed_uris/_track_failed_spoken are reset on evidence
             # of PLAYBACK (NowPlaying.handle_track_state_change's
             # TrackState.PLAYING_* branch), not here on LOADED_MEDIA/
             # BUFFERED_MEDIA — a track that loads fine but fails to play
@@ -1640,9 +1636,11 @@ class OCPMediaPlayer:
         """
         if not self._paused_on_duck:
             return
+        # runs at the bus edge, never on the dispatcher: an 8s wait there
+        # would stall every other command. Only the resume is dispatched.
         speak_detected = self.bus.wait_for_message('speak', timeout=8.0)
         if not speak_detected:
-            self.handle_uncork_request(message)
+            self.dispatcher.submit(lambda: self.handle_uncork_request(message))
 
     def handle_utterance_handled(self, message):
         """
@@ -1684,14 +1682,19 @@ class OCPMediaPlayer:
 
     # track data
     def handle_track_length_request(self, message):
-        l = self.now_playing.length
+        # answered off the dispatcher. The backend adapters below are the
+        # sanctioned off-thread read: only the plugin knows the live
+        # length/position, and a queued round-trip would return a value
+        # already stale by the time it was emitted.
+        l = self.snapshot.track_info.get("length") or self.now_playing.length
         for adapter in self.roster.route("position", self.playback_type):
             l = adapter.length() or l
         data = {"length": l}
         self.bus.emit(message.response(data))
 
     def handle_track_position_request(self, message):
-        pos = self.now_playing.position
+        # live read, see handle_track_length_request
+        pos = self.snapshot.track_info.get("position") or self.now_playing.position
         for adapter in self.roster.route("position", self.playback_type):
             pos = adapter.position() or pos
         data = {"position": pos}
@@ -1703,8 +1706,7 @@ class OCPMediaPlayer:
             self.seek(miliseconds)
 
     def handle_track_info_request(self, message):
-        data = self.now_playing.as_dict
-        self.bus.emit(message.response(data))
+        self.bus.emit(message.response(dict(self.snapshot.track_info)))
 
     # internal info
     def handle_list_backends_request(self, message):

--- a/ovos_media/player/dispatcher.py
+++ b/ovos_media/player/dispatcher.py
@@ -1,0 +1,333 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Single-threaded execution model for the player.
+
+Every command that mutates player state runs on one worker thread, in the
+order it was submitted. The bus edge, the MPRIS thread and the delayed
+invalid-stream retry all hand their work to this queue instead of touching
+the player from their own threads, so the state machine has exactly one
+writer and needs no locks: two END_OF_MEDIA events are two queued commands,
+the second one seeing what the first one did.
+
+Reads are not serialized. Queries answer from :class:`PlayerSnapshot`, an
+immutable view published after every command; the live track position is
+the one sanctioned off-thread read, because it must reach the plugin.
+"""
+
+import queue
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, Tuple
+
+from ovos_utils.log import LOG
+
+
+class Dispatcher:
+    """FIFO command queue drained by a single worker thread.
+
+    The worker starts on the first submitted command, so a player that is
+    only ever driven by direct calls never spawns a thread.
+
+    ``immediate=True`` runs every command inline in the calling thread. It
+    exists for tests that drive the player directly and assert its state on
+    the next line; the ordering guarantee is then the calling thread's own.
+    """
+
+    def __init__(self, name: str = "ocp-dispatcher", immediate: bool = False):
+        self.name = name
+        self.immediate = immediate
+        self.post_hook: Optional[Callable[[], None]] = None
+        self._queue: "queue.Queue[Optional[Callable[[], None]]]" = queue.Queue()
+        self._thread: Optional[threading.Thread] = None
+        self._epoch: int = 0
+        self._timers: set = set()
+        # guards _timers only: timers are added from whichever thread
+        # schedules delayed work and removed from the timer threads
+        # themselves, so the set is touched concurrently by design
+        self._timers_lock = threading.Lock()
+        self._lock = threading.Lock()
+        self._local = threading.local()
+        self._stopped = False
+
+    @classmethod
+    def immediate_dispatcher(cls, name: str = "ocp-dispatcher-immediate") -> "Dispatcher":
+        """A dispatcher that runs everything inline (see class docstring)."""
+        return cls(name=name, immediate=True)
+
+    # --- worker -----------------------------------------------------------
+    def _ensure_worker(self) -> None:
+        with self._lock:
+            if self._thread is not None or self._stopped:
+                return
+            self._thread = threading.Thread(target=self._run, name=self.name,
+                                            daemon=True)
+            self._thread.start()
+
+    def _run(self) -> None:
+        while True:
+            fn = self._queue.get()
+            if fn is None:  # shutdown sentinel
+                return
+            self._execute(fn)
+
+    def _execute(self, fn: Callable[[], None]) -> None:
+        depth = getattr(self._local, "depth", 0)
+        self._local.depth = depth + 1
+        try:
+            fn()
+        except Exception as e:
+            LOG.exception(f"dispatched command failed: {e}")
+        finally:
+            self._local.depth = depth
+        if self.post_hook is not None:
+            try:
+                self.post_hook()
+            except Exception as e:
+                LOG.exception(f"dispatcher post hook failed: {e}")
+
+    def on_thread(self) -> bool:
+        """True when the caller reads and writes as the dispatcher does.
+
+        In immediate mode every caller does, since commands run inline.
+        """
+        if self.immediate:
+            return True
+        return threading.current_thread() is self._thread
+
+    def in_command(self) -> bool:
+        """True only while a submitted command is running.
+
+        Unlike :meth:`on_thread` this is False for a caller that reaches
+        the player some other way, which is what tells a callback from a
+        backend whether the stop it reports is one of our own commands.
+        """
+        return getattr(self._local, "depth", 0) > 0
+
+    # --- submission -------------------------------------------------------
+    def submit(self, fn: Callable[[], None]) -> None:
+        """Queue *fn* to run on the worker. Fire and forget."""
+        if self._stopped:
+            LOG.debug("dispatcher is shut down, dropping command")
+            return
+        if self.immediate:
+            self._execute(fn)
+            return
+        self._ensure_worker()
+        self._queue.put(fn)
+
+    def call(self, fn: Callable[[], Any], timeout: float = 5.0) -> Any:
+        """Run *fn* on the worker and return its result.
+
+        For the rare read that cannot be answered from a snapshot. Called
+        from the worker itself it runs inline, so a command may use it
+        without deadlocking.
+        """
+        if self.immediate or self.on_thread():
+            return fn()
+        done = threading.Event()
+        box: list = [None, None]
+
+        def wrapper():
+            try:
+                box[0] = fn()
+            except Exception as e:  # re-raised in the caller
+                box[1] = e
+            finally:
+                done.set()
+
+        self.submit(wrapper)
+        if not done.wait(timeout):
+            raise TimeoutError(f"dispatched call did not complete in {timeout}s")
+        if box[1] is not None:
+            raise box[1]
+        return box[0]
+
+    def settle(self, timeout: float = 10.0) -> bool:
+        """Wait until the queue has been empty across a full idle pass.
+
+        A command can queue more work — most of the player's commands emit
+        on the bus, and the edge submits what comes back — so draining
+        what was queued when this was called is not enough. Returns False
+        if the player was still busy when *timeout* ran out.
+        """
+        if self.immediate:
+            return True
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._queue.empty():
+                try:
+                    self.call(lambda: None,
+                              timeout=max(deadline - time.monotonic(), 0.01))
+                except TimeoutError:
+                    return False
+                if self._queue.empty():
+                    return True
+            threading.Event().wait(0.005)
+        return False
+
+    # --- epochs and delayed work -----------------------------------------
+    @property
+    def epoch(self) -> int:
+        """Token identifying the current generation of delayed work."""
+        return self._epoch
+
+    def bump_epoch(self) -> int:
+        """Supersede every delayed command scheduled so far.
+
+        Nothing is cancelled: a superseded command is dropped when its
+        timer fires, which is what makes "a new play request wins" a plain
+        comparison instead of cancellation bookkeeping.
+        """
+        self._epoch += 1
+        return self._epoch
+
+    def call_later(self, delay: float, fn: Callable[[], None],
+                   epoch: Optional[int] = None) -> threading.Timer:
+        """Submit *fn* after *delay* seconds, unless its epoch is stale.
+
+        The epoch is compared at execution time, not when the timer fires,
+        so a command already queued behind an epoch bump is still dropped.
+        """
+        if epoch is None:
+            epoch = self._epoch
+        handle: list = []
+        timer = threading.Timer(max(delay, 0.0),
+                                lambda: self._fire(fn, epoch, handle[0]))
+        handle.append(timer)
+        timer.daemon = True
+        with self._timers_lock:
+            self._timers.add(timer)
+        timer.start()
+        return timer
+
+    def _fire(self, fn: Callable[[], None], epoch: int,
+              timer: threading.Timer) -> None:
+        # forget this timer only — never rebuild the set, which another
+        # thread may be adding to at the same moment. The bookkeeping is
+        # also kept off the path to submit(): a delayed command must be
+        # queued (and then dropped on its epoch, or run) whatever happens
+        # to the housekeeping.
+        try:
+            with self._timers_lock:
+                self._timers.discard(timer)
+        except Exception as e:
+            LOG.exception(f"delayed command bookkeeping failed: {e}")
+        if self._stopped:
+            return
+
+        def guarded():
+            if epoch != self._epoch:
+                LOG.debug("dropping superseded delayed command")
+                return
+            fn()
+
+        self.submit(guarded)
+
+    @property
+    def pending(self) -> int:
+        """How many delayed commands are still armed for the current epoch."""
+        with self._timers_lock:
+            return len([t for t in self._timers if t.is_alive()])
+
+    # --- teardown ---------------------------------------------------------
+    def shutdown(self) -> None:
+        """Stop the worker, abandoning whatever is still queued.
+
+        Abandon rather than drain: shutdown is reached from stop paths, and
+        running the commands that a stop just made irrelevant is how a
+        shutting-down player used to resume playing. Delayed work is
+        superseded by the same epoch bump every stop does.
+        """
+        if self._stopped:
+            return
+        self._stopped = True
+        self.bump_epoch()
+        with self._timers_lock:
+            timers = list(self._timers)
+            self._timers.clear()
+        for timer in timers:
+            timer.cancel()
+        thread = self._thread
+        if thread is None:
+            return
+        try:
+            while True:
+                self._queue.get_nowait()
+        except queue.Empty:
+            pass
+        self._queue.put(None)
+        if thread is not threading.current_thread():
+            thread.join(timeout=2)
+        self._thread = None
+
+
+@dataclass(frozen=True)
+class PlayerSnapshot:
+    """Immutable view of the player, published after every command.
+
+    Query handlers answer from this instead of reading the live state from
+    another thread. It carries exactly what the status/track_info bus
+    responses have always carried.
+    """
+    player_state: Any = None
+    media_state: Any = None
+    loop_state: Any = None
+    shuffle: bool = False
+    playback_type: Any = None
+    media_type: Any = None
+    playlist_position: int = 0
+    playlist_size: int = 0
+    title: str = ""
+    artist: str = ""
+    image: str = ""
+    track_info: dict = field(default_factory=dict)
+    queue: Tuple[dict, ...] = ()
+
+    @property
+    def as_status_dict(self) -> dict:
+        """The 'ovos.common_play.status' response payload."""
+        return {
+            "playback_type": self.playback_type,
+            "media_type": self.media_type,
+            "player_state": self.player_state,
+            "loop_state": self.loop_state,
+            "media_state": self.media_state,
+            "shuffle": self.shuffle,
+            "playlist_position": self.playlist_position,
+            "playlist_size": self.playlist_size,
+            "title": self.title,
+            "artist": self.artist,
+            "image": self.image,
+        }
+
+    @classmethod
+    def of(cls, player) -> "PlayerSnapshot":
+        """Take a snapshot of *player*'s current state."""
+        now_playing = player.now_playing
+        playlist = player.playlist
+        return cls(
+            player_state=player.state,
+            media_state=player.media_state,
+            loop_state=player.loop_state,
+            shuffle=player.shuffle,
+            playback_type=player.playback_type,
+            media_type=now_playing.media_type,
+            playlist_position=playlist.position,
+            playlist_size=len(playlist),
+            title=now_playing.title,
+            artist=now_playing.artist,
+            image=now_playing.image,
+            track_info=dict(now_playing.as_dict),
+            queue=tuple(e.as_dict for e in playlist.entries),
+        )

--- a/test/end2end/conftest.py
+++ b/test/end2end/conftest.py
@@ -1,0 +1,42 @@
+"""These tests run the real worker thread, so they wait for it.
+
+A bus message now becomes a command the player runs on its dispatcher, a
+moment after the emit returns. The harness yields 50 ms after each emit,
+which is enough on a fast machine and not on a loaded one — a coverage
+run turned assertions that read the player straight after an emit into
+race losses. Rather than sprinkle waits through the test files, every
+harness bus emit is followed here by one call to ``Dispatcher.settle()``,
+which returns as soon as the player is idle. No assertion changes, and no
+fixed sleeps are added.
+
+An emit made by the worker itself (a command emitting on the bus) is left
+alone: it is already inside the work settle() would be waiting for.
+"""
+import pytest
+from ovoscope.media import OCPPlayerHarness
+
+from ovos_media.player.dispatcher import Dispatcher
+
+_original_enter = OCPPlayerHarness.__enter__
+
+
+def _settling_enter(self):
+    harness = _original_enter(self)
+    player = getattr(harness, "player", None)
+    dispatcher = getattr(player, "dispatcher", None)
+    if isinstance(dispatcher, Dispatcher):
+        emit = harness.bus.emit
+
+        def settling_emit(message):
+            result = emit(message)
+            if not dispatcher.in_command():
+                dispatcher.settle(timeout=10)
+            return result
+
+        harness.bus.emit = settling_emit
+    return harness
+
+
+@pytest.fixture(autouse=True)
+def settle_after_every_emit(monkeypatch):
+    monkeypatch.setattr(OCPPlayerHarness, "__enter__", _settling_enter)

--- a/test/unittests/conftest.py
+++ b/test/unittests/conftest.py
@@ -1,0 +1,26 @@
+"""Unit tests drive the player directly, so their dispatcher runs inline.
+
+These tests call player methods from the test thread and assert the result
+on the next line. A worker thread would turn every one of them into a wait
+loop without testing anything more: the ordering they exercise is the
+order they call things in. The dispatcher therefore runs in immediate mode
+here, and the ordering guarantee itself is tested against a real worker in
+test_dispatcher.py and test_transport_ordering.py, which ask for one
+explicitly with ``Dispatcher(immediate=False)``.
+
+The end-to-end suite runs the real threaded dispatcher, unpatched.
+"""
+import pytest
+
+from ovos_media.player.dispatcher import Dispatcher
+
+_original_init = Dispatcher.__init__
+
+
+@pytest.fixture(autouse=True)
+def immediate_dispatchers(monkeypatch):
+    def patched(self, name="ocp-dispatcher", immediate=None):
+        _original_init(self, name=name,
+                       immediate=True if immediate is None else immediate)
+
+    monkeypatch.setattr(Dispatcher, "__init__", patched)

--- a/test/unittests/test_dispatcher.py
+++ b/test/unittests/test_dispatcher.py
@@ -1,0 +1,292 @@
+"""Tests for the player's execution model: one worker, FIFO order, epochs."""
+import threading
+import time
+import unittest
+
+from ovos_media.player.dispatcher import Dispatcher, PlayerSnapshot
+
+
+def _real() -> Dispatcher:
+    """A dispatcher with a real worker thread (see conftest.py)."""
+    return Dispatcher(immediate=False)
+
+
+class TestOrdering(unittest.TestCase):
+
+    def test_commands_run_in_submission_order(self):
+        d = _real()
+        seen = []
+        done = threading.Event()
+        for i in range(50):
+            d.submit(lambda i=i: seen.append(i))
+        d.submit(done.set)
+        self.assertTrue(done.wait(5))
+        self.assertEqual(seen, list(range(50)))
+        d.shutdown()
+
+    def test_commands_never_overlap(self):
+        """A second command cannot start while the first is still running."""
+        d = _real()
+        overlaps = []
+        running = []
+        done = threading.Event()
+
+        def slow(tag):
+            if running:
+                overlaps.append(tag)
+            running.append(tag)
+            time.sleep(0.02)
+            running.pop()
+
+        for tag in range(5):
+            d.submit(lambda tag=tag: slow(tag))
+        d.submit(done.set)
+        self.assertTrue(done.wait(5))
+        self.assertEqual(overlaps, [])
+        d.shutdown()
+
+    def test_all_commands_share_one_thread(self):
+        d = _real()
+        threads = set()
+        done = threading.Event()
+        for _ in range(5):
+            d.submit(lambda: threads.add(threading.current_thread().name))
+        d.submit(done.set)
+        self.assertTrue(done.wait(5))
+        self.assertEqual(len(threads), 1)
+        self.assertNotIn(threading.current_thread().name, threads)
+        d.shutdown()
+
+    def test_a_failing_command_does_not_stop_the_worker(self):
+        d = _real()
+        seen = []
+        done = threading.Event()
+        d.submit(lambda: 1 / 0)
+        d.submit(lambda: seen.append("after"))
+        d.submit(done.set)
+        self.assertTrue(done.wait(5))
+        self.assertEqual(seen, ["after"])
+        d.shutdown()
+
+
+class TestOnThread(unittest.TestCase):
+
+    def test_on_thread_is_false_outside_and_true_inside(self):
+        d = _real()
+        inside = []
+        done = threading.Event()
+        self.assertFalse(d.on_thread())
+        d.submit(lambda: inside.append(d.on_thread()))
+        d.submit(done.set)
+        self.assertTrue(done.wait(5))
+        self.assertEqual(inside, [True])
+        d.shutdown()
+
+    def test_immediate_dispatcher_is_always_on_thread(self):
+        d = Dispatcher(immediate=True)
+        self.assertTrue(d.on_thread())
+
+
+class TestCall(unittest.TestCase):
+
+    def test_call_returns_the_result_from_the_worker(self):
+        d = _real()
+        thread_name = d.call(lambda: threading.current_thread().name)
+        self.assertNotEqual(thread_name, threading.current_thread().name)
+        self.assertEqual(d.call(lambda: 6 * 7), 42)
+        d.shutdown()
+
+    def test_call_reraises_in_the_caller(self):
+        d = _real()
+        with self.assertRaises(ValueError):
+            d.call(lambda: (_ for _ in ()).throw(ValueError("boom")))
+        d.shutdown()
+
+    def test_call_from_the_worker_runs_inline(self):
+        """A command may use call() without waiting for itself."""
+        d = _real()
+        box = []
+        done = threading.Event()
+        d.submit(lambda: box.append(d.call(lambda: "inline")))
+        d.submit(done.set)
+        self.assertTrue(done.wait(5))
+        self.assertEqual(box, ["inline"])
+        d.shutdown()
+
+    def test_call_times_out_behind_a_stuck_command(self):
+        d = _real()
+        block = threading.Event()
+        d.submit(block.wait)
+        with self.assertRaises(TimeoutError):
+            d.call(lambda: None, timeout=0.1)
+        block.set()
+        d.shutdown()
+
+
+class TestEpochs(unittest.TestCase):
+
+    def test_call_later_runs_when_its_epoch_still_stands(self):
+        d = _real()
+        ran = threading.Event()
+        d.call_later(0.01, ran.set, d.epoch)
+        self.assertTrue(ran.wait(5))
+        d.shutdown()
+
+    def test_call_later_is_dropped_after_a_bump(self):
+        d = _real()
+        ran = []
+        d.call_later(0.05, lambda: ran.append(1), d.epoch)
+        d.bump_epoch()
+        time.sleep(0.2)
+        self.assertEqual(ran, [])
+        d.shutdown()
+
+    def test_a_bump_drops_only_earlier_work(self):
+        d = _real()
+        ran = []
+        d.call_later(0.05, lambda: ran.append("old"), d.epoch)
+        d.bump_epoch()
+        later = threading.Event()
+        d.call_later(0.05, lambda: (ran.append("new"), later.set()), d.epoch)
+        self.assertTrue(later.wait(5))
+        self.assertEqual(ran, ["new"])
+        d.shutdown()
+
+    def test_bump_returns_a_new_token_every_time(self):
+        d = _real()
+        tokens = [d.epoch] + [d.bump_epoch() for _ in range(3)]
+        self.assertEqual(len(set(tokens)), 4)
+        d.shutdown()
+
+    def test_pending_counts_armed_delayed_work(self):
+        d = _real()
+        self.assertEqual(d.pending, 0)
+        d.call_later(0.05, lambda: None, d.epoch)
+        self.assertEqual(d.pending, 1)
+        time.sleep(0.2)
+        self.assertEqual(d.pending, 0)
+        d.shutdown()
+
+
+class TestDelayedWorkUnderLoad(unittest.TestCase):
+    """Delayed work is armed from whichever thread schedules it and
+    disarmed from the timer threads themselves, so the bookkeeping is
+    touched concurrently by design. It must never raise there: an
+    exception on that path used to happen before the command was queued,
+    so the command was lost."""
+
+    def test_scheduling_while_timers_fire_loses_nothing(self):
+        d = _real()
+        ran = []
+        errors = []
+
+        def hammer():
+            for _ in range(300):
+                try:
+                    d.call_later(0.001, lambda: ran.append(1), d.epoch)
+                except Exception as e:  # pragma: no cover - the defect
+                    errors.append(e)
+
+        threads = [threading.Thread(target=hammer) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and len(ran) < 1200:
+            time.sleep(0.02)
+        d.call(lambda: None, timeout=10)
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(ran), 1200,
+                         "delayed commands were dropped under concurrent "
+                         "scheduling")
+        self.assertEqual(d.pending, 0)
+        d.shutdown()
+
+
+class TestShutdown(unittest.TestCase):
+
+    def test_shutdown_abandons_queued_commands(self):
+        d = _real()
+        block = threading.Event()
+        ran = []
+        started = threading.Event()
+        d.submit(lambda: (started.set(), block.wait(2)))
+        d.submit(lambda: ran.append("queued"))
+        self.assertTrue(started.wait(5))
+        block.set()
+        d.shutdown()
+        self.assertEqual(ran, [])
+
+    def test_submitting_after_shutdown_is_a_no_op(self):
+        d = _real()
+        d.shutdown()
+        ran = []
+        d.submit(lambda: ran.append(1))
+        time.sleep(0.1)
+        self.assertEqual(ran, [])
+
+    def test_shutdown_drops_delayed_work(self):
+        d = _real()
+        ran = []
+        d.call_later(0.05, lambda: ran.append(1), d.epoch)
+        d.shutdown()
+        time.sleep(0.2)
+        self.assertEqual(ran, [])
+
+    def test_shutdown_is_idempotent(self):
+        d = _real()
+        d.submit(lambda: None)
+        d.shutdown()
+        d.shutdown()
+
+    def test_post_hook_runs_after_every_command(self):
+        d = _real()
+        hooks = []
+        d.post_hook = lambda: hooks.append(len(hooks))
+        done = threading.Event()
+        d.submit(lambda: None)
+        d.submit(lambda: 1 / 0)  # a failure still publishes the new state
+        d.submit(done.set)
+        self.assertTrue(done.wait(5))
+        self.assertEqual(len(hooks), 3)
+        d.shutdown()
+
+
+class TestImmediateMode(unittest.TestCase):
+
+    def test_submit_runs_inline_and_in_order(self):
+        d = Dispatcher(immediate=True)
+        seen = []
+        d.submit(lambda: seen.append(1))
+        self.assertEqual(seen, [1])
+        d.submit(lambda: seen.append(2))
+        self.assertEqual(seen, [1, 2])
+
+    def test_call_runs_inline(self):
+        d = Dispatcher(immediate=True)
+        self.assertEqual(d.call(lambda: "x"),  "x")
+
+
+class TestSnapshot(unittest.TestCase):
+
+    def test_status_dict_carries_the_status_payload(self):
+        snap = PlayerSnapshot(player_state="PLAYING", shuffle=True,
+                              title="T", artist="A", playlist_size=3)
+        data = snap.as_status_dict
+        self.assertEqual(data["player_state"], "PLAYING")
+        self.assertTrue(data["shuffle"])
+        self.assertEqual(data["title"], "T")
+        self.assertEqual(data["playlist_size"], 3)
+        self.assertNotIn("track_info", data)
+
+    def test_snapshot_is_immutable(self):
+        snap = PlayerSnapshot()
+        with self.assertRaises(Exception):
+            snap.shuffle = True
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_end_of_track_handling.py
+++ b/test/unittests/test_end_of_track_handling.py
@@ -112,6 +112,12 @@ class _StubBackend:
 # ---------------------------------------------------------------------------
 
 class TestSingleWriterEndOfMedia(unittest.TestCase):
+    """The duplicate-END_OF_MEDIA case moved to test_transport_ordering.py:
+    it asserted that a lock made two threads entering the handler at once
+    advance the queue once. Two threads can no longer enter it — the bus
+    edge submits both events to the one worker — so the invariant is now
+    asserted as ordering, not as mutual exclusion."""
+
 
     def test_raced_end_of_media_handlers_still_advance(self):
         """END_OF_MEDIA delivered while other media.state subscribers run
@@ -183,40 +189,6 @@ class TestSingleWriterEndOfMedia(unittest.TestCase):
                          "a late media.state subscriber wiped the track the "
                          "player had just advanced to")
         player.shutdown()
-
-    def test_two_concurrent_end_of_media_advance_exactly_once(self):
-        """Two END_OF_MEDIA events racing must advance the queue ONCE.
-
-        Pre-fix this double-advanced in 263/300 runs: both threads passed the
-        unsynchronised `state == self.media_state` compare-and-set.
-        """
-        for attempt in range(40):
-            bus = FakeBus()
-            player = _make_player(bus)
-            tracks = [_track(f"http://example.com/{n}.mp3", n)
-                      for n in ("a", "b", "c")]
-            _load(player, tracks)
-            player.set_player_state(PlayerState.PLAYING)
-            player.media_state = MediaState.BUFFERED_MEDIA
-
-            with patch.object(player, "play"):
-                start = threading.Barrier(2)
-
-                def fire():
-                    start.wait(timeout=5)
-                    bus.emit(Message("ovos.common_play.media.state",
-                                     {"state": MediaState.END_OF_MEDIA}))
-
-                threads = [threading.Thread(target=fire) for _ in range(2)]
-                for t in threads:
-                    t.start()
-                for t in threads:
-                    t.join(timeout=5)
-
-            self.assertEqual(player.now_playing.uri, tracks[1].uri,
-                             f"attempt {attempt}: two concurrent END_OF_MEDIA "
-                             f"events advanced past track b")
-            player.shutdown()
 
     def test_now_playing_no_longer_subscribes_to_media_state(self):
         """NowPlaying must not be a second subscriber to the topic."""
@@ -422,12 +394,10 @@ class TestLoadOkPlayFailQueue(unittest.TestCase):
             # initial STOPPED and a test polling for "reached STOPPED"
             # would trivially pass without the retry chain ever running.
             player.set_player_state(PlayerState.PLAYING)
-            with player._state_lock:
-                player.media_state = MediaState.LOADING_MEDIA
+            player.media_state = MediaState.LOADING_MEDIA
             player.bus.emit(Message("ovos.common_play.media.state",
                                     {"state": MediaState.LOADED_MEDIA}))
-            with player._state_lock:
-                player.media_state = MediaState.BUFFERED_MEDIA
+            player.media_state = MediaState.BUFFERED_MEDIA
             player.bus.emit(Message("ovos.common_play.media.state",
                                     {"state": MediaState.INVALID_MEDIA}))
 

--- a/test/unittests/test_spoken_failure_dialogs.py
+++ b/test/unittests/test_spoken_failure_dialogs.py
@@ -127,8 +127,7 @@ class TestTrackFailedDialog(unittest.TestCase):
         self.assertEqual(p.media.speak_dialog.call_count, 1)
         # a bare LOADED_MEDIA/BUFFERED_MEDIA transition (no PLAYING_* track
         # state) must be a no-op for the guard
-        with p._state_lock:
-            p.media_state = MediaState.LOADED_MEDIA
+        p.media_state = MediaState.LOADED_MEDIA
         p.handle_invalid_media()
         self.assertEqual(p.media.speak_dialog.call_count, 1,
                         "LOADED_MEDIA alone must not reset the track.failed "
@@ -171,7 +170,6 @@ class TestTrackFailedDialog(unittest.TestCase):
         # stub out the collaborators reset() also touches that this fixture
         # doesn't construct, so only the bookkeeping under test is real.
         p.now_playing.reset = MagicMock()
-        p._invalid_timer = None
         p.playlist.clear = MagicMock()
         p.set_media_state = MagicMock()
         p.playback_type = PlaybackType.UNDEFINED

--- a/test/unittests/test_stop_and_retry_scoping.py
+++ b/test/unittests/test_stop_and_retry_scoping.py
@@ -7,12 +7,13 @@ BaseMediaService.stop() must invoke the player-wide ``on_stop`` callback
     interface's stop() while only audio is playing must not suppress the
     next natural audio END_OF_MEDIA advance.
 
-``_mark_stop_requested`` must cancel the pending invalid-stream retry timer
-    (``_invalid_timer``), and so must ``OCPMediaPlayer.stop()`` (not only
-    reset()/shutdown()). A stop arriving during the 3s post-INVALID_MEDIA
-    retry window must not leave the timer armed to fire play_next() after
-    the stop has already settled the player into STOPPED, which would
-    spontaneously resume playback.
+``_mark_stop_requested`` must supersede the pending invalid-stream retry,
+    and so must ``OCPMediaPlayer.stop()`` (not only reset()/shutdown()). A
+    stop arriving during the 3s post-INVALID_MEDIA retry window must not
+    leave the retry able to run play_next() after the stop has already
+    settled the player into STOPPED, which would spontaneously resume
+    playback. Supersession is by epoch: the retry still comes up, sees a
+    bumped epoch and is dropped.
 
 Both tests drive the scenario through the real objects (FakeBus + a stub
 backend), mirroring test_end_of_track_handling.py.
@@ -44,14 +45,14 @@ def _load(player, entries):
     player.set_now_playing(player.playlist[0])
 
 
-def _wait_for_timer(player, deadline=3.0):
-    """Poll until the invalid-stream retry timer is armed (bounded).
+def _wait_for_retry(player, deadline=3.0):
+    """Poll until the delayed invalid-stream retry is armed (bounded).
 
     Handler dispatch runs on the bus executor pool; a fixed sleep races it
     under full-suite load, so wait on the observable state instead."""
     end = time.monotonic() + deadline
     while time.monotonic() < end:
-        if player._invalid_timer is not None:
+        if player.dispatcher.pending:
             return
         time.sleep(0.01)
 
@@ -214,9 +215,10 @@ class TestStopCancelsInvalidRetry(unittest.TestCase):
 
         player.play()
         # let INVALID_MEDIA propagate and on_invalid_stream() arm the timer
-        _wait_for_timer(player)
-        self.assertIsNotNone(player._invalid_timer,
-                             "invalid-stream retry timer was not armed")
+        _wait_for_retry(player)
+        self.assertTrue(player.dispatcher.pending,
+                        "invalid-stream retry was not armed")
+        armed_epoch = player.dispatcher.epoch
 
         # simulate the backend having something to actually stop, so
         # BaseMediaService._perform_stop signals on_stop()
@@ -224,22 +226,16 @@ class TestStopCancelsInvalidRetry(unittest.TestCase):
         player.audio_service.play_start_time = time.monotonic() - 5
         player.audio_service.stop()
 
-        self.assertIsNone(player._invalid_timer,
-                          "stop() did not cancel the pending invalid-stream "
-                          "retry timer")
+        self.assertNotEqual(player.dispatcher.epoch, armed_epoch,
+                            "stop() did not supersede the pending "
+                            "invalid-stream retry")
 
         # wait past the original retry window. Note: a direct
         # BaseMediaService.stop() call does not by itself set player.state
         # (only OCPMediaPlayer.stop() does that) — the observable defect
-        # here is the deferred play_next() firing and silently advancing
+        # here is the deferred play_next() running and silently advancing
         # the queue after the stop had already been acted on.
-        self.assertIsNone(player._invalid_timer,
-                          "invalid-stream retry timer reappeared before the "
-                          "wait")
         time.sleep(0.3)
-        self.assertIsNone(player._invalid_timer,
-                          "a new invalid-stream retry timer was armed after "
-                          "the stop, meaning the old one fired")
         self.assertNotEqual(player.now_playing.uri, b.uri,
                             "the deferred play_next() fired after stop and "
                             "loaded the next track anyway")
@@ -252,17 +248,18 @@ class TestStopCancelsInvalidRetry(unittest.TestCase):
         bus, player, backend, a, b = self._player_with_invalid_backend()
 
         player.play()
-        _wait_for_timer(player)
-        self.assertIsNotNone(player._invalid_timer,
-                             "invalid-stream retry timer was not armed")
+        _wait_for_retry(player)
+        self.assertTrue(player.dispatcher.pending,
+                        "invalid-stream retry was not armed")
+        armed_epoch = player.dispatcher.epoch
 
         backend._playing = True
         player.audio_service.play_start_time = time.monotonic() - 5
         player.stop()
 
-        self.assertIsNone(player._invalid_timer,
-                          "OCPMediaPlayer.stop() did not cancel the pending "
-                          "invalid-stream retry timer")
+        self.assertNotEqual(player.dispatcher.epoch, armed_epoch,
+                            "OCPMediaPlayer.stop() did not supersede the "
+                            "pending invalid-stream retry")
 
         time.sleep(0.3)
 
@@ -284,8 +281,8 @@ class TestStopCancelsInvalidRetry(unittest.TestCase):
 class TestPlayCancelsStaleInvalidRetry(unittest.TestCase):
 
     def _arm_stale_timer(self, bus, player):
-        """Play an always-invalid track to arm player._invalid_timer, then
-        return once it is confirmed armed."""
+        """Play an always-invalid track to arm the delayed retry, then
+        return the epoch it was armed under once it is confirmed armed."""
         backend = _InvalidBackend(bus)
         player.invalid_stream_delay = 0.15
         player.audio_service.services = [backend]
@@ -294,9 +291,10 @@ class TestPlayCancelsStaleInvalidRetry(unittest.TestCase):
         _load(player, [bad])
 
         player.play()
-        _wait_for_timer(player)
-        self.assertIsNotNone(player._invalid_timer,
-                             "invalid-stream retry timer was not armed")
+        _wait_for_retry(player)
+        self.assertTrue(player.dispatcher.pending,
+                        "invalid-stream retry was not armed")
+        return player.dispatcher.epoch
 
     def test_new_play_cancels_stale_timer_before_it_skips_the_new_track(self):
         """A new play() of a valid, multi-track queue arriving inside the
@@ -306,7 +304,7 @@ class TestPlayCancelsStaleInvalidRetry(unittest.TestCase):
         """
         bus = FakeBus()
         player = _make_player(bus)
-        self._arm_stale_timer(bus, player)
+        armed_epoch = self._arm_stale_timer(bus, player)
 
         # a genuinely new play request for an unrelated, valid, multi-track
         # queue arrives while the stale timer from the earlier bad track is
@@ -320,9 +318,10 @@ class TestPlayCancelsStaleInvalidRetry(unittest.TestCase):
         player.play()
         player.set_player_state(PlayerState.PLAYING)
 
-        self.assertIsNone(player._invalid_timer,
-                          "play() did not cancel the stale invalid-stream "
-                          "retry timer left over from the earlier track")
+        self.assertNotEqual(player.dispatcher.epoch, armed_epoch,
+                            "play() did not supersede the stale "
+                            "invalid-stream retry left over from the "
+                            "earlier track")
 
         # wait past the original retry window
         time.sleep(0.3)
@@ -349,7 +348,7 @@ class TestPlayCancelsStaleInvalidRetry(unittest.TestCase):
         """
         bus = FakeBus()
         player = _make_player(bus)
-        self._arm_stale_timer(bus, player)
+        armed_epoch = self._arm_stale_timer(bus, player)
 
         good_backend = _StubBackend(bus, name="good_stub_solo")
         player.audio_service.services = [good_backend]
@@ -359,9 +358,10 @@ class TestPlayCancelsStaleInvalidRetry(unittest.TestCase):
         player.play()
         player.set_player_state(PlayerState.PLAYING)
 
-        self.assertIsNone(player._invalid_timer,
-                          "play() did not cancel the stale invalid-stream "
-                          "retry timer left over from the earlier track")
+        self.assertNotEqual(player.dispatcher.epoch, armed_epoch,
+                            "play() did not supersede the stale "
+                            "invalid-stream retry left over from the "
+                            "earlier track")
 
         time.sleep(0.3)
 

--- a/test/unittests/test_transport_ordering.py
+++ b/test/unittests/test_transport_ordering.py
@@ -1,0 +1,334 @@
+"""Transport-command ordering, driven through the real worker thread.
+
+These cases used to be races: two END_OF_MEDIA events landing at once, a
+stop landing while an END_OF_MEDIA was in flight, an invalid-stream retry
+firing against a track it was not scheduled for. Each was held together by
+a lock or by cancellation bookkeeping, and each test asserted that
+mechanism. With one worker draining commands in arrival order the same
+questions have deterministic answers, so what is asserted here is the
+outcome: submit A then B, and the player ends where the order says it
+should.
+"""
+import threading
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import MediaEntry, MediaState, PlaybackType, PlayerState
+
+from ovos_media.bus.api import OCPBusApi
+from ovos_media.player import OCPMediaPlayer
+from ovos_media.player.dispatcher import Dispatcher
+
+
+def _track(uri, title):
+    return MediaEntry(uri=uri, title=title, playback=PlaybackType.AUDIO)
+
+
+class _StubBackend:
+    """Backend that loads anything and reports nothing on its own."""
+
+    def __init__(self, bus, name="stub"):
+        self.bus = bus
+        self.name = name
+        self.aliases = [name]
+        self.loaded = []
+        self.stopped = 0
+        self._playing = False
+
+    def supported_uris(self):
+        return ["http", "https", "file"]
+
+    def set_track_start_callback(self, cb):
+        pass
+
+    def load_track(self, uri):
+        self.loaded.append(uri)
+        self._playing = True
+
+    def play(self, repeat=False):
+        pass
+
+    def stop(self):
+        self.stopped += 1
+        was = self._playing
+        self._playing = False
+        return was
+
+    def ocp_stop(self):
+        # what an OPM backend emits from stop(): indistinguishable from a
+        # track ending naturally, except for the order it arrives in
+        self.bus.emit(Message("ovos.common_play.media.state",
+                              {"state": MediaState.END_OF_MEDIA}))
+
+    def shutdown(self):
+        pass
+
+
+class _OrderingTest(unittest.TestCase):
+    """Base fixture: a player whose commands run on a real worker thread."""
+
+    config = {}
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.player = OCPMediaPlayer(self.bus, config=dict(self.config))
+        self.player.now_playing.extract_stream = lambda: None
+        # replace the inline test dispatcher with a real one, then rebuild
+        # the bus edge so its listeners submit to it
+        self.player.dispatcher.shutdown()
+        self.player.dispatcher = Dispatcher(immediate=False)
+        self.player.dispatcher.post_hook = self.player.publish_snapshot
+        self.player.bus_api.shutdown()
+        self.player.bus_api = OCPBusApi(self.bus, player=self.player)
+
+        self.backend = _StubBackend(self.bus)
+        self.player.audio_service.services = [self.backend]
+        self.player.audio_service.current = self.backend
+        self.player.audio_service.play_start_time = 0  # past the stop guard
+
+        self.a = _track("http://example.com/a.mp3", "A")
+        self.b = _track("http://example.com/b.mp3", "B")
+        self.c = _track("http://example.com/c.mp3", "C")
+
+    def tearDown(self):
+        self.player.shutdown()
+
+    def load(self, entries):
+        self.player.playlist.clear()
+        for e in entries:
+            self.player.playlist.add_entry(e)
+        self.drain(lambda: self.player.set_now_playing(self.player.playlist[0]))
+
+    def drain(self, fn=None):
+        """Run *fn* on the worker, then let the player settle.
+
+        A command can queue more work by emitting on the bus, so waiting
+        for what was queued when drain() was called is not enough: keep
+        going until a full pass finds nothing left to run.
+        """
+        result = self.player.dispatcher.call(fn or (lambda: None), timeout=10)
+        self.assertTrue(self.player.dispatcher.settle(timeout=10),
+                        "the player never went idle")
+        return result
+
+    def end_of_media(self):
+        self.bus.emit(Message("ovos.common_play.media.state",
+                              {"state": MediaState.END_OF_MEDIA}))
+
+
+class TestDoubleEndOfMedia(_OrderingTest):
+    """Was: two END_OF_MEDIA events racing the compare-and-set, one
+    reading media_state before the other wrote it, so a single end of a
+    single track was acted on twice. The lock made the second one lose the
+    compare; the queue does, because it runs after the first command
+    finished and sees the state that command wrote."""
+
+    config = {"autoplay": False}
+
+    def test_a_duplicate_end_of_media_is_acted_on_once(self):
+        self.load([self.a, self.b, self.c])
+        self.drain(self.player.play)
+
+        ends = []
+        original = self.player.handle_playback_ended
+        self.player.handle_playback_ended = \
+            lambda *a, **kw: (ends.append(1), original(*a, **kw))[1]
+
+        self.end_of_media()
+        self.end_of_media()
+        self.drain()
+
+        self.assertEqual(len(ends), 1,
+                         "one track ending was acted on twice")
+
+
+class TestSequentialEndOfMedia(_OrderingTest):
+    """Each genuine end of a track advances the queue by exactly one."""
+
+    def test_a_third_advance_needs_a_state_change_first(self):
+        self.load([self.a, self.b, self.c])
+        self.drain(self.player.play)
+
+        self.end_of_media()
+        self.drain()
+        self.assertEqual(self.player.now_playing.uri, self.b.uri)
+        # play() of the new track resets media_state, so the NEXT genuine
+        # end of media is a state change again and does advance
+        self.end_of_media()
+        self.drain()
+        self.assertEqual(self.player.now_playing.uri, self.c.uri)
+
+
+class TestStopVersusEndOfMedia(_OrderingTest):
+    """Was: the on_stop callback, which existed only to make the stop flag
+    win against the END_OF_MEDIA its own ocp_stop() emits. Now the stop
+    command runs to completion first, so that END_OF_MEDIA is simply a
+    later command."""
+
+    def test_stop_does_not_advance_the_queue(self):
+        self.load([self.a, self.b])
+        self.drain(self.player.play)
+
+        self.bus.emit(Message("ovos.common_play.stop"))
+        self.drain()
+
+        self.assertEqual(self.player.state, PlayerState.STOPPED)
+        self.assertNotEqual(self.player.now_playing.uri, self.b.uri,
+                            "an explicit stop advanced the queue")
+
+    def test_an_end_of_media_queued_after_a_stop_is_ignored(self):
+        self.load([self.a, self.b])
+        self.drain(self.player.play)
+
+        self.bus.emit(Message("ovos.common_play.stop"))
+        self.end_of_media()
+        self.drain()
+
+        self.assertEqual(self.player.state, PlayerState.STOPPED)
+        self.assertNotEqual(self.player.now_playing.uri, self.b.uri)
+
+    def test_an_end_of_media_queued_before_a_play_still_advances(self):
+        """The stop flag is per play attempt: a play command clears it, so
+        a track ending after it advances normally."""
+        self.load([self.a, self.b])
+        self.drain(self.player.play)
+        self.bus.emit(Message("ovos.common_play.stop"))
+        self.drain()
+
+        self.load([self.a, self.b])
+        self.drain(self.player.play)
+        self.end_of_media()
+        self.drain()
+
+        self.assertEqual(self.player.now_playing.uri, self.b.uri)
+
+
+class TestSupersededInvalidRetry(_OrderingTest):
+    """Was: cancelling _invalid_timer from four places and asserting the
+    handle was None afterwards. The retry is now tagged with the epoch it
+    was scheduled under and dropped when a newer command has bumped it."""
+
+    def test_a_retry_from_an_earlier_track_never_skips_the_new_one(self):
+        self.player.invalid_stream_delay = 0.05
+        self.load([self.a, self.b])
+        self.drain(self.player.play)
+        self.drain(self.player.on_invalid_stream)  # arms the delayed retry
+
+        # a new play request arrives inside the retry window
+        self.load([self.c])
+        self.drain(self.player.play)
+
+        threading.Event().wait(0.3)
+        self.drain()
+        self.assertEqual(self.player.now_playing.uri, self.c.uri,
+                         "the superseded retry skipped the new track")
+
+    def test_a_retry_survives_when_nothing_supersedes_it(self):
+        self.player.invalid_stream_delay = 0.05
+        self.load([self.a, self.b])
+        self.drain(self.player.play)
+        self.drain(self.player.on_invalid_stream)
+
+        threading.Event().wait(0.3)
+        self.drain()
+        self.assertEqual(self.player.now_playing.uri, self.b.uri,
+                         "the invalid-stream retry never advanced the queue")
+
+    def test_a_stop_supersedes_the_retry(self):
+        self.player.invalid_stream_delay = 0.05
+        self.load([self.a, self.b])
+        self.drain(self.player.play)
+        self.drain(self.player.on_invalid_stream)
+
+        self.bus.emit(Message("ovos.common_play.stop"))
+        self.drain()
+        threading.Event().wait(0.3)
+        self.drain()
+
+        self.assertEqual(self.player.state, PlayerState.STOPPED,
+                         "the superseded retry resumed playback after a stop")
+
+
+class TestStopThenPlay(_OrderingTest):
+    """A play arriving while a stop is still executing must win.
+
+    The stop reaches the backend, whose stop path calls back into the
+    player. Recording that callback as a new command put the stop flag
+    back *after* the play had already cleared it, so the play's own
+    END_OF_MEDIA was then read as a stop and wiped the new track. Nothing
+    is drained between the two commands here: that gap is the defect.
+    """
+
+    def test_play_arriving_during_a_stop_wins(self):
+        for attempt in range(20):
+            self.load([self.a, self.b])
+            self.drain(self.player.play)
+
+            self.bus.emit(Message("ovos.common_play.stop"))
+            self.bus.emit(Message("ovos.common_play.play",
+                                  {"media": self.b.as_dict}))
+            self.drain()
+
+            self.assertEqual(self.player.state, PlayerState.PLAYING,
+                             f"attempt {attempt}: the stop settled over the "
+                             f"play that replaced it")
+            self.assertEqual(self.player.now_playing.uri, self.b.uri,
+                             f"attempt {attempt}: the requested track was "
+                             f"wiped after the stop")
+            self.assertFalse(self.player._stop_requested,
+                             f"attempt {attempt}: the stop flag outlived the "
+                             f"stop it belonged to")
+
+    def test_a_skill_stopping_a_backend_directly_is_still_recorded(self):
+        """The other caller of the same callback: a stop from a foreign
+        thread, which the player has no other way to learn about."""
+        self.load([self.a, self.b])
+        self.drain(self.player.play)
+        self.backend._playing = True
+
+        self.player.audio_service.stop()  # as a skill would
+        self.drain()
+
+        self.assertTrue(self.player._stop_requested,
+                        "a backend stopped from outside the player was read "
+                        "as a track ending")
+        self.assertNotEqual(self.player.now_playing.uri, self.b.uri,
+                            "a skill-initiated stop advanced the queue")
+
+
+class TestQueriesDoNotQueue(_OrderingTest):
+    """Queries answer from the published snapshot, so a status request
+    never waits behind a command (and never blocks the worker)."""
+
+    def test_status_is_answered_while_a_command_is_in_flight(self):
+        self.load([self.a, self.b])
+        self.drain(self.player.play)
+
+        replies = []
+        self.bus.on("ovos.common_play.status.response",
+                    lambda m: replies.append(m.data))
+
+        block = threading.Event()
+        self.player.dispatcher.submit(lambda: block.wait(5))
+        self.bus.emit(Message("ovos.common_play.status"))
+
+        self.assertEqual(len(replies), 1,
+                         "the status query waited for the worker")
+        self.assertEqual(replies[0]["player_state"], PlayerState.PLAYING)
+        block.set()
+        self.drain()
+
+    def test_the_snapshot_follows_the_last_command(self):
+        self.load([self.a, self.b])
+        self.drain(self.player.play)
+        self.assertEqual(self.player.snapshot.player_state, PlayerState.PLAYING)
+        self.assertEqual(self.player.snapshot.title, self.a.title)
+
+        self.bus.emit(Message("ovos.common_play.stop"))
+        self.drain()
+        self.assertEqual(self.player.snapshot.player_state, PlayerState.STOPPED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

The player used to be written to from whatever thread happened to deliver the event: the bus client's dispatch pool, the MPRIS exporter's thread, and a `threading.Timer` for the retry after a bad stream. Every safety property it had was bolted on afterwards — a reentrant lock around the state compare-and-set, a callback threaded through the backend services so a stop could be flagged before the `END_OF_MEDIA` it causes, and cancel-the-timer bookkeeping in four separate places. This replaces that with one worker thread draining a FIFO queue of commands. The state machine now has a single writer and needs none of it.

`ovos_media/player/dispatcher.py` holds the whole model: `submit` for fire-and-forget commands, `call` for the rare blocking round trip (inline when the caller is already the worker, so a command can use it), `call_later` for delayed work tagged with an epoch that is compared at execution time, and `bump_epoch` to supersede it. Shutdown abandons what is still queued rather than draining it — shutdown is reached from stop paths, and running the commands a stop just made irrelevant is exactly how a shutting-down player used to resume playing. `PlayerSnapshot`, an immutable view republished after every command, is what queries answer from: status, track info, backend listing and the SEI list are served at the bus edge and never wait behind a playback command. Live track position and length still go straight to the backend plugin, the one sanctioned read from another thread, because only the plugin knows them and a queued answer would be stale by the time it was emitted.

The bus edge marks each registration as mutating or not and submits accordingly; the MPRIS thread submits at its boundary, with reads (Metadata, PlaybackStatus, Position, CanGoNext) still direct. `handle_record_end` keeps its 8-second wait for a `speak` on the calling thread and submits only the resume it decides on, so nothing blocking ever runs on the worker. Gone with the serialization: `_state_lock`, `_invalid_timer` and its cancel bookkeeping, and the compare-and-set in `_mark_stop_requested`, which is now a plain flag write. `liked_songs_lock` stays — it is shared with the catalog skill and unrelated to command ordering.

Two defects found in review are fixed here. A play arriving while a stop was still executing used to lose: the backend's stop path calls back into the player, that callback was recorded as a new command, and it landed after the play had already cleared the stop flag — so the play's own end of media was read as a stop and wiped the new track (20/20 runs). The callback now ignores stops that originate in a command the player is already running, which is exactly the case where the flag has been set already; a stop from another thread still has to be recorded, and is. The other was in the dispatcher itself: the delayed-work bookkeeping rebuilt its set from a timer thread while another thread was adding to it, which raised, and it raised before the delayed command was queued, so the command was silently lost. That set is now guarded by its own lock, each timer forgets only its own handle, and the bookkeeping is off the path to submission entirely.

One deviation from the plan is worth review. The `on_stop` callback into the backend services survives, with a narrower job. Serialization does remove its ordering role for stops the player itself requests: `stop()` runs to completion, backend call included, so the resulting `END_OF_MEDIA` is simply a later command that sees the flag. But a skill calling a backend service's `stop()` directly is not a player command at all, and dropping the callback would make that stop indistinguishable from a track ending, silently advancing the queue. The callback now submits the flag write instead of performing it, and the scoping rule it always had (only the service with an active backend may signal) is unchanged.

The race tests that existed to pin the removed mechanisms are rewritten as ordering tests in `test/unittests/test_transport_ordering.py`, driven through a real worker: the duplicate `END_OF_MEDIA`, the stop against the `END_OF_MEDIA` its own backend emits, and the retry superseded by a newer play. One test was deleted rather than ported — it started two threads inside the media-state handler and asserted a lock made them advance once, and two threads can no longer enter that handler at all. `test_dispatcher.py` covers the model itself: ordering, non-overlap, epoch drop and bump semantics, timeouts, the abandon-on-shutdown policy. The rest of the unit suite drives the player directly and asserts on the next line, so a `conftest.py` fixture gives those tests an inline dispatcher; the two new files ask for a real worker explicitly, and the end-to-end suite runs the threaded dispatcher unmodified.

The end-to-end suite needed one adaptation, and it is worth being explicit about why. A bus message is now acted on a moment after the emit returns, and several of those tests read the player on the next line; the harness's fixed 50 ms yield is enough on an idle machine and not on a loaded one, which is how a coverage run failed them. `Dispatcher.settle()` waits for the player to go idle, and a conftest in that suite calls it after each harness emit — no assertion changed, no sleeps added, no test file touched. With 200 ms of artificial delay injected before every command, the whole suite still passes, which is a stronger statement about the tests than the original timing was.

A meta-finding from the review belongs here too: the end-to-end suite passes with the stop-requested flag gutted entirely, so it did not cover the path the first defect above lived on. The new no-drain regression test is that coverage, and the audit wave after this restructure will attack threaded-mode ordering broadly rather than trusting the suite's silence.

Unrelated to this PR but worth noting for the next one: the MPRIS property getters still read live player state from the D-Bus thread, the same exposure they have on `dev`; the MPRIS PR converts them to snapshot reads.

Unit suite 906 passed (from 870, +72 subtests unchanged): 37 added across the two new files, one deleted. End-to-end 68 passed with the real worker thread, unchanged except for the settle conftest — that suite is the oracle here, since it is the only place the threaded model actually runs. Both suites green on repeated randomized-order runs, under coverage, and with the injected-delay run described above.
