### PR TITLE
refactor: decompose media catalog and extract voice skill

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,17 +62,21 @@ The rest of this document focuses on the daemon itself.
    Each loads OPM plugins at startup and delegates actual playback to the selected
    plugin instance.
 
-The player package splits along the state it owns: `OCPMediaPlayer` and the
-catalog skill in `ovos_media/player/__init__.py`, the queue in
+The player package splits along the state it owns: `OCPMediaPlayer` in
+`ovos_media/player/__init__.py`, the queue in
 `ovos_media/player/queue.py`, the now-playing tracker in
 `ovos_media/player/now_playing.py`, and stream extraction in
-`ovos_media/player/streams.py`. `PlayQueue` owns the user queue, the identity
+`ovos_media/player/streams.py`. What can be played is a separate package,
+`ovos_media/catalog/`: `MediaCatalog` holds the roster of announced OCP skills
+and the search results, `LikedSongsStore` owns the persisted liked songs and
+the lock serializing them, and `KeywordRegistrar` teaches the OCP pipeline the
+liked-song keywords. `PlayQueue` owns the user queue, the identity
 of the selected entry and the uris that failed to load, and answers which
 track comes next; what to do with that answer — repeat, autoplay, stop —
 stays with the player.
 
 Every subscription `MediaService`, `OCPMediaPlayer`, `NowPlaying` and
-`OCPMediaCatalog` make lives in the bus edge, `ovos_media/bus/api.py`.
+`MediaCatalog` make lives in the bus edge, `ovos_media/bus/api.py`.
 `OCPBusApi` holds one registration table naming, per topic, the payload decoder
 to run, whether the topic is gated to the local session, and the method to
 call. The same table drives teardown, so a shut-down daemon cannot keep
@@ -80,10 +84,22 @@ answering a topic it registered.
 
 The backend services are the exception: each of `AudioService`,
 `VideoService` and `WebService` binds its own
-`ovos.common_play.media.state` listener in `BaseMediaService.__init__`, and the
-skill base class the catalog inherits from registers its intents and keyword
-plumbing itself. Reading the table therefore tells you what the player layer
+`ovos.common_play.media.state` listener in `BaseMediaService.__init__`, and
+`OCPVoiceSkill` registers its intents and keyword plumbing through the skill
+base class. Reading the table therefore tells you what the player layer
 answers, not everything this process has bound.
+
+### The voice front-end
+
+`MediaService` also builds one real skill, `OCPVoiceSkill`
+(`ovos_media/skill.py`), and it is the only part of the daemon that speaks.
+It owns the five media intents ("what song is this", shuffle on/off), the
+liked-songs search results the OCP pipeline asks for, and every dialog.
+Playback code never calls `speak_dialog`: when a track fails, a queue ends or
+no backend is installed, the player asks its catalog to announce a dialog and
+the skill, registered as a listener on that catalog, decides what to say. A
+player running without a voice front-end therefore stays silent instead of
+reaching into a skill it does not own.
 
 Payload validation for all layers lives in `ovos_media/bus/schemas.py`.
 Every rule an incoming bus payload must satisfy — numeric fields that must be

--- a/ovos_media/catalog/__init__.py
+++ b/ovos_media/catalog/__init__.py
@@ -1,0 +1,5 @@
+from ovos_media.catalog.catalog import MediaCatalog
+from ovos_media.catalog.keywords import KeywordRegistrar
+from ovos_media.catalog.likes import LikedSongsStore
+
+__all__ = ["MediaCatalog", "KeywordRegistrar", "LikedSongsStore"]

--- a/ovos_media/catalog/catalog.py
+++ b/ovos_media/catalog/catalog.py
@@ -1,0 +1,114 @@
+"""The media catalog: what can be played and what was found.
+
+Holds the roster of OCP skills that announced themselves, the featured
+media they advertise, the liked-songs store and the search results the
+player merges into its queue. It is a plain object with no bus
+subscriptions of its own — :mod:`ovos_media.bus.api` binds
+``ovos.common_play.announce`` and ``ovos.common_play.skills.detach`` to
+the handlers below.
+
+It is also the seam through which the player asks for a dialog. The
+player never speaks: it notifies the catalog, and whatever voice
+front-end registered a listener (see :class:`ovos_media.skill.
+OCPVoiceSkill`) decides what to say. Without a listener the notification
+is dropped, which is what a headless player with no skill attached wants.
+"""
+import threading
+from typing import Callable, List, Optional
+
+from ovos_bus_client.message import Message
+from ovos_utils.log import LOG
+from ovos_utils.ocp import MediaType, Playlist
+
+from ovos_media.bus.schemas import flatten_media_types
+from ovos_media.catalog.likes import LikedSongsStore
+
+
+class MediaCatalog:
+
+    def __init__(self, bus, likes: LikedSongsStore) -> None:
+        self.bus = bus
+        # injected, never invented: one store per process, shared with the
+        # voice front-end that searches it (see ovos_media.service)
+        self.likes = likes
+        self.search_playlist = Playlist()
+        self.ocp_skills = {}
+        self.featured_skills = {}
+        self._dialog_listeners: List[Callable[[str, Optional[dict]], None]] = []
+
+    def add_dialog_listener(self, listener: Callable) -> None:
+        """Register a voice front-end to speak notified dialogs."""
+        if listener not in self._dialog_listeners:
+            self._dialog_listeners.append(listener)
+
+    def remove_dialog_listener(self, listener: Callable) -> None:
+        if listener in self._dialog_listeners:
+            self._dialog_listeners.remove(listener)
+
+    def notify_dialog(self, dialog: str, data: Optional[dict] = None) -> None:
+        """Ask the voice front-end to speak a dialog.
+
+        A listener that raises must not take the caller down with it — the
+        callers are playback paths where a failed announcement is never a
+        reason to abort playback.
+        """
+        for listener in list(self._dialog_listeners):
+            try:
+                listener(dialog, data)
+            except Exception as e:
+                LOG.exception(f"Failed to speak {dialog} dialog: {e}")
+
+    def handle_skill_announce(self, message: Message) -> None:
+        skill_id = message.data.get("skill_id")
+        skill_name = message.data.get("skill_name") or skill_id
+        img = message.data.get("image") or message.data.get("thumbnail")
+        has_featured = bool(message.data.get("featured_tracks"))
+        media_types = message.data.get("media_types") or \
+                      message.data.get("media_type") or \
+                      [MediaType.GENERIC]
+        media_types = flatten_media_types(media_types)
+
+        if skill_id not in self.ocp_skills:
+            LOG.debug(f"Registered {skill_id}")
+            self.ocp_skills[skill_id] = []
+
+        if has_featured:
+            LOG.debug(f"Found skill with featured media: {skill_id}")
+            self.featured_skills[skill_id] = {
+                "skill_id": skill_id,
+                "skill_name": skill_name,
+                "image": img,
+                "media_types": media_types
+            }
+
+    def handle_ocp_skill_detach(self, message: Message) -> None:
+        skill_id = message.data["skill_id"]
+        if skill_id in self.ocp_skills:
+            self.ocp_skills.pop(skill_id)
+        if skill_id in self.featured_skills:
+            self.featured_skills.pop(skill_id)
+
+    def get_featured_skills(self, adult: bool = False) -> list:
+        """Emit a skills-get broadcast and return the registered featured skills.
+
+        The 200 ms wait allows in-process skill announcements to arrive before
+        the list is read.  A threading.Event is used instead of time.sleep so
+        the call can be interrupted by a shutdown signal in future work.
+        """
+        self.bus.emit(Message("ovos.common_play.skills.get"))
+        threading.Event().wait(timeout=0.2)  # non-blocking sleep equivalent
+        skills = list(self.featured_skills.values())
+        if adult:
+            return skills
+        return [s for s in skills
+                if MediaType.ADULT not in s["media_types"] and
+                MediaType.HENTAI not in s["media_types"]]
+
+    def clear(self) -> None:
+        self.search_playlist.clear()
+
+    def replace(self, playlist) -> None:
+        self.search_playlist.replace(playlist)
+
+    def shutdown(self) -> None:
+        self._dialog_listeners.clear()

--- a/ovos_media/catalog/keywords.py
+++ b/ovos_media/catalog/keywords.py
@@ -1,0 +1,98 @@
+"""OCP keyword registration for the liked-songs catalog.
+
+Two consumers learn about keywords: the local Aho-Corasick NER matcher
+inside ovos-workshop, and the OCP pipeline classifier, which is told over
+the bus. The "ner" extra (``ahocorasick_ner``) is optional, and its
+absence is not a pure speed optimization —
+``OVOSCommonPlaybackSkill.ocp_voc_match`` hard-depends on it, so without
+it "play my liked songs" style searches match nothing. The bus half does
+not need it, but in ovos-workshop the emit happens after the per-language
+NER registration inside the same method, so an ImportError there stops
+the classifier from ever hearing about the keywords. That half is
+replicated here so the classifier still learns them.
+"""
+from typing import Callable, List, Optional
+
+from ovos_bus_client.message import Message
+from ovos_utils.log import LOG
+from ovos_utils.ocp import MediaType
+
+PLAYLIST_KEYWORDS = ["favorite", "liked", "favorites",
+                     "favorite songs", "favorite tracks",
+                     "favorite music", "my favorite songs",
+                     "my favorite tracks", "my favorite music",
+                     "liked songs", "liked tracks", "liked music",
+                     "my liked songs", "my liked tracks", "my liked music"]
+
+
+def normalize_title(title: str) -> str:
+    """Strip the parenthesised/bracketed decoration song titles carry
+    ("Song (Live) - Remaster") down to the bare name people say."""
+    return title.split("|")[0].split("(")[0].split("[")[0] \
+        .split("{")[0].split("-")[0].strip()
+
+
+class KeywordRegistrar:
+    """Registers OCP keywords on behalf of a skill."""
+
+    def __init__(self, bus, skill_id: str, native_langs: List[str],
+                 cache_dir: str,
+                 ner_register: Optional[Callable] = None) -> None:
+        self.bus = bus
+        self.skill_id = skill_id
+        self.native_langs = native_langs
+        self.cache_dir = cache_dir
+        # OVOSCommonPlaybackSkill.register_ocp_keyword; absent when there is
+        # no skill to register against, in which case only the bus half runs
+        self.ner_register = ner_register
+
+    def register_liked_songs(self, likes) -> None:
+        """Register the liked song titles and the playlist synonyms."""
+        titles = [normalize_title(t) for t in likes.titles()]
+        try:
+            if self.ner_register is None:
+                raise ImportError("no NER-backed registration available")
+            self.ner_register(MediaType.MUSIC, "song_name", titles)
+            self.ner_register(MediaType.MUSIC, "playlist_name",
+                              PLAYLIST_KEYWORDS)
+        except ImportError:
+            LOG.warning("ahocorasick_ner not installed - OCP local keyword "
+                        "NER matching disabled, and 'search_db' (eg. 'play "
+                        "my liked songs') will find nothing until it is "
+                        "installed. Install the 'ner' extra to fix this. "
+                        "The classifier is still informed of the keywords "
+                        "via the bus so media-type disambiguation still "
+                        "works.")
+            self.emit(MediaType.MUSIC, "song_name", titles)
+            self.emit(MediaType.MUSIC, "playlist_name", PLAYLIST_KEYWORDS)
+
+    def emit(self, media_type: MediaType, label: str,
+             samples: List[str]) -> None:
+        """Tell the OCP pipeline classifier about a set of keyword samples.
+
+        Mirrors the NER-independent tail half of
+        ``OVOSCommonPlaybackSkill.register_ocp_keyword``: same message name
+        and same payload shape, so the classifier cannot tell the
+        difference.
+        """
+        samples = list(set(samples))
+        for lang in self.native_langs:
+            if len(samples) >= 20:
+                csv_path = f"{self.cache_dir}/{self.skill_id}_{label}_{lang}.csv"
+                with open(csv_path, "w") as f:
+                    f.write("label,sample")
+                    for s in samples:
+                        f.write(f"\n{label},{s}")
+                self.bus.emit(
+                    Message('ovos.common_play.register_keyword',
+                            {"skill_id": self.skill_id,
+                             "label": label,
+                             "csv": csv_path,
+                             "media_type": media_type}))
+            else:
+                self.bus.emit(
+                    Message('ovos.common_play.register_keyword',
+                            {"skill_id": self.skill_id,
+                             "label": label,
+                             "samples": samples,
+                             "media_type": media_type}))

--- a/ovos_media/catalog/likes.py
+++ b/ovos_media/catalog/likes.py
@@ -1,0 +1,109 @@
+"""The persisted liked-songs store.
+
+A thin wrapper around the ``OCP_liked_songs`` JSON store that owns the lock
+guarding it. Every mutation and every read that iterates the dict goes
+through this object: ``store()`` does a ``json.dump`` that iterates while
+the like/unlike/play-count writers mutate from separate bus-dispatch
+threads, so without a single shared lock a ``store()`` racing a ``pop()``
+raises "dictionary changed size during iteration".
+"""
+from threading import RLock
+from typing import List, Optional
+
+from json_database import JsonStorageXDG
+from ovos_config.meta import get_xdg_base
+from ovos_utils.log import LOG
+from ovos_utils.ocp import MediaEntry, MediaType, PlaybackType
+
+
+class LikedSongsStore:
+    """Liked songs, keyed by uri, persisted as JSON."""
+
+    def __init__(self, store=None) -> None:
+        self._store = store if store is not None else \
+            JsonStorageXDG("OCP_liked_songs", subfolder=get_xdg_base())
+        self._lock = RLock()
+        LOG.debug(f"Liked songs playlist loaded: {self.path}")
+
+    @property
+    def path(self) -> str:
+        return getattr(self._store, "path", "")
+
+    def __contains__(self, uri: str) -> bool:
+        with self._lock:
+            return uri in self._store
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._store)
+
+    def items(self) -> list:
+        with self._lock:
+            return list(self._store.items())
+
+    def like(self, uri: str, title: str = "", artist: str = "",
+             image: str = "") -> None:
+        with self._lock:
+            self._store[uri] = {"title": title, "artist": artist,
+                                "image": image, "uri": uri}
+            self._store.store()
+        LOG.info(f"liked song: {uri}")
+
+    def unlike(self, uri: str) -> bool:
+        """Drop a song from the store. Returns whether it was there."""
+        with self._lock:
+            if uri not in self._store:
+                return False
+            self._store.pop(uri)
+            self._store.store()
+        LOG.info(f"unliked song: {uri}")
+        return True
+
+    def increment_play_count(self, uri: Optional[str]) -> bool:
+        """Bump the play count of a liked song. Returns whether it was one."""
+        with self._lock:
+            entry = self._store.get(uri)
+            if entry is None:
+                return False
+            entry["play_count"] = entry.get("play_count", 0) + 1
+            self._store.store()
+        return True
+
+    def titles(self) -> List[str]:
+        """The titles of every well-formed entry.
+
+        The store is persisted JSON, editable outside this process (GUI,
+        manual edits, older or newer schema versions). A single malformed
+        entry — a non-dict value, or a dict without a title — is skipped
+        with a warning rather than raised, which used to kill daemon
+        startup.
+        """
+        titles = []
+        for uri, song in self.items():
+            if not isinstance(song, dict):
+                LOG.warning(f"Skipping malformed liked song entry {uri!r}: "
+                            f"expected a dict, got {type(song).__name__}")
+                continue
+            title = song.get("title", "")
+            if not title:
+                LOG.warning(f"Skipping liked song entry {uri!r}: "
+                            f"missing/empty title")
+                continue
+            titles.append(title)
+        return titles
+
+    def as_entries(self) -> List[MediaEntry]:
+        """The store as canonical MediaEntry objects, most-played first.
+
+        ``match_confidence`` tracks the play count so the entries sort
+        most-played-first once handed to a Playlist.
+        """
+        entries = [MediaEntry(uri=uri,
+                              title=song.get("title", ""),
+                              artist=song.get("artist", ""),
+                              image=song.get("image", ""),
+                              media_type=MediaType.MUSIC,
+                              playback=PlaybackType.AUDIO,
+                              match_confidence=song.get("play_count", 0) + 50)
+                   for uri, song in self.items()]
+        return sorted(entries, key=lambda e: e.match_confidence, reverse=True)

--- a/ovos_media/player/__init__.py
+++ b/ovos_media/player/__init__.py
@@ -1,20 +1,14 @@
-import threading
-from os.path import dirname
-from threading import RLock
 from typing import List, Optional, Union
-
-from json_database import JsonStorageXDG
 
 from ovos_bus_client import MessageBusClient
 from ovos_config import Configuration
-from ovos_config.meta import get_xdg_base
 from ovos_media.media_backends import AudioService, VideoService, WebService
 from ovos_media.mpris import OcpMprisExporter
 from ovos_media.bus.api import OCPBusApi
-from ovos_media.utils import is_default_session
+from ovos_media.catalog import LikedSongsStore, MediaCatalog
 from ovos_media.bus.schemas import (decode_media_state, decode_playlist_tracks,
                                     decode_seek, decode_track_position,
-                                    flatten_media_types, validated_entries)
+                                    validated_entries)
 from ovos_media.player.queue import (AllFailed, KeepCurrent, PlayQueue,
                                      QueueEnd)
 from ovos_media.player.now_playing import NowPlaying
@@ -25,347 +19,16 @@ from ovos_plugin_manager.ocp import load_stream_extractors
 from ovos_plugin_manager.templates.media import MediaBackend
 from ovos_utils.log import LOG
 from ovos_bus_client.message import Message
-from ovos_utils.ocp import MediaType, Playlist
-from ovos_utils.ocp import OCP_ID, PlayerState, LoopState, PlaybackType, PlaybackMode, TrackState, MediaState, \
+from ovos_utils.ocp import Playlist
+from ovos_utils.ocp import PlayerState, LoopState, PlaybackType, PlaybackMode, TrackState, MediaState, \
     MediaEntry, PluginStream
-from ovos_workshop.decorators.ocp import ocp_search
-from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill
 
-
-# locale/ and qt5/ live in the ovos_media package, one level above this
-# subpackage; the catalog skill reads its dialogs, intents and icons from there
-RESOURCES_DIR = dirname(dirname(__file__))
-
-
-class OCPMediaCatalog(OVOSCommonPlaybackSkill):
-    def __init__(self, *args, validate_source: bool = True, **kwargs):
-        kwargs.setdefault("resources_dir", RESOURCES_DIR)
-        super().__init__(*args, **kwargs)
-        # mirrors the bus edge's session gate: keeps playback-affecting
-        # intent handlers (shuffle on/off) on the local/"default" session, unless the owning service was configured
-        # with media.validate_source: false (satellite acting on everything)
-        self.validate_source = validate_source
-        self.skill_icon = f"{RESOURCES_DIR}/qt5/images/liked.svg"
-
-        self.liked_songs = JsonStorageXDG("OCP_liked_songs",
-                                          subfolder=get_xdg_base())
-        # Guards every liked_songs mutation + store() together, and every
-        # unlocked read that iterates the dict (eg. liked_songs_playlist);
-        # store() does a json.dump that iterates the dict, and
-        # handle_like/handle_unlike/play()'s play-count block all mutate it
-        # from separate bus-dispatch threads. OCPMediaPlayer aliases its
-        # own _liked_songs_lock to this one so writers and readers share it.
-        self.liked_songs_lock = RLock()
-        LOG.debug(f"Liked songs playlist loaded: {self.liked_songs.path}")
-        self.search_playlist = Playlist()
-        self.ocp_skills = {}
-        self.featured_skills = {}
-        # TODO - add search results clear/replace events
-
-        # register keywords
-        def norm_name(n):
-            return n.split("|")[0].split("(")[0].split("[")[0].split("{")[0].split("-")[0].strip()
-
-        # ahocorasick_ner ("ner" extra) is OPTIONAL, but its absence is not
-        # a pure speed optimization: OVOSCommonPlaybackSkill.ocp_voc_match
-        # (used by search_db, see below) hard-depends on it, so without it
-        # "play my liked songs" / "play my favorites" style searches never
-        # match anything. It is still true that the five WhatSong/WhatAlbum/
-        # WhatArtist/ShuffleOn/ShuffleOff intents registered below do not
-        # depend on it and keep working.
-        #
-        # register_ocp_keyword() itself does two things: it registers the
-        # samples with the local Aho-Corasick NER matcher (raises
-        # ImportError without the "ner" extra), and it emits
-        # 'ovos.common_play.register_keyword' on the bus so the OCP pipeline
-        # classifier learns the keywords too - that emit does not need local
-        # NER. In the installed ovos-workshop, the emit happens *after* the
-        # per-language NER registration loop inside the same method, so an
-        # ImportError there prevents the emit from ever running. We
-        # replicate the (NER-independent) emit here directly so the
-        # classifier still learns the keywords even without the "ner" extra.
-        # liked-songs is a persisted JSON store editable outside this
-        # process (GUI, manual edits, older/newer schema versions). A single
-        # malformed entry (a non-dict value, or a dict missing "title") used
-        # to raise here and kill daemon startup entirely. Skip and warn
-        # instead — mirrors the defensive .get() style liked_songs_playlist
-        # already uses.
-        liked_titles = []
-        for uri, song in self.liked_songs.items():
-            if not isinstance(song, dict):
-                LOG.warning(f"Skipping malformed liked song entry {uri!r}: "
-                           f"expected a dict, got {type(song).__name__}")
-                continue
-            title = song.get("title", "")
-            if not title:
-                LOG.warning(f"Skipping liked song entry {uri!r}: missing/empty title")
-                continue
-            liked_titles.append(norm_name(title))
-
-        try:
-            self.register_ocp_keyword(MediaType.MUSIC, "song_name", liked_titles)
-            self.register_ocp_keyword(MediaType.MUSIC, "playlist_name",
-                                      ["favorite", "liked", "favorites",
-                                       "favorite songs", "favorite tracks",
-                                       "favorite music", "my favorite songs",
-                                       "my favorite tracks", "my favorite music",
-                                       "liked songs", "liked tracks", "liked music",
-                                       "my liked songs", "my liked tracks", "my liked music"])
-        except ImportError:
-            LOG.warning("ahocorasick_ner not installed - OCP local keyword "
-                       "NER matching disabled, and 'search_db' (eg. 'play "
-                       "my liked songs') will find nothing until it is "
-                       "installed. Install the 'ner' extra to fix this. "
-                       "The classifier is still informed of the keywords "
-                       "via the bus so media-type disambiguation still "
-                       "works.")
-            self._emit_ocp_keyword_registration(
-                MediaType.MUSIC, "song_name", liked_titles)
-            self._emit_ocp_keyword_registration(
-                MediaType.MUSIC, "playlist_name",
-                ["favorite", "liked", "favorites",
-                 "favorite songs", "favorite tracks",
-                 "favorite music", "my favorite songs",
-                 "my favorite tracks", "my favorite music",
-                 "liked songs", "liked tracks", "liked music",
-                 "my liked songs", "my liked tracks", "my liked music"])
-
-        # intents about the currently playing media, see issue #23
-        self.register_intent_file("WhatSong.intent", self.handle_what_song)
-        self.register_intent_file("WhatAlbum.intent", self.handle_what_album)
-        self.register_intent_file("WhatArtist.intent", self.handle_what_artist)
-        self.register_intent_file("ShuffleOn.intent", self.handle_shuffle_on)
-        self.register_intent_file("ShuffleOff.intent", self.handle_shuffle_off)
-
-    def _emit_ocp_keyword_registration(self, media_type: MediaType, label: str,
-                                       samples: List[str]) -> None:
-        """
-        Emit the 'ovos.common_play.register_keyword' bus message that
-        informs the OCP pipeline classifier about a set of keyword samples,
-        WITHOUT going through OVOSCommonPlaybackSkill.register_ocp_keyword
-        (which also registers the samples with the local Aho-Corasick NER
-        matcher and requires the optional "ner" extra to be installed).
-
-        This mirrors the (NER-independent) tail half of
-        OVOSCommonPlaybackSkill.register_ocp_keyword: same message name and
-        same payload shape, so the classifier cannot tell the difference.
-        Used as a fallback when ahocorasick_ner is not installed.
-        """
-        samples = list(set(samples))
-        for lang in self.native_langs:
-            if len(samples) >= 20:
-                csv_path = f"{self.ocp_cache_dir}/{self.skill_id}_{label}_{lang}.csv"
-                with open(csv_path, "w") as f:
-                    f.write("label,sample")
-                    for s in samples:
-                        f.write(f"\n{label},{s}")
-                self.bus.emit(
-                    Message('ovos.common_play.register_keyword',
-                            {"skill_id": self.skill_id,
-                             "label": label,
-                             "csv": csv_path,
-                             "media_type": media_type}))
-            else:
-                self.bus.emit(
-                    Message('ovos.common_play.register_keyword',
-                            {"skill_id": self.skill_id,
-                             "label": label,
-                             "samples": samples,
-                             "media_type": media_type}))
-
-    def _get_status(self, message: Message) -> Optional[dict]:
-        """Query current player status via the existing status bus API.
-
-        Reuses the 'ovos.common_play.status' request/response messages that
-        OCPMediaPlayer.handle_status already answers; this avoids adding any
-        new bus message types or coupling this skill directly to the
-        OCPMediaPlayer instance.
-
-        The request is forwarded from the triggering intent message so the
-        session context (session_id, lang, etc) is preserved on the wire.
-
-        Returns None if no response was received within the timeout (player
-        not responding), as opposed to an empty dict, which means the player
-        answered but nothing is currently playing.
-        """
-        response = self.bus.wait_for_response(message.forward("ovos.common_play.status"),
-                                               timeout=3)
-        return response.data if response else None
-
-    # WhatSong/WhatAlbum/WhatArtist are deliberately UN-gated by session:
-    # they mirror OCPMediaPlayer.handle_status, which itself answers every
-    # session's "ovos.common_play.status" query with the single shared
-    # player's state (its bus topic is not gated).
-    # The consistency rule this repo follows is that each intent front-end
-    # mirrors its backing handler's own gating - handle_status is global
-    # read-only state, so these read handlers stay global too. Only the
-    # shuffle on/off handlers below are gated, because they mirror
-    # handle_set_shuffle/handle_unset_shuffle, which ARE gated.
-    def handle_what_song(self, message):
-        status = self._get_status(message)
-        if status is None:
-            self.speak_dialog("player.not.responding")
-            return
-        title = status.get("title")
-        artist = status.get("artist")
-        if not title:
-            self.speak_dialog("nothing.playing")
-        elif artist:
-            self.speak_dialog("now.playing.song", {"title": title, "artist": artist})
-        else:
-            self.speak_dialog("now.playing.song.no.artist", {"title": title})
-
-    def handle_what_album(self, message):
-        status = self._get_status(message)
-        if status is None:
-            self.speak_dialog("player.not.responding")
-            return
-        if not status.get("title"):
-            self.speak_dialog("nothing.playing")
-        else:
-            # NowPlaying/MediaEntry does not track album metadata, so this
-            # always falls back gracefully instead of guessing or crashing.
-            self.speak_dialog("no.album.info")
-
-    def handle_what_artist(self, message):
-        status = self._get_status(message)
-        if status is None:
-            self.speak_dialog("player.not.responding")
-            return
-        title = status.get("title")
-        artist = status.get("artist")
-        if not title:
-            self.speak_dialog("nothing.playing")
-        elif artist:
-            self.speak_dialog("now.playing.artist", {"artist": artist})
-        else:
-            self.speak_dialog("no.artist.info")
-
-    def _is_default_session(self, message: Message) -> bool:
-        """Whether the player will act on a request forwarded from this
-        message, using the same rule the bus edge applies to
-        'ovos.common_play.shuffle.set'/'.unset'. On a non-default (e.g.
-        HiveMind satellite) session with validate_source left True the
-        emitted message is silently dropped by the player - this must not be
-        reported back to the user as a success. When validate_source is
-        False the player WILL act on it, so this front-end must agree."""
-        return is_default_session(message, self.validate_source)
-
-    def handle_shuffle_on(self, message):
-        if not self._is_default_session(message):
-            self.speak_dialog("cannot.control.device")
-            return
-        self.bus.emit(message.forward("ovos.common_play.shuffle.set"))
-        self.speak_dialog("shuffle.on")
-
-    def handle_shuffle_off(self, message):
-        if not self._is_default_session(message):
-            self.speak_dialog("cannot.control.device")
-            return
-        self.bus.emit(message.forward("ovos.common_play.shuffle.unset"))
-        self.speak_dialog("shuffle.off")
-
-    @ocp_search()
-    def search_db(self, phrase, media_type):
-        base_score = 15 if media_type == MediaType.MUSIC else 0
-        entities = self.ocp_voc_match(phrase)
-        base_score += 30 * len(entities)
-
-        if entities.get("playlist_name"):
-            if phrase.lower() == entities["playlist_name"]:
-                base_score = 100
-            yield {
-                "match_confidence": min(base_score + 35, 100),
-                "media_type": MediaType.MUSIC,
-                "playback": PlaybackType.AUDIO,
-                "playlist": [e.as_dict for e in self.liked_songs_playlist],
-                "skill_icon": self.skill_icon,
-                "title": "Liked Songs",
-                "skill_id": self.skill_id
-            }
-
-        if entities.get("song_name"):
-            title = entities["song_name"].lower()
-            for entry in self.liked_songs_playlist:
-                if title not in entry.title.lower():
-                    continue
-                result = entry.as_dict
-                result["match_confidence"] = min(base_score + 40, 100)
-                result["skill_id"] = self.skill_id
-                result["skill_icon"] = self.skill_icon
-                yield result
-
-    @property
-    def liked_songs_playlist(self) -> List[MediaEntry]:
-        # canonicalize the persisted liked-songs store (raw dicts) into
-        # MediaEntry objects; match_confidence tracks play_count so the entries
-        # sort most-played-first once handed to a Playlist.
-        # tolerate catalogs constructed via __new__ (bypassing __init__)
-        # that never set liked_songs_lock
-        lock = getattr(self, "liked_songs_lock", None) or RLock()
-        with lock:
-            items = list(self.liked_songs.items())
-        entries = [MediaEntry(uri=uri,
-                              title=song.get("title", ""),
-                              artist=song.get("artist", ""),
-                              image=song.get("image", ""),
-                              media_type=MediaType.MUSIC,
-                              playback=PlaybackType.AUDIO,
-                              match_confidence=song.get("play_count", 0) + 50)
-                   for uri, song in items]
-        return sorted(entries, key=lambda e: e.match_confidence, reverse=True)
-
-    def handle_skill_announce(self, message):
-        skill_id = message.data.get("skill_id")
-        skill_name = message.data.get("skill_name") or skill_id
-        img = message.data.get("image") or message.data.get("thumbnail")
-        has_featured = bool(message.data.get("featured_tracks"))
-        media_types = message.data.get("media_types") or \
-                      message.data.get("media_type") or \
-                      [MediaType.GENERIC]
-        media_types = flatten_media_types(media_types)
-
-        if skill_id not in self.ocp_skills:
-            LOG.debug(f"Registered {skill_id}")
-            self.ocp_skills[skill_id] = []
-
-        if has_featured:
-            LOG.debug(f"Found skill with featured media: {skill_id}")
-            self.featured_skills[skill_id] = {
-                "skill_id": skill_id,
-                "skill_name": skill_name,
-                "image": img,
-                "media_types": media_types
-            }
-
-    def handle_ocp_skill_detach(self, message):
-        skill_id = message.data["skill_id"]
-        if skill_id in self.ocp_skills:
-            self.ocp_skills.pop(skill_id)
-        if skill_id in self.featured_skills:
-            self.featured_skills.pop(skill_id)
-
-    def get_featured_skills(self, adult: bool = False) -> list:
-        """Emit a skills-get broadcast and return the currently registered featured skills.
-
-        The 200 ms wait allows in-process skill announcements to arrive before
-        the list is read.  A threading.Event is used instead of time.sleep so
-        the call can be interrupted by a shutdown signal in future work.
-        """
-        self.bus.emit(Message("ovos.common_play.skills.get"))
-        threading.Event().wait(timeout=0.2)  # non-blocking sleep equivalent
-        skills = list(self.featured_skills.values())
-        if adult:
-            return skills
-        return [s for s in skills
-                if MediaType.ADULT not in s["media_types"] and
-                MediaType.HENTAI not in s["media_types"]]
-
-    def clear(self):
-        self.search_playlist.clear()
-
-    def replace(self, playlist):
-        self.search_playlist.replace(playlist)
+# The catalog is constructed through this module-level name and nothing
+# else: ovoscope's OCPPlayerHarness patches ``ovos_media.player.
+# OCPMediaCatalog`` with a MagicMock to build a real player without a real
+# catalog, so the name has to stay both importable and the one the player
+# calls.
+OCPMediaCatalog = MediaCatalog
 
 
 class OCPMediaPlayer:
@@ -377,7 +40,7 @@ class OCPMediaPlayer:
     """
 
     def __init__(self, bus: MessageBusClient, config: Optional[dict] = None,
-                 validate_source: bool = True) -> None:
+                 validate_source: bool = True, likes=None) -> None:
         self.bus = bus
         self.ocp_config = config or Configuration().get("media", {})
         # When True, playback-executing handlers act only on the local/"default"
@@ -391,8 +54,11 @@ class OCPMediaPlayer:
         self.media_state: MediaState = MediaState.NO_MEDIA
         self.shuffle: bool = False
         self.track_history: dict = {}  # Dict of track URI to play count
-        self.media: OCPMediaCatalog = OCPMediaCatalog(bus=bus, skill_id=OCP_ID + ".favorites",
-                                                       validate_source=self.validate_source)
+        # MediaService injects the store it also gives the voice skill; a
+        # player built on its own has no one to share with, so it opens the
+        # store itself.
+        self.media: MediaCatalog = OCPMediaCatalog(
+            bus=bus, likes=likes if likes is not None else LikedSongsStore())
         self._init_runtime_state()
         # the owned queue, also the container the rest of the world reads as
         # "the playlist" (bus status, MPRIS track list)
@@ -450,19 +116,6 @@ class OCPMediaPlayer:
         self.dispatcher.post_hook = self.publish_snapshot
         # what queries answer from; replaced wholesale after every command
         self._snapshot: PlayerSnapshot = PlayerSnapshot()
-        # Alias of self.media.liked_songs_lock: guards every liked_songs
-        # mutation + store() together, and every unlocked read that
-        # iterates the dict. store() does a json.dump that iterates the
-        # dict, and handle_like/handle_unlike/play()'s play-count block all
-        # mutate it from separate bus-dispatch threads; without this a
-        # store() racing a pop() raises "dictionary changed size during
-        # iteration". Kept as a shared lock (not a private one) so
-        # OCPMediaCatalog.liked_songs_playlist can snapshot under the same
-        # lock writers use. Falls back to a private RLock when applied
-        # standalone (eg. tests calling _init_runtime_state() before
-        # self.media exists) so it stays usable outside full __init__.
-        media = getattr(self, "media", None)
-        self._liked_songs_lock = media.liked_songs_lock if media is not None else RLock()
         # True between a stop request and the next play(). An explicit stop
         # must NOT advance the queue, but OPM backends emit END_OF_MEDIA from
         # ocp_stop(), so a stop is indistinguishable from a natural track end at
@@ -539,27 +192,19 @@ class OCPMediaPlayer:
             # liked-songs playlist, and broadcast an empty-string keyword
             # sample to the NER matcher on the next boot.
             LOG.warning("Cannot like: nothing is playing and no uri was given")
-            self.media.speak_dialog("nothing.playing")
+            self.media.notify_dialog("nothing.playing")
             return
         title = message.data.get("title") or self.now_playing.title
         image = message.data.get("image") or message.data.get("thumbnail") or self.now_playing.image
         artist = message.data.get("artist") or self.now_playing.artist
-        with self._liked_songs_lock:
-            self.media.liked_songs[uri] = {"title": title, "artist": artist,
-                                           "image": image, "uri": uri}
-            self.media.liked_songs.store()
-        LOG.info(f"liked song: {uri}")
+        self.media.likes.like(uri, title=title, artist=artist, image=image)
         self.bus.emit(message.forward("mycroft.audio.play_sound",
                                       {"uri": "snd/acknowledge.mp3"}))
 
     def handle_unlike(self, message):
         # sent from GUI or intent
         uri = message.data.get("uri") or self.now_playing.original_uri
-        with self._liked_songs_lock:
-            if uri in self.media.liked_songs:
-                self.media.liked_songs.pop(uri)
-                self.media.liked_songs.store()
-                LOG.info(f"unliked song: {uri}")
+        self.media.likes.unlike(uri)
 
     @property
     def active_skill(self) -> str:
@@ -978,10 +623,7 @@ class OCPMediaPlayer:
                 self.audio_service.services or self.video_service.services or
                 self.web_service.services):
             self._no_backend_dialog_spoken = True
-            try:
-                self.media.speak_dialog("no.playback.backend")
-            except Exception as e:
-                LOG.exception(f"Failed to speak no.playback.backend dialog: {e}")
+            self.media.notify_dialog("no.playback.backend")
 
         if disambiguation:
             valid_disambiguation = validated_entries(disambiguation)
@@ -1029,15 +671,7 @@ class OCPMediaPlayer:
         # two backends end up playing at once.
         self.roster.deactivate_others(self.playback_type)
 
-        # track play count - store() does a json.dump that iterates the
-        # dict, and handle_like()/handle_unlike() can mutate it concurrently
-        # from another bus-dispatch thread, so every mutation+store goes
-        # through _liked_songs_lock to serialize access to the dict.
-        with self._liked_songs_lock:
-            entry = self.media.liked_songs.get(self.now_playing.uri)
-            if entry is not None:
-                entry["play_count"] = entry.get("play_count", 0) + 1
-                self.media.liked_songs.store()
+        self.media.likes.increment_play_count(self.now_playing.uri)
 
         # validate new stream
         if not self.validate_stream():
@@ -1162,10 +796,7 @@ class OCPMediaPlayer:
                 LOG.info("Requested next (shuffle), but there are no more "
                          "tracks in the queue")
                 self.set_player_state(PlayerState.STOPPED)
-                try:
-                    self.media.speak_dialog("queue.finished")
-                except Exception as e:
-                    LOG.exception(f"Failed to speak queue.finished dialog: {e}")
+                self.media.notify_dialog("queue.finished")
             return
 
         queue = self._merged_queue()
@@ -1195,20 +826,7 @@ class OCPMediaPlayer:
             # here, not in handle_playback_ended — that call site fires on
             # every autoplay-off track end and on MPRIS-external track
             # ends too, neither of which is really "the queue finished".
-            # This always speaks into the default session. play_next() is
-            # reached from an END_OF_MEDIA bus event (or the invalid-stream
-            # retry timer), neither of which carries the session of whatever
-            # 'ovos.common_play.play' request originally started this
-            # queue — so a satellite-triggered playback's queue.finished
-            # announces on the default/local session instead of the
-            # satellite's. Fixing this needs the player to stash the
-            # triggering message's session at play time (handle_play_request)
-            # and thread it through to speak_dialog here and at the
-            # track.failed site below; see the issue tracker.
-            try:
-                self.media.speak_dialog("queue.finished")
-            except Exception as e:
-                LOG.exception(f"Failed to speak queue.finished dialog: {e}")
+            self.media.notify_dialog("queue.finished")
             return
         self.play()
 
@@ -1361,14 +979,10 @@ class OCPMediaPlayer:
         self.stop()
         if self.mpris:
             self.mpris.shutdown()
-        # self.media.shutdown() is the no-op OVOSSkill.shutdown() hook — it
-        # does NOT remove what ovos-workshop registered for the catalog (the
-        # OCP intents, the keyword/announce plumbing of the skill base class).
-        # default_shutdown() is the real OVOSSkill teardown that removes
-        # them; without it a "shut down" service kept answering intents.
-        # The catalog's own announce/skills.detach topics belong to
-        # self.bus_api, torn down below.
-        self.media.default_shutdown()
+        # the catalog's own announce/skills.detach topics belong to
+        # self.bus_api, torn down below; this only drops the dialog
+        # listeners a voice front-end registered
+        self.media.shutdown()
         self.audio_service.shutdown()
         self.video_service.shutdown()
         self.web_service.shutdown()
@@ -1430,12 +1044,7 @@ class OCPMediaPlayer:
         # does not talk over itself
         if not self._track_failed_spoken:
             self._track_failed_spoken = True
-            # Same default-session gap as queue.finished above — see that
-            # comment. INVALID_MEDIA carries no session either.
-            try:
-                self.media.speak_dialog("track.failed")
-            except Exception as e:
-                LOG.exception(f"Failed to speak track.failed dialog: {e}")
+            self.media.notify_dialog("track.failed")
 
     def handle_playback_ended(self, message, playback_type: PlaybackType = None,
                               playback_uri: str = None,

--- a/ovos_media/service.py
+++ b/ovos_media/service.py
@@ -5,8 +5,12 @@ from ovos_utils.log import LOG
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
 
 from ovos_config.config import Configuration
+from ovos_utils.ocp import OCP_ID
+
 from ovos_media.bus.api import OCPBusApi
+from ovos_media.catalog import LikedSongsStore
 from ovos_media.player import OCPMediaPlayer
+from ovos_media.skill import OCPVoiceSkill
 
 def on_ready():
     LOG.info('Media service is ready.')
@@ -65,7 +69,11 @@ class MediaService(Thread):
         self.status.bind(self.bus)
         self.status.set_alive()
         self.init_messagebus()
-        self.ocp = OCPMediaPlayer(self.bus, validate_source=self.validate_source)
+        # one liked-songs store, shared by the player (which writes likes
+        # and play counts) and the voice skill (which searches it)
+        self.likes = LikedSongsStore()
+        self.ocp = OCPMediaPlayer(self.bus, validate_source=self.validate_source,
+                                  likes=self.likes)
         # 'ovos.common_play.home' and 'ovos.common_play.search.start'/
         # '.search.end' are pipeline-side signals (the OCP pipeline plugin
         # uses them to drive a GUI's own navigation/loading state); this
@@ -77,6 +85,17 @@ class MediaService(Thread):
         # is built here (after OCPMediaPlayer's plugin-loading construction
         # above), not in init_messagebus() which runs before self.ocp is
         # assigned, so the topic is never answerable before self.ocp exists.
+        # the voice front-end: the only thing in this daemon that speaks.
+        # It shares the player's liked-songs store and listens on its
+        # catalog for the dialogs playback asks to have announced. The
+        # skill_id is what the OCP pipeline sees on its search results and
+        # keyword registrations, so it stays the one the catalog always
+        # used.
+        self.voice_skill = OCPVoiceSkill(bus=self.bus,
+                                         skill_id=OCP_ID + ".favorites",
+                                         likes=self.likes,
+                                         catalog=self.ocp.media,
+                                         validate_source=self.validate_source)
         self.bus_api = OCPBusApi(self.bus, service=self)
 
     def handle_ping(self, message):
@@ -111,6 +130,10 @@ class MediaService(Thread):
         self.ocp.reset()
         self.status.set_stopping()
         self.ocp.shutdown()
+        # default_shutdown() is the real OVOSSkill teardown (plain
+        # shutdown() is the no-op user hook): without it a shut-down
+        # service keeps answering the media intents.
+        self.voice_skill.default_shutdown()
         # the service's own topics go last: a shut-down service must stop
         # answering ping/opm.audio.query too.
         self.bus_api.shutdown()

--- a/ovos_media/skill.py
+++ b/ovos_media/skill.py
@@ -1,0 +1,196 @@
+"""The voice front-end of the media daemon.
+
+Everything spoken by ovos-media is spoken here. The player and the
+catalog only notify; this skill owns the dialogs, the "what's playing"
+and shuffle intents, and the liked-songs search results the OCP pipeline
+asks for.
+"""
+from os.path import dirname
+from typing import Optional
+
+from ovos_bus_client.message import Message
+from ovos_utils.ocp import MediaType, PlaybackType
+from ovos_workshop.decorators.ocp import ocp_search
+from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill
+
+from ovos_media.catalog import KeywordRegistrar, LikedSongsStore, MediaCatalog
+from ovos_media.utils import is_default_session
+
+# locale/ and qt5/ live in the ovos_media package, next to this module;
+# the skill reads its dialogs, intents and icons from there
+RESOURCES_DIR = dirname(__file__)
+
+
+class OCPVoiceSkill(OVOSCommonPlaybackSkill):
+    """Intents, dialogs and liked-songs search for the media daemon."""
+
+    def __init__(self, *args, likes: LikedSongsStore,
+                 catalog: Optional[MediaCatalog] = None,
+                 validate_source: bool = True, **kwargs):
+        kwargs.setdefault("resources_dir", RESOURCES_DIR)
+        super().__init__(*args, **kwargs)
+        # mirrors the bus edge's session gate: keeps playback-affecting
+        # intent handlers (shuffle on/off) on the local/"default" session,
+        # unless the owning service was configured with
+        # media.validate_source: false (satellite acting on everything)
+        self.validate_source = validate_source
+        self.skill_icon = f"{RESOURCES_DIR}/qt5/images/liked.svg"
+
+        # the same store the player writes likes and play counts into
+        self.likes = likes
+        self.catalog = catalog
+        if catalog is not None:
+            catalog.add_dialog_listener(self.handle_dialog_notification)
+
+        KeywordRegistrar(self.bus, self.skill_id, self.native_langs,
+                         self.ocp_cache_dir,
+                         self.register_ocp_keyword).register_liked_songs(self.likes)
+
+        # intents about the currently playing media, see issue #23
+        self.register_intent_file("WhatSong.intent", self.handle_what_song)
+        self.register_intent_file("WhatAlbum.intent", self.handle_what_album)
+        self.register_intent_file("WhatArtist.intent", self.handle_what_artist)
+        self.register_intent_file("ShuffleOn.intent", self.handle_shuffle_on)
+        self.register_intent_file("ShuffleOff.intent", self.handle_shuffle_off)
+
+    def handle_dialog_notification(self, dialog: str,
+                                   data: Optional[dict] = None) -> None:
+        """Speak a dialog the player asked the catalog to announce.
+
+        These announcements (track.failed, queue.finished,
+        no.playback.backend, nothing.playing) always land on the default
+        session: they are reached from bus events that carry no session of
+        their own (END_OF_MEDIA, INVALID_MEDIA, the invalid-stream retry
+        timer). A satellite-triggered playback therefore announces
+        locally. Fixing that needs the player to stash the triggering
+        message's session at play time and pass it along; see the issue
+        tracker.
+        """
+        self.speak_dialog(dialog, data)
+
+    def _get_status(self, message: Message) -> Optional[dict]:
+        """Query current player status via the existing status bus API.
+
+        Reuses the 'ovos.common_play.status' request/response messages that
+        OCPMediaPlayer.handle_status already answers; this avoids adding any
+        new bus message types or coupling this skill directly to the
+        OCPMediaPlayer instance.
+
+        The request is forwarded from the triggering intent message so the
+        session context (session_id, lang, etc) is preserved on the wire.
+
+        Returns None if no response was received within the timeout (player
+        not responding), as opposed to an empty dict, which means the player
+        answered but nothing is currently playing.
+        """
+        response = self.bus.wait_for_response(message.forward("ovos.common_play.status"),
+                                              timeout=3)
+        return response.data if response else None
+
+    # WhatSong/WhatAlbum/WhatArtist are deliberately UN-gated by session:
+    # they mirror OCPMediaPlayer.handle_status, which itself answers every
+    # session's "ovos.common_play.status" query with the single shared
+    # player's state (its bus topic is not gated).
+    # The consistency rule this repo follows is that each intent front-end
+    # mirrors its backing handler's own gating - handle_status is global
+    # read-only state, so these read handlers stay global too. Only the
+    # shuffle on/off handlers below are gated, because they mirror
+    # handle_set_shuffle/handle_unset_shuffle, which ARE gated.
+    def handle_what_song(self, message):
+        status = self._get_status(message)
+        if status is None:
+            self.speak_dialog("player.not.responding")
+            return
+        title = status.get("title")
+        artist = status.get("artist")
+        if not title:
+            self.speak_dialog("nothing.playing")
+        elif artist:
+            self.speak_dialog("now.playing.song", {"title": title, "artist": artist})
+        else:
+            self.speak_dialog("now.playing.song.no.artist", {"title": title})
+
+    def handle_what_album(self, message):
+        status = self._get_status(message)
+        if status is None:
+            self.speak_dialog("player.not.responding")
+            return
+        if not status.get("title"):
+            self.speak_dialog("nothing.playing")
+        else:
+            # NowPlaying/MediaEntry does not track album metadata, so this
+            # always falls back gracefully instead of guessing or crashing.
+            self.speak_dialog("no.album.info")
+
+    def handle_what_artist(self, message):
+        status = self._get_status(message)
+        if status is None:
+            self.speak_dialog("player.not.responding")
+            return
+        title = status.get("title")
+        artist = status.get("artist")
+        if not title:
+            self.speak_dialog("nothing.playing")
+        elif artist:
+            self.speak_dialog("now.playing.artist", {"artist": artist})
+        else:
+            self.speak_dialog("no.artist.info")
+
+    def _is_default_session(self, message: Message) -> bool:
+        """Whether the player will act on a request forwarded from this
+        message, using the same rule the bus edge applies to
+        'ovos.common_play.shuffle.set'/'.unset'. On a non-default (e.g.
+        HiveMind satellite) session with validate_source left True the
+        emitted message is silently dropped by the player - this must not be
+        reported back to the user as a success. When validate_source is
+        False the player WILL act on it, so this front-end must agree."""
+        return is_default_session(message, self.validate_source)
+
+    def handle_shuffle_on(self, message):
+        if not self._is_default_session(message):
+            self.speak_dialog("cannot.control.device")
+            return
+        self.bus.emit(message.forward("ovos.common_play.shuffle.set"))
+        self.speak_dialog("shuffle.on")
+
+    def handle_shuffle_off(self, message):
+        if not self._is_default_session(message):
+            self.speak_dialog("cannot.control.device")
+            return
+        self.bus.emit(message.forward("ovos.common_play.shuffle.unset"))
+        self.speak_dialog("shuffle.off")
+
+    @ocp_search()
+    def search_db(self, phrase, media_type):
+        base_score = 15 if media_type == MediaType.MUSIC else 0
+        entities = self.ocp_voc_match(phrase)
+        base_score += 30 * len(entities)
+
+        if entities.get("playlist_name"):
+            if phrase.lower() == entities["playlist_name"]:
+                base_score = 100
+            yield {
+                "match_confidence": min(base_score + 35, 100),
+                "media_type": MediaType.MUSIC,
+                "playback": PlaybackType.AUDIO,
+                "playlist": [e.as_dict for e in self.likes.as_entries()],
+                "skill_icon": self.skill_icon,
+                "title": "Liked Songs",
+                "skill_id": self.skill_id
+            }
+
+        if entities.get("song_name"):
+            title = entities["song_name"].lower()
+            for entry in self.likes.as_entries():
+                if title not in entry.title.lower():
+                    continue
+                result = entry.as_dict
+                result["match_confidence"] = min(base_score + 40, 100)
+                result["skill_id"] = self.skill_id
+                result["skill_icon"] = self.skill_icon
+                yield result
+
+    def default_shutdown(self):
+        if self.catalog is not None:
+            self.catalog.remove_dialog_listener(self.handle_dialog_notification)
+        super().default_shutdown()

--- a/test/unittests/test_autoplay_and_search_gating.py
+++ b/test/unittests/test_autoplay_and_search_gating.py
@@ -282,6 +282,7 @@ class TestPipelineSideSignalsAreNotHandled(unittest.TestCase):
              patch("ovos_media.player.OcpMprisExporter"), \
              patch("ovos_media.player.Configuration", return_value={"media": {}}), \
              patch("ovos_media.player.OCPMediaCatalog"), \
+             patch("ovos_media.service.OCPVoiceSkill"), \
              patch("ovos_media.service.ProcessStatus") as MockStatus, \
              patch("ovos_media.service.Configuration", return_value={"media": {}}):
             MockStatus.return_value = MagicMock()

--- a/test/unittests/test_backend_isolation_and_catalog_filters.py
+++ b/test/unittests/test_backend_isolation_and_catalog_filters.py
@@ -12,10 +12,6 @@ wrong backend.
 BaseMediaService.available_backends() left the per-service body
 (including the .name access) outside any guard, so one backend whose
 .name raised killed the whole listing.
-OCPMediaCatalog.liked_songs_playlist iterated self.liked_songs.items()
-with no lock while writers mutate the dict under _liked_songs_lock,
-producing "dictionary changed size during iteration" under concurrent
-like+search traffic.
 OCPMediaPlayer.play_prev matched playback_type in
 [PlaybackType.SKILL, PlaybackType.UNDEFINED], so an idle "previous"
 (the UNDEFINED default) emitted a bogus skill-control message and
@@ -23,7 +19,6 @@ never reached the merged-queue logic - asymmetric with play_next,
 which only matches PlaybackType.SKILL.
 """
 import threading
-import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -37,10 +32,16 @@ from ovos_utils.ocp import MediaType, PlaybackType
 # ---------------------------------------------------------------------------
 
 def _make_catalog():
+    from ovos_media.catalog import LikedSongsStore
     from ovos_media.player import OCPMediaCatalog
+
+    class _FakeStore(dict):
+        def store(self):
+            pass
+
     bus = FakeBus()
     with patch("ovos_media.player.load_stream_extractors"):
-        cat = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+        cat = OCPMediaCatalog(bus=bus, likes=LikedSongsStore(_FakeStore()))
     return cat, bus
 
 
@@ -224,104 +225,6 @@ class TestGetPreferredPlayersToleratesRaisingService(unittest.TestCase):
         svc, bus = _make_base_svc(services=[a, b])
         result = svc.get_preferred_players()
         self.assertEqual(set(result), {"a", "b"})
-
-
-# ---------------------------------------------------------------------------
-# liked_songs_playlist locking
-# ---------------------------------------------------------------------------
-
-class _LockProbe:
-    """Records acquire()/release() calls, standing in for an RLock so a
-    test can assert a critical section actually took the lock (same
-    pattern as TestLikedSongsLockSerialization in test_player_coverage2.py)."""
-
-    def __init__(self):
-        self.acquire_count = 0
-        self.release_count = 0
-
-    def __enter__(self):
-        self.acquire_count += 1
-        return self
-
-    def __exit__(self, *exc):
-        self.release_count += 1
-        return False
-
-
-class TestLikedSongsLockUsage(unittest.TestCase):
-
-    def test_liked_songs_playlist_acquires_the_shared_lock(self):
-        from ovos_media.player import OCPMediaPlayer
-
-        with patch("ovos_media.player.AudioService"), \
-             patch("ovos_media.player.VideoService"), \
-             patch("ovos_media.player.WebService"), \
-             patch("ovos_media.player.OcpMprisExporter"), \
-                 patch("ovos_media.player.Configuration", return_value={"media": {}}):
-            p = OCPMediaPlayer(FakeBus(), config={})
-
-        # the player's writer lock and the catalog's lock must be the same
-        # object, so a reader snapshotting under one is actually serialized
-        # against writers taking the other
-        self.assertIs(p._liked_songs_lock, p.media.liked_songs_lock)
-
-        p.media.liked_songs = {"file://a.mp3": {"title": "A", "play_count": 1}}
-        probe = _LockProbe()
-        p.media.liked_songs_lock = probe
-        _ = p.media.liked_songs_playlist
-        self.assertGreaterEqual(probe.acquire_count, 1)
-        self.assertEqual(probe.acquire_count, probe.release_count)
-
-    def test_concurrent_read_and_locked_write_no_runtime_error(self):
-        """Adversarial: a reader iterating liked_songs_playlist concurrently
-        with a locked writer mutating the dict must never raise
-        RuntimeError (dictionary changed size during iteration). This test
-        FAILS on the pre-fix code (unlocked property read) within ~2s."""
-        from ovos_media.player import OCPMediaPlayer
-
-        with patch("ovos_media.player.AudioService"), \
-             patch("ovos_media.player.VideoService"), \
-             patch("ovos_media.player.WebService"), \
-             patch("ovos_media.player.OcpMprisExporter"), \
-                 patch("ovos_media.player.Configuration", return_value={"media": {}}):
-            p = OCPMediaPlayer(FakeBus(), config={})
-
-        p.media.liked_songs = {
-            f"file://{i}.mp3": {"title": f"T{i}", "play_count": i}
-            for i in range(20)
-        }
-        errors = []
-        stop = threading.Event()
-
-        def reader():
-            while not stop.is_set():
-                try:
-                    list(p.media.liked_songs_playlist)
-                except RuntimeError as e:
-                    errors.append(e)
-                    return
-
-        def writer():
-            i = 0
-            while not stop.is_set():
-                uri = f"file://{i}.mp3"
-                with p._liked_songs_lock:
-                    if uri in p.media.liked_songs:
-                        p.media.liked_songs.pop(uri)
-                    else:
-                        p.media.liked_songs[uri] = {"title": "T", "play_count": i}
-                i += 1
-
-        threads = [threading.Thread(target=reader) for _ in range(4)]
-        threads.append(threading.Thread(target=writer))
-        for t in threads:
-            t.start()
-        time.sleep(2)
-        stop.set()
-        for t in threads:
-            t.join(timeout=2)
-
-        self.assertEqual(errors, [], f"race triggered: {errors}")
 
 
 # ---------------------------------------------------------------------------

--- a/test/unittests/test_catalog.py
+++ b/test/unittests/test_catalog.py
@@ -1,0 +1,183 @@
+"""Tests for MediaCatalog: the OCP skill roster, the featured-media
+filter, the search playlist, and the dialog-notification seam the player
+speaks through.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import MediaEntry, MediaType
+
+from ovos_media.catalog import LikedSongsStore, MediaCatalog
+
+
+class _FakeStore(dict):
+    """The JsonStorageXDG surface LikedSongsStore writes through, without
+    touching disk."""
+
+    def store(self):
+        pass
+
+
+def _likes(entries=None):
+    return LikedSongsStore(_FakeStore(entries or {}))
+
+
+def _announce(catalog, **data):
+    catalog.handle_skill_announce(Message("ovos.common_play.announce", data))
+
+
+class TestSkillAnnounceMediaTypesNormalization(unittest.TestCase):
+    """D2: a skill announcing with the singular "media_type" key can send
+    a bare scalar (eg. an int), which used to be stored as-is and blow up
+    get_featured_skills()'s "in media_types" membership checks."""
+
+    def test_singular_int_media_type_is_featured_and_does_not_raise(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        _announce(catalog, skill_id="skill.a", skill_name="A",
+                  featured_tracks=["t1"], media_type=int(MediaType.MUSIC))
+
+        skills = catalog.get_featured_skills()  # must not raise
+
+        self.assertEqual(len(skills), 1)
+        self.assertEqual(skills[0]["skill_id"], "skill.a")
+
+    def test_plural_list_media_types_still_works(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        _announce(catalog, skill_id="skill.b", skill_name="B",
+                  featured_tracks=["t1"], media_types=[MediaType.MUSIC])
+
+        skills = catalog.get_featured_skills()
+
+        self.assertEqual(len(skills), 1)
+        self.assertEqual(skills[0]["skill_id"], "skill.b")
+
+    def test_adult_singular_media_type_is_filtered_out(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        _announce(catalog, skill_id="skill.c", skill_name="C",
+                  featured_tracks=["t1"], media_type=int(MediaType.ADULT))
+
+        skills = catalog.get_featured_skills()  # must not raise
+
+        self.assertEqual(skills, [])
+
+    def test_adult_skills_are_listed_when_asked_for(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        _announce(catalog, skill_id="skill.c", skill_name="C",
+                  featured_tracks=["t1"], media_type=int(MediaType.ADULT))
+
+        self.assertEqual(len(catalog.get_featured_skills(adult=True)), 1)
+
+
+class TestSkillRoster(unittest.TestCase):
+    def test_announce_registers_the_skill_even_without_featured_tracks(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        _announce(catalog, skill_id="skill.d", skill_name="D")
+
+        self.assertIn("skill.d", catalog.ocp_skills)
+        self.assertNotIn("skill.d", catalog.featured_skills)
+
+    def test_detach_drops_the_skill_from_both_registries(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        _announce(catalog, skill_id="skill.e", skill_name="E",
+                  featured_tracks=["t1"], media_types=[MediaType.MUSIC])
+
+        catalog.handle_ocp_skill_detach(
+            Message("ovos.common_play.skills.detach", {"skill_id": "skill.e"}))
+
+        self.assertNotIn("skill.e", catalog.ocp_skills)
+        self.assertNotIn("skill.e", catalog.featured_skills)
+
+    def test_detach_of_an_unknown_skill_is_a_noop(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        catalog.handle_ocp_skill_detach(
+            Message("ovos.common_play.skills.detach", {"skill_id": "nope"}))
+        self.assertEqual(catalog.ocp_skills, {})
+
+    def test_get_featured_skills_broadcasts_the_skills_get_request(self):
+        bus = FakeBus()
+        catalog = MediaCatalog(bus, _likes())
+        seen = []
+        bus.on("ovos.common_play.skills.get", lambda m: seen.append(m))
+
+        catalog.get_featured_skills()
+
+        self.assertEqual(len(seen), 1)
+
+
+class TestSearchPlaylist(unittest.TestCase):
+    def test_clear_empties_the_search_results(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        catalog.search_playlist.add_entry(MediaEntry(uri="file://a.mp3",
+                                                     title="A"))
+        catalog.clear()
+        self.assertEqual(len(catalog.search_playlist), 0)
+
+    def test_replace_swaps_the_search_results(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        catalog.search_playlist.add_entry(MediaEntry(uri="file://a.mp3",
+                                                     title="A"))
+        catalog.replace([MediaEntry(uri="file://b.mp3", title="B")])
+        self.assertEqual([e.uri for e in catalog.search_playlist.entries],
+                         ["file://b.mp3"])
+
+
+class TestDialogNotifications(unittest.TestCase):
+    """The catalog carries dialog requests from the player to whatever
+    voice front-end is attached; it never speaks itself."""
+
+    def test_listener_receives_dialog_and_data(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        listener = MagicMock()
+        catalog.add_dialog_listener(listener)
+
+        catalog.notify_dialog("queue.finished", {"title": "X"})
+
+        listener.assert_called_once_with("queue.finished", {"title": "X"})
+
+    def test_listener_is_registered_once(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        listener = MagicMock()
+        catalog.add_dialog_listener(listener)
+        catalog.add_dialog_listener(listener)
+
+        catalog.notify_dialog("track.failed")
+
+        self.assertEqual(listener.call_count, 1)
+
+    def test_removed_listener_is_not_called(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        listener = MagicMock()
+        catalog.add_dialog_listener(listener)
+        catalog.remove_dialog_listener(listener)
+
+        catalog.notify_dialog("track.failed")
+
+        listener.assert_not_called()
+
+    def test_a_raising_listener_does_not_reach_the_caller(self):
+        """The notify sites are playback paths — a front-end that blows up
+        while speaking must never abort playback."""
+        catalog = MediaCatalog(FakeBus(), _likes())
+        catalog.add_dialog_listener(MagicMock(side_effect=RuntimeError("boom")))
+        survivor = MagicMock()
+        catalog.add_dialog_listener(survivor)
+
+        catalog.notify_dialog("track.failed")  # must not raise
+
+        survivor.assert_called_once()
+
+    def test_shutdown_drops_every_listener(self):
+        catalog = MediaCatalog(FakeBus(), _likes())
+        listener = MagicMock()
+        catalog.add_dialog_listener(listener)
+
+        catalog.shutdown()
+        catalog.notify_dialog("track.failed")
+
+        listener.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_defect_fixes.py
+++ b/test/unittests/test_defect_fixes.py
@@ -42,10 +42,6 @@ class TestA1DaemonStartup(unittest.TestCase):
         player = OCPMediaPlayer(bus, config={})
         self.assertEqual(player.playlist.title, "Search Results")
         self.assertEqual(len(player.playlist), 0)
-        # validate_source must be plumbed through to the catalog (#90);
-        # this was dead code prior to the A1 fix since construction never
-        # completed far enough to exercise it
-        self.assertIs(player.media.validate_source, player.validate_source)
 
     def test_media_service_constructs_on_fakebus(self):
         from ovos_media.service import MediaService
@@ -53,6 +49,11 @@ class TestA1DaemonStartup(unittest.TestCase):
         service = MediaService(bus=bus)
         self.assertIsNotNone(service.ocp)
         self.assertEqual(service.ocp.playlist.title, "Search Results")
+        # validate_source must be plumbed through to the voice front-end
+        # (#90), which mirrors the player's session gate on its shuffle
+        # intents
+        self.assertIs(service.voice_skill.validate_source,
+                      service.validate_source)
         service.shutdown()
 
 

--- a/test/unittests/test_end_of_track_handling.py
+++ b/test/unittests/test_end_of_track_handling.py
@@ -370,7 +370,7 @@ class TestLoadOkPlayFailQueue(unittest.TestCase):
 
     def _four_track_queue(self, bus):
         player = _make_player(bus)
-        player.media.speak_dialog = MagicMock()
+        player.media.notify_dialog = MagicMock()
         player.invalid_stream_delay = 0.02
         tracks = [_track(f"http://example.com/{n}.mp3", n)
                   for n in ("a", "b", "c", "d")]
@@ -412,7 +412,7 @@ class TestLoadOkPlayFailQueue(unittest.TestCase):
         while len(calls) < len(tracks) and time.monotonic() < deadline:
             time.sleep(0.02)
 
-        speak_calls = [c for c in player.media.speak_dialog.call_args_list
+        speak_calls = [c for c in player.media.notify_dialog.call_args_list
                       if c.args and c.args[0] == "track.failed"]
         self.assertEqual(len(speak_calls), 1,
                         "track.failed must be spoken once per queue, not "

--- a/test/unittests/test_failure_notifications.py
+++ b/test/unittests/test_failure_notifications.py
@@ -10,7 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Quick-win #4: spoken failure dialogs.
+"""Failure dialogs the player asks its catalog to announce.
+
+The player never speaks: it calls MediaCatalog.notify_dialog and the
+voice skill listening on the catalog turns that into speech (see
+test_voice_skill.py). What is pinned here is WHEN the player notifies.
 
 - no.playback.backend: spoken once, at the first play attempt, when zero
   backends of any kind are loaded.
@@ -64,24 +68,24 @@ class TestNoPlaybackBackendDialog(unittest.TestCase):
     def test_spoken_when_no_backends_loaded(self):
         p = self._make_player_with_backends([])
         p.play_media({"uri": "http://x.mp3", "title": "X"})
-        p.media.speak_dialog.assert_called_once_with("no.playback.backend")
+        p.media.notify_dialog.assert_called_once_with("no.playback.backend")
 
     def test_not_spoken_when_a_backend_is_loaded(self):
         p = self._make_player_with_backends([MagicMock()])
         p.play_media({"uri": "http://x.mp3", "title": "X"})
-        p.media.speak_dialog.assert_not_called()
+        p.media.notify_dialog.assert_not_called()
 
     def test_spoken_only_once_across_repeated_play_attempts(self):
         p = self._make_player_with_backends([])
         p.play_media({"uri": "http://x.mp3", "title": "X"})
         p.play_media({"uri": "http://y.mp3", "title": "Y"})
         p.play_media({"uri": "http://z.mp3", "title": "Z"})
-        self.assertEqual(p.media.speak_dialog.call_count, 1)
+        self.assertEqual(p.media.notify_dialog.call_count, 1)
 
     def test_video_only_backend_still_counts_as_available(self):
         p = self._make_player_with_backends([], video_services=[MagicMock()])
         p.play_media({"uri": "http://x.mp4", "title": "X"})
-        p.media.speak_dialog.assert_not_called()
+        p.media.notify_dialog.assert_not_called()
 
 
 class TestTrackFailedDialog(unittest.TestCase):
@@ -106,14 +110,14 @@ class TestTrackFailedDialog(unittest.TestCase):
     def test_spoken_on_first_invalid_media(self):
         p = self._make_player()
         p.handle_invalid_media()
-        p.media.speak_dialog.assert_called_once_with("track.failed")
+        p.media.notify_dialog.assert_called_once_with("track.failed")
 
     def test_not_spoken_again_for_a_second_invalid_track_in_the_same_queue(self):
         p = self._make_player()
         p.handle_invalid_media()
         p.handle_invalid_media()
         p.handle_invalid_media()
-        self.assertEqual(p.media.speak_dialog.call_count, 1)
+        self.assertEqual(p.media.notify_dialog.call_count, 1)
 
     def test_not_reset_by_loaded_media_alone(self):
         """LOADED_MEDIA without a subsequent confirmed-PLAYING TrackState
@@ -124,12 +128,12 @@ class TestTrackFailedDialog(unittest.TestCase):
         would never trip _all_tracks_failed() and would loop unbounded."""
         p = self._make_player()
         p.handle_invalid_media()
-        self.assertEqual(p.media.speak_dialog.call_count, 1)
+        self.assertEqual(p.media.notify_dialog.call_count, 1)
         # a bare LOADED_MEDIA/BUFFERED_MEDIA transition (no PLAYING_* track
         # state) must be a no-op for the guard
         p.media_state = MediaState.LOADED_MEDIA
         p.handle_invalid_media()
-        self.assertEqual(p.media.speak_dialog.call_count, 1,
+        self.assertEqual(p.media.notify_dialog.call_count, 1,
                         "LOADED_MEDIA alone must not reset the track.failed "
                         "rate limit")
 
@@ -141,7 +145,7 @@ class TestTrackFailedDialog(unittest.TestCase):
         from ovos_utils.ocp import TrackState
         p = self._make_player()
         p.handle_invalid_media()
-        self.assertEqual(p.media.speak_dialog.call_count, 1)
+        self.assertEqual(p.media.notify_dialog.call_count, 1)
         # set_player_state()'s own status-report side effects need a fuller
         # player than this fixture builds; stub it so the test isolates the
         # guard-reset logic under test (handle_track_state_change calling
@@ -157,7 +161,7 @@ class TestTrackFailedDialog(unittest.TestCase):
         self.assertEqual(p._failed_uris, set())
         self.assertFalse(p._track_failed_spoken)
         p.handle_invalid_media()
-        self.assertEqual(p.media.speak_dialog.call_count, 2)
+        self.assertEqual(p.media.notify_dialog.call_count, 2)
 
     def test_flag_is_cleared_by_reset_body(self):
         """reset() must clear the per-queue rate-limit flag alongside
@@ -180,7 +184,7 @@ class TestTrackFailedDialog(unittest.TestCase):
         self.assertFalse(p._track_failed_spoken)
         self.assertEqual(p._failed_uris, set())
         p.handle_invalid_media()
-        self.assertEqual(p.media.speak_dialog.call_count, 2)
+        self.assertEqual(p.media.notify_dialog.call_count, 2)
 
 
 def _track(uri, title, playback=PlaybackType.AUDIO):
@@ -189,14 +193,14 @@ def _track(uri, title, playback=PlaybackType.AUDIO):
 
 def _real_player(bus=None, config=None):
     """A real OCPMediaPlayer on a FakeBus (same construction pattern as
-    test_end_of_track_handling.py), with stream extraction and the actual
-    speak_dialog call stubbed out so tests observe calls without touching
-    real dialog resources."""
+    test_end_of_track_handling.py), with stream extraction stubbed out and
+    the dialog notification captured, so tests observe the announcements
+    without a voice front-end attached."""
     from ovos_media.player import OCPMediaPlayer
     bus = bus or FakeBus()
     player = OCPMediaPlayer(bus, config=config if config is not None else {})
     player.now_playing.extract_stream = lambda: None
-    player.media.speak_dialog = MagicMock()
+    player.media.notify_dialog = MagicMock()
     return player
 
 
@@ -226,13 +230,13 @@ class TestQueueFinishedDialog(unittest.TestCase):
             player.bus.emit(Message("ovos.common_play.media.state",
                                     {"state": MediaState.END_OF_MEDIA}))
             self.assertEqual(player.now_playing.uri, b.uri)
-            player.media.speak_dialog.assert_not_called()
+            player.media.notify_dialog.assert_not_called()
 
             # track B ends -> no more tracks -> spoken exactly once
             player.media_state = MediaState.BUFFERED_MEDIA
             player.bus.emit(Message("ovos.common_play.media.state",
                                     {"state": MediaState.END_OF_MEDIA}))
-        player.media.speak_dialog.assert_called_once_with("queue.finished")
+        player.media.notify_dialog.assert_called_once_with("queue.finished")
         self.assertEqual(player.state, PlayerState.STOPPED)
         player.shutdown()
 
@@ -251,7 +255,7 @@ class TestQueueFinishedDialog(unittest.TestCase):
             player.bus.emit(Message("ovos.common_play.media.state",
                                     {"state": MediaState.END_OF_MEDIA}))
             mock_play_next.assert_not_called()
-        player.media.speak_dialog.assert_not_called()
+        player.media.notify_dialog.assert_not_called()
         player.shutdown()
 
     def test_mpris_track_end_is_silent(self):
@@ -264,7 +268,7 @@ class TestQueueFinishedDialog(unittest.TestCase):
             message=None, playback_type=PlaybackType.MPRIS,
             playback_uri=a.uri, stop_requested=False,
         )
-        player.media.speak_dialog.assert_not_called()
+        player.media.notify_dialog.assert_not_called()
         player.shutdown()
 
     def test_explicit_stop_is_silent(self):
@@ -276,7 +280,7 @@ class TestQueueFinishedDialog(unittest.TestCase):
             message=None, playback_type=PlaybackType.AUDIO,
             playback_uri=a.uri, stop_requested=True,
         )
-        player.media.speak_dialog.assert_not_called()
+        player.media.notify_dialog.assert_not_called()
         player.shutdown()
 
     def test_not_spoken_when_nothing_ever_played(self):
@@ -287,7 +291,7 @@ class TestQueueFinishedDialog(unittest.TestCase):
             message=None, playback_type=PlaybackType.UNDEFINED,
             playback_uri=None, stop_requested=False,
         )
-        player.media.speak_dialog.assert_not_called()
+        player.media.notify_dialog.assert_not_called()
         player.shutdown()
 
 

--- a/test/unittests/test_keywords.py
+++ b/test/unittests/test_keywords.py
@@ -1,0 +1,135 @@
+"""Tests for KeywordRegistrar: the liked-songs keyword samples handed to
+the local NER matcher, and the bus half that keeps the OCP pipeline
+classifier informed when the optional "ner" extra is missing.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import MediaType
+
+from ovos_media.catalog.keywords import (PLAYLIST_KEYWORDS, KeywordRegistrar,
+                                         normalize_title)
+
+SKILL_ID = "ovos.common_play.favorites"
+
+
+def _registrar(bus, ner_register=None, langs=("en-us",), cache_dir="/tmp"):
+    return KeywordRegistrar(bus, SKILL_ID, list(langs), cache_dir,
+                            ner_register=ner_register)
+
+
+def _likes(titles):
+    return MagicMock(**{"titles.return_value": list(titles)})
+
+
+class TestNormalizeTitle(unittest.TestCase):
+    def test_strips_decoration(self):
+        self.assertEqual(normalize_title("Song (Live)"), "Song")
+        self.assertEqual(normalize_title("Song [Remaster]"), "Song")
+        self.assertEqual(normalize_title("Song {Demo}"), "Song")
+        self.assertEqual(normalize_title("Song | Bonus"), "Song")
+        self.assertEqual(normalize_title("Song - Remaster"), "Song")
+
+    def test_leaves_a_plain_title_alone(self):
+        self.assertEqual(normalize_title("Bohemian Rhapsody"),
+                         "Bohemian Rhapsody")
+
+
+class TestNerBackedRegistration(unittest.TestCase):
+    def test_registers_normalized_titles_and_playlist_synonyms(self):
+        ner = MagicMock()
+        _registrar(FakeBus(), ner).register_liked_songs(
+            _likes(["Alpha (Live)", "Beta"]))
+
+        ner.assert_any_call(MediaType.MUSIC, "song_name", ["Alpha", "Beta"])
+        ner.assert_any_call(MediaType.MUSIC, "playlist_name",
+                            PLAYLIST_KEYWORDS)
+
+    def test_nothing_is_emitted_on_the_bus_when_ner_is_available(self):
+        bus = FakeBus()
+        emitted = []
+        bus.on("ovos.common_play.register_keyword",
+               lambda m: emitted.append(m.data))
+
+        _registrar(bus, MagicMock()).register_liked_songs(_likes(["Alpha"]))
+
+        self.assertEqual(emitted, [])
+
+
+class TestFallbackEmit(unittest.TestCase):
+    """Without the "ner" extra, register_ocp_keyword raises ImportError
+    before its own bus emit runs, so the classifier would never hear about
+    the keywords. The bus half is replicated here instead."""
+
+    def _emitted_without_ner(self, titles, ner_register=None):
+        bus = FakeBus()
+        emitted = []
+        bus.on("ovos.common_play.register_keyword",
+               lambda m: emitted.append(m.data))
+        _registrar(bus, ner_register).register_liked_songs(_likes(titles))
+        return emitted
+
+    def test_both_labels_are_emitted(self):
+        emitted = self._emitted_without_ner(["Alpha"])
+        self.assertEqual({e["label"] for e in emitted},
+                         {"song_name", "playlist_name"})
+
+    def test_import_error_from_the_ner_path_falls_back(self):
+        ner = MagicMock(side_effect=ImportError("no ahocorasick_ner"))
+        emitted = self._emitted_without_ner(["Alpha"], ner)
+        self.assertEqual({e["label"] for e in emitted},
+                         {"song_name", "playlist_name"})
+
+    def test_song_name_is_emitted_even_with_no_liked_songs(self):
+        emitted = self._emitted_without_ner([])
+        song_name = [e for e in emitted if e["label"] == "song_name"]
+        self.assertEqual(len(song_name), 1)
+        self.assertEqual(song_name[0]["samples"], [])
+        self.assertEqual(set(song_name[0].keys()),
+                         {"skill_id", "label", "samples", "media_type"})
+
+    def test_payload_carries_the_skill_id_and_media_type(self):
+        emitted = self._emitted_without_ner(["Alpha"])
+        for data in emitted:
+            self.assertEqual(data["skill_id"], SKILL_ID)
+            self.assertEqual(data["media_type"], MediaType.MUSIC)
+
+    def test_one_emit_per_native_language(self):
+        bus = FakeBus()
+        emitted = []
+        bus.on("ovos.common_play.register_keyword",
+               lambda m: emitted.append(m.data))
+
+        _registrar(bus, langs=("en-us", "pt-pt")).register_liked_songs(
+            _likes(["Alpha"]))
+
+        self.assertEqual(len(emitted), 4)
+
+
+class TestLargeSampleSets(unittest.TestCase):
+    """20+ samples go through a CSV file instead of an inline payload —
+    the shape ovos-workshop's own registration uses."""
+
+    def test_samples_are_written_to_a_csv(self):
+        import tempfile
+        bus = FakeBus()
+        emitted = []
+        bus.on("ovos.common_play.register_keyword",
+               lambda m: emitted.append(m.data))
+        titles = [f"Song {i}" for i in range(25)]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            _registrar(bus, cache_dir=tmp).register_liked_songs(_likes(titles))
+            song_name = [e for e in emitted if e["label"] == "song_name"][0]
+            self.assertNotIn("samples", song_name)
+            with open(song_name["csv"]) as f:
+                lines = f.read().splitlines()
+
+        self.assertEqual(lines[0], "label,sample")
+        self.assertEqual(len(lines), 26)
+        self.assertTrue(all(line.startswith("song_name,") for line in lines[1:]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_lifecycle_hygiene.py
+++ b/test/unittests/test_lifecycle_hygiene.py
@@ -2,16 +2,16 @@
 
 L1 - shutdown() left bus listeners bound (zombie service kept answering
      ping/status/etc. after "shutdown").
-L2 - a malformed liked-songs store entry crashed daemon startup.
 L3 - liking with nothing playing persisted an empty-string store entry.
 L4 - opm.audio.query was bound before self.ocp existed.
 """
-import threading
 import unittest
 from unittest.mock import MagicMock, patch
 
 from ovos_utils.fakebus import FakeBus
 from ovos_bus_client.message import Message
+
+from ovos_media.catalog import LikedSongsStore
 
 
 def _listener_count(bus):
@@ -26,6 +26,7 @@ def _make_service(bus):
          patch("ovos_media.player.OcpMprisExporter"), \
          patch("ovos_media.player.Configuration", return_value={"media": {}}), \
          patch("ovos_media.player.OCPMediaCatalog") as MockCatalog, \
+         patch("ovos_media.service.OCPVoiceSkill"), \
          patch("ovos_media.service.ProcessStatus") as MockStatus, \
          patch("ovos_media.service.Configuration", return_value={"media": {}}):
         MockStatus.return_value = MagicMock()
@@ -76,6 +77,7 @@ class TestL1ZombieServiceShutdown(unittest.TestCase):
              patch("ovos_media.player.OcpMprisExporter"), \
                  patch("ovos_media.player.Configuration", return_value={"media": {}}), \
              patch("ovos_media.player.OCPMediaCatalog"), \
+             patch("ovos_media.service.OCPVoiceSkill"), \
              patch("ovos_media.service.ProcessStatus") as MockStatus, \
              patch("ovos_media.service.Configuration", return_value={"media": {}}):
             MockStatus.return_value = MagicMock()
@@ -113,46 +115,6 @@ class TestL1ZombieServiceShutdown(unittest.TestCase):
         self.assertEqual(replies, [])
 
 
-class TestL2LikedSongsStoreTolerance(unittest.TestCase):
-    """A malformed liked-songs store entry must not crash daemon startup."""
-
-    def _construct_real(self, store_values):
-        """Construct a real OCPMediaCatalog (a real OVOSCommonPlaybackSkill,
-        wired to a real FakeBus - same pattern as
-        test_catalog_now_playing_intents.py) against the given liked_songs
-        store contents, and return it (or let the exception propagate)."""
-        from ovos_media.player import OCPMediaCatalog
-        bus = FakeBus()
-        fake_store = MagicMock()
-        fake_store.items.return_value = list(store_values.items())
-        fake_store.values.return_value = list(store_values.values())
-        fake_store.path = "/tmp/fake_liked_songs.json"
-
-        with patch("ovos_media.player.JsonStorageXDG", return_value=fake_store):
-            catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
-        return catalog
-
-    def test_entry_missing_title_is_skipped(self):
-        catalog = self._construct_real({
-            "http://a.mp3": {"uri": "http://a.mp3"},  # no "title"
-            "http://b.mp3": {"uri": "http://b.mp3", "title": "Good Song"},
-        })
-        self.assertIsNotNone(catalog)
-
-    def test_entry_non_dict_value_is_skipped(self):
-        catalog = self._construct_real({
-            "http://a.mp3": "notadict",
-            "http://b.mp3": {"uri": "http://b.mp3", "title": "Good Song"},
-        })
-        self.assertIsNotNone(catalog)
-
-    def test_entry_list_value_is_skipped(self):
-        catalog = self._construct_real({
-            "http://a.mp3": [1, 2, 3],
-        })
-        self.assertIsNotNone(catalog)
-
-
 class TestL3EmptyLikeGuarded(unittest.TestCase):
     """Liking with nothing playing must not persist an empty-string entry."""
 
@@ -167,29 +129,29 @@ class TestL3EmptyLikeGuarded(unittest.TestCase):
         p.now_playing.image = ""
         p.now_playing.artist = ""
         p.media = MagicMock()
-        # a plain dict subclass (not a bare MagicMock) so assertIn/assertEqual
-        # against its contents are meaningful, with .store() stubbed out like
-        # the real JsonStorageXDG.store() (persist-to-disk) would be.
+        # a real store over a plain dict subclass (not a bare MagicMock) so
+        # assertIn/assertEqual against its contents are meaningful, with
+        # .store() stubbed out like the real JsonStorageXDG.store()
+        # (persist-to-disk) would be.
         class _FakeStore(dict):
             def store(self):
                 pass
-        p.media.liked_songs = _FakeStore()
-        p.media.speak_dialog = MagicMock()
-        p._liked_songs_lock = threading.RLock()
+        self.store = _FakeStore()
+        p.media.likes = LikedSongsStore(self.store)
         return p
 
     def test_like_with_nothing_playing_does_not_store_empty_key(self):
         p = self._make_player()
         msg = Message("ovos.common_play.like", {})
         p.handle_like(msg)
-        self.assertNotIn("", p.media.liked_songs)
-        self.assertEqual(p.media.liked_songs, {})
+        self.assertNotIn("", self.store)
+        self.assertEqual(dict(self.store), {})
 
     def test_like_with_explicit_uri_still_stores(self):
         p = self._make_player()
         msg = Message("ovos.common_play.like", {"uri": "http://x.mp3", "title": "X"})
         p.handle_like(msg)
-        self.assertIn("http://x.mp3", p.media.liked_songs)
+        self.assertIn("http://x.mp3", self.store)
 
 
 class TestL4LateQueryBinding(unittest.TestCase):
@@ -223,6 +185,7 @@ class TestL4LateQueryBinding(unittest.TestCase):
              patch("ovos_media.player.OcpMprisExporter"), \
                  patch("ovos_media.player.Configuration", return_value={"media": {}}), \
              patch("ovos_media.player.OCPMediaCatalog"), \
+             patch("ovos_media.service.OCPVoiceSkill"), \
              patch("ovos_media.service.ProcessStatus") as MockStatus, \
              patch("ovos_media.service.Configuration", return_value={"media": {}}), \
              patch.object(MediaService, "init_messagebus", patched_init_messagebus):

--- a/test/unittests/test_likes.py
+++ b/test/unittests/test_likes.py
@@ -1,0 +1,282 @@
+"""Tests for LikedSongsStore: malformed-entry tolerance, the MediaEntry
+shape search results are built from, and the lock that serializes the
+write-through against readers.
+
+The store is persisted JSON: store() does a json.dump that iterates the
+dict while like/unlike/play-count writers mutate it from separate
+bus-dispatch threads, so an unserialized read raises "dictionary changed
+size during iteration" under concurrent like+search traffic.
+"""
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_utils.ocp import MediaEntry, MediaType, PlaybackType
+
+from ovos_media.catalog import LikedSongsStore
+
+
+class _FakeStore(dict):
+    """A dict with the JsonStorageXDG surface the store writes through."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.path = "/tmp/fake_liked_songs.json"
+        self.store_calls = 0
+
+    def store(self):
+        self.store_calls += 1
+
+
+class _RacyStore(_FakeStore):
+    """A store whose reads and writes walk the dict in pure Python, with a
+    yield point per entry — JsonStorageXDG.store() does a json.dump that
+    iterates the same dict, and a reader snapshotting it iterates too. The
+    C-level equivalents are atomic under the GIL, which would hide the very
+    interleaving the lock exists to prevent.
+    """
+
+    def items(self):
+        # a live view, deliberately not snapshotted: only the caller's lock
+        # can keep a concurrent mutation out of this walk
+        out = []
+        for pair in super().items():
+            time.sleep(0)
+            out.append(pair)
+        return out
+
+    def store(self):
+        super().store()
+        for _ in super().items():
+            time.sleep(0)
+
+
+class _LockProbe:
+    """Records acquire()/release() calls, standing in for an RLock so a
+    test can assert a critical section actually took the lock."""
+
+    def __init__(self):
+        self.acquire_count = 0
+        self.release_count = 0
+
+    def __enter__(self):
+        self.acquire_count += 1
+        return self
+
+    def __exit__(self, *exc):
+        self.release_count += 1
+        return False
+
+
+class TestMalformedEntryTolerance(unittest.TestCase):
+    """A malformed store entry must not crash daemon startup — the store
+    is editable outside this process."""
+
+    def test_entry_missing_title_is_skipped(self):
+        likes = LikedSongsStore(_FakeStore({
+            "http://a.mp3": {"uri": "http://a.mp3"},  # no "title"
+            "http://b.mp3": {"uri": "http://b.mp3", "title": "Good Song"},
+        }))
+        self.assertEqual(likes.titles(), ["Good Song"])
+
+    def test_entry_non_dict_value_is_skipped(self):
+        likes = LikedSongsStore(_FakeStore({
+            "http://a.mp3": "notadict",
+            "http://b.mp3": {"uri": "http://b.mp3", "title": "Good Song"},
+        }))
+        self.assertEqual(likes.titles(), ["Good Song"])
+
+    def test_entry_list_value_is_skipped(self):
+        likes = LikedSongsStore(_FakeStore({"http://a.mp3": [1, 2, 3]}))
+        self.assertEqual(likes.titles(), [])
+
+
+class TestWriteThrough(unittest.TestCase):
+    def test_like_persists_the_track(self):
+        store = _FakeStore()
+        likes = LikedSongsStore(store)
+
+        likes.like("http://x.mp3", title="X", artist="A", image="i.png")
+
+        self.assertEqual(store["http://x.mp3"],
+                         {"title": "X", "artist": "A", "image": "i.png",
+                          "uri": "http://x.mp3"})
+        self.assertEqual(store.store_calls, 1)
+
+    def test_unlike_removes_and_persists(self):
+        store = _FakeStore({"http://x.mp3": {"title": "X"}})
+        likes = LikedSongsStore(store)
+
+        self.assertTrue(likes.unlike("http://x.mp3"))
+
+        self.assertEqual(dict(store), {})
+        self.assertEqual(store.store_calls, 1)
+
+    def test_unlike_of_an_unknown_uri_does_not_persist(self):
+        store = _FakeStore()
+        likes = LikedSongsStore(store)
+
+        self.assertFalse(likes.unlike("http://x.mp3"))
+
+        self.assertEqual(store.store_calls, 0)
+
+    def test_play_count_increments_and_persists(self):
+        store = _FakeStore({"http://liked.mp3": {"title": "Liked"}})
+        likes = LikedSongsStore(store)
+
+        self.assertTrue(likes.increment_play_count("http://liked.mp3"))
+
+        self.assertEqual(store["http://liked.mp3"]["play_count"], 1)
+        self.assertEqual(store.store_calls, 1)
+
+    def test_play_count_of_an_unliked_track_does_not_persist(self):
+        store = _FakeStore()
+        likes = LikedSongsStore(store)
+
+        self.assertFalse(likes.increment_play_count("http://nope.mp3"))
+
+        self.assertEqual(store.store_calls, 0)
+
+    def test_play_count_survives_a_concurrent_unlike(self):
+        """The entry can be popped by another bus-handler thread between
+        the lookup and the mutation - a real race, since bus handlers
+        dispatch on a thread pool."""
+
+        class _PoppedBetweenCheckAndIndex(_FakeStore):
+            def __contains__(self, key):
+                return True
+
+            def get(self, key, default=None):
+                return default
+
+        store = _PoppedBetweenCheckAndIndex()
+        likes = LikedSongsStore(store)
+
+        self.assertFalse(likes.increment_play_count("http://liked.mp3"))
+        self.assertEqual(store.store_calls, 0)
+
+
+class TestEntryShape(unittest.TestCase):
+    """as_entries() must yield canonical MediaEntry objects - the playback
+    path and the search results both use attribute access on them."""
+
+    def test_returns_media_entries_sorted_most_played_first(self):
+        likes = LikedSongsStore(_FakeStore({
+            "file://a.mp3": {"title": "Alpha", "play_count": 2},
+            "file://b.mp3": {"title": "Beta", "play_count": 5},
+        }))
+
+        entries = likes.as_entries()
+
+        self.assertTrue(all(isinstance(e, MediaEntry) for e in entries))
+        self.assertEqual([e.title for e in entries], ["Beta", "Alpha"])
+        self.assertTrue(all(e.playback == PlaybackType.AUDIO for e in entries))
+        self.assertTrue(all(e.media_type == MediaType.MUSIC for e in entries))
+
+    def test_does_not_mutate_the_persisted_store(self):
+        store = _FakeStore({"file://a.mp3": {"title": "Alpha", "play_count": 1}})
+        likes = LikedSongsStore(store)
+
+        _ = likes.as_entries()
+
+        self.assertEqual(store["file://a.mp3"],
+                         {"title": "Alpha", "play_count": 1})
+
+
+class TestLocking(unittest.TestCase):
+    def test_reads_and_writes_take_the_lock(self):
+        likes = LikedSongsStore(_FakeStore({"file://a.mp3": {"title": "A"}}))
+        probe = _LockProbe()
+        likes._lock = probe
+
+        _ = likes.as_entries()
+        likes.like("file://b.mp3", title="B")
+        likes.unlike("file://b.mp3")
+        likes.increment_play_count("file://a.mp3")
+
+        self.assertGreaterEqual(probe.acquire_count, 4)
+        self.assertEqual(probe.acquire_count, probe.release_count)
+
+    def test_concurrent_read_and_write_no_runtime_error(self):
+        """Adversarial: readers snapshotting the store while a writer
+        mutates it must never raise RuntimeError (dictionary changed size
+        during iteration).
+
+        The backing store here iterates in pure Python with a yield point
+        on every entry, the way JsonStorageXDG.store()'s json.dump walks
+        the dict — a C-level iteration would be atomic under the GIL and
+        the race would be undetectable. Replacing the store's lock with a
+        no-op makes this fail within ~2s.
+        """
+        likes = LikedSongsStore(_RacyStore({
+            f"file://{i}.mp3": {"title": f"T{i}", "play_count": i}
+            for i in range(20)
+        }))
+        errors = []
+        stop = threading.Event()
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    list(likes.as_entries())
+                except RuntimeError as e:
+                    errors.append(e)
+                    return
+
+        def writer():
+            i = 0
+            while not stop.is_set():
+                uri = f"file://{i % 40}.mp3"
+                try:
+                    if uri in likes:
+                        likes.unlike(uri)
+                    else:
+                        likes.like(uri, title="T")
+                except RuntimeError as e:
+                    errors.append(e)
+                    return
+                i += 1
+
+        threads = [threading.Thread(target=reader) for _ in range(4)]
+        threads.append(threading.Thread(target=writer))
+        for t in threads:
+            t.start()
+        time.sleep(2)
+        stop.set()
+        for t in threads:
+            t.join(timeout=2)
+
+        self.assertEqual(errors, [], f"race triggered: {errors}")
+
+
+class TestStoreSurface(unittest.TestCase):
+    def test_membership_and_length_read_the_backing_store(self):
+        likes = LikedSongsStore(_FakeStore({"file://a.mp3": {"title": "A"}}))
+        self.assertIn("file://a.mp3", likes)
+        self.assertNotIn("file://b.mp3", likes)
+        self.assertEqual(len(likes), 1)
+
+    def test_path_reports_the_backing_store_path(self):
+        likes = LikedSongsStore(_FakeStore())
+        self.assertEqual(likes.path, "/tmp/fake_liked_songs.json")
+
+    def test_items_returns_a_snapshot_not_a_live_view(self):
+        store = _FakeStore({"file://a.mp3": {"title": "A"}})
+        likes = LikedSongsStore(store)
+
+        snapshot = likes.items()
+        store["file://b.mp3"] = {"title": "B"}
+
+        self.assertEqual(len(snapshot), 1)
+
+    def test_defaults_to_the_persisted_xdg_store(self):
+        with unittest.mock.patch("ovos_media.catalog.likes.JsonStorageXDG") as mock:
+            mock.return_value = MagicMock(path="/xdg/OCP_liked_songs.json")
+            likes = LikedSongsStore()
+        self.assertEqual(likes.path, "/xdg/OCP_liked_songs.json")
+        mock.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_media_entry_shape.py
+++ b/test/unittests/test_media_entry_shape.py
@@ -11,7 +11,7 @@ Covers defects surfaced by the ecosystem audit:
   a NowPlaying instance directly used to raise
   ``TypeError: Type is not JSON serializable: NowPlaying`` whenever orjson
   was installed (the GUI-update/bus payload path via ``as_dict``).
-* ``OCPMediaCatalog.liked_songs_playlist`` used to return (and mutate) the raw
+* the liked-songs search used to return (and mutate) the raw
   persisted store dicts, mixing plain dicts with the MediaEntry objects the
   playback path expects and polluting the on-disk store.
 """
@@ -66,55 +66,52 @@ class TestNowPlayingSerializesAllFields(unittest.TestCase):
                           "file://track.mp3")
 
 
-class TestLikedSongsPlaylistShape(unittest.TestCase):
-    """liked_songs_playlist must yield canonical MediaEntry objects."""
+class TestSearchResultShape(unittest.TestCase):
+    """The liked-songs search yields dicts (the OCP search contract)
+    carrying the same data the MediaEntry path exposes as attributes."""
 
-    def _make_catalog(self, liked):
-        from ovos_media.player import OCPMediaCatalog
-        cat = OCPMediaCatalog.__new__(OCPMediaCatalog)
-        cat.liked_songs = dict(liked)
-        cat.skill_icon = "icon.svg"
-        cat.skill_id = "ovos.common_play"
-        return cat
+    def _make_skill(self, liked):
+        from ovos_media.catalog import LikedSongsStore
+        from ovos_media.skill import OCPVoiceSkill
 
-    def test_returns_media_entries_with_attribute_access(self):
-        cat = self._make_catalog({
-            "file://a.mp3": {"title": "Alpha", "play_count": 2},
-            "file://b.mp3": {"title": "Beta", "play_count": 5},
-        })
-        entries = cat.liked_songs_playlist
-        self.assertTrue(all(isinstance(e, MediaEntry) for e in entries))
-        # attribute access must work on every entry (the playback path uses it)
-        self.assertEqual([e.title for e in entries], ["Beta", "Alpha"])
-        self.assertTrue(all(e.playback == PlaybackType.AUDIO for e in entries))
-        self.assertTrue(all(e.media_type == MediaType.MUSIC for e in entries))
+        class _FakeStore(dict):
+            def store(self):
+                pass
 
-    def test_does_not_mutate_persisted_store(self):
-        stored = {"file://a.mp3": {"title": "Alpha", "play_count": 1}}
-        cat = self._make_catalog(stored)
-        _ = cat.liked_songs_playlist
-        # the raw store dict must not gain search-only keys
-        self.assertEqual(stored["file://a.mp3"],
-                         {"title": "Alpha", "play_count": 1})
+        skill = OCPVoiceSkill.__new__(OCPVoiceSkill)
+        skill.likes = LikedSongsStore(_FakeStore(liked))
+        skill.skill_icon = "icon.svg"
+        skill.skill_id = "ovos.common_play"
+        return skill
 
     def test_search_song_branch_yields_serializable_dicts(self):
-        cat = self._make_catalog(
+        skill = self._make_skill(
             {"file://a.mp3": {"title": "Alpha", "play_count": 1}})
 
-        def fake_voc_match(phrase):
-            return {"song_name": "alpha"}
-
-        with patch.object(cat, "ocp_voc_match", side_effect=fake_voc_match):
-            results = list(cat.search_db("alpha", MediaType.MUSIC))
+        with patch.object(skill, "ocp_voc_match",
+                          side_effect=lambda phrase: {"song_name": "alpha"}):
+            results = list(skill.search_db("alpha", MediaType.MUSIC))
 
         self.assertEqual(len(results), 1)
         r = results[0]
-        # yielded results are dicts (OCP search contract) but carry the same
-        # data the MediaEntry path exposes as attributes
         self.assertEqual(r["uri"], "file://a.mp3")
         self.assertEqual(r["title"], "Alpha")
         self.assertEqual(r["playback"], PlaybackType.AUDIO)
         self.assertEqual(MediaEntry.from_dict(r).title, "Alpha")
+
+    def test_playlist_branch_yields_the_liked_songs_most_played_first(self):
+        skill = self._make_skill({
+            "file://a.mp3": {"title": "Alpha", "play_count": 2},
+            "file://b.mp3": {"title": "Beta", "play_count": 5},
+        })
+
+        with patch.object(skill, "ocp_voc_match",
+                          side_effect=lambda phrase: {"playlist_name": "liked songs"}):
+            results = list(skill.search_db("liked songs", MediaType.MUSIC))
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual([t["title"] for t in results[0]["playlist"]],
+                         ["Beta", "Alpha"])
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_player_coverage.py
+++ b/test/unittests/test_player_coverage.py
@@ -582,13 +582,13 @@ class TestHandleInvalidMedia(unittest.TestCase):
 
     def test_speaks_track_failed_once(self):
         p = _make_player()
-        p.media.speak_dialog = MagicMock()
+        p.media.notify_dialog = MagicMock()
         p.handle_invalid_media(Message("ovos.common_play.media.state"))
-        p.media.speak_dialog.assert_called_once_with("track.failed")
+        p.media.notify_dialog.assert_called_once_with("track.failed")
         self.assertTrue(p._track_failed_spoken)
         # rate-limited: a second call must not speak again
         p.handle_invalid_media(Message("ovos.common_play.media.state"))
-        p.media.speak_dialog.assert_called_once_with("track.failed")
+        p.media.notify_dialog.assert_called_once_with("track.failed")
 
 
 # ---------------------------------------------------------------------------

--- a/test/unittests/test_player_coverage2.py
+++ b/test/unittests/test_player_coverage2.py
@@ -285,125 +285,19 @@ class TestPlayerPlayWithMpris(unittest.TestCase):
 
 
 class TestPlayerPlayWithLikedSongs(unittest.TestCase):
-    """Test play() with liked_songs play count tracking."""
+    """play() bumps the play count of the track it starts; the store owns
+    the write-through and the locking (see test_likes.py)."""
 
     def test_play_increments_liked_songs_play_count(self):
-        """play() should increment play_count for liked songs."""
         p = _make_player()
         p.now_playing.uri = "http://liked.mp3"
-        # Create a mock object that acts like a dict with a store() method
-        liked_songs_mock = MagicMock()
-        liked_songs_dict = {"http://liked.mp3": {"title": "Liked"}}
-        liked_songs_mock.__getitem__.side_effect = liked_songs_dict.__getitem__
-        liked_songs_mock.__setitem__.side_effect = liked_songs_dict.__setitem__
-        liked_songs_mock.__contains__.side_effect = liked_songs_dict.__contains__
-        liked_songs_mock.get.side_effect = liked_songs_dict.get
-        p.media.liked_songs = liked_songs_mock
 
         with patch.object(p, "validate_stream", return_value=True), \
              patch.object(p, "set_player_state"):
             p.play()
 
-        # Check that play_count was incremented
-        self.assertEqual(liked_songs_dict["http://liked.mp3"]["play_count"], 1)
-        liked_songs_mock.store.assert_called_once()
-
-    def test_play_survives_liked_song_popped_between_check_and_index(self):
-        """play() must not raise KeyError when another bus-handler thread
-        (handle_unlike) pops the now-playing uri from liked_songs between
-        the membership check and the play_count mutation - a real race,
-        since bus handlers dispatch on a thread pool."""
-        p = _make_player()
-        p.now_playing.uri = "http://liked.mp3"
-
-        class _PoppedBetweenCheckAndIndex(dict):
-            """Membership looks True (the entry existed a moment ago) but
-            indexing/`.get()` raises/returns None as if it was concurrently
-            popped - simulates the race window without needing real
-            threads."""
-
-            def __contains__(self, key):
-                return True
-
-            def __getitem__(self, key):
-                raise KeyError(key)
-
-            def get(self, key, default=None):
-                return default
-
-        liked_songs = _PoppedBetweenCheckAndIndex()
-        liked_songs.store = MagicMock()
-        p.media.liked_songs = liked_songs
-
-        with patch.object(p, "validate_stream", return_value=True), \
-             patch.object(p, "set_player_state"):
-            p.play()  # must not raise KeyError
-
-        # no entry to mutate - store() must not be called
-        liked_songs.store.assert_not_called()
-
-
-class _LockProbe:
-    """Records acquire()/release() calls, standing in for an RLock so a
-    test can assert a critical section actually took the lock."""
-
-    def __init__(self):
-        self.acquire_count = 0
-        self.release_count = 0
-
-    def __enter__(self):
-        self.acquire_count += 1
-        return self
-
-    def __exit__(self, *exc):
-        self.release_count += 1
-        return False
-
-
-class TestLikedSongsLockSerialization(unittest.TestCase):
-    """D4: liked_songs.store() (json.dump) iterates the dict while
-    handle_like/handle_unlike/play()'s play-count block can mutate it from
-    other bus-dispatch threads - all three sites must go through the same
-    _liked_songs_lock. Fails on the old code because the lock attribute
-    doesn't exist / isn't held around these sites."""
-
-    def test_play_play_count_block_holds_liked_songs_lock(self):
-        p = _make_player()
-        p.now_playing.uri = "http://liked.mp3"
-        liked_songs_mock = MagicMock()
-        liked_songs_dict = {"http://liked.mp3": {"title": "Liked"}}
-        liked_songs_mock.__getitem__.side_effect = liked_songs_dict.__getitem__
-        liked_songs_mock.__setitem__.side_effect = liked_songs_dict.__setitem__
-        liked_songs_mock.__contains__.side_effect = liked_songs_dict.__contains__
-        liked_songs_mock.get.side_effect = liked_songs_dict.get
-        p.media.liked_songs = liked_songs_mock
-
-        probe = _LockProbe()
-        p._liked_songs_lock = probe
-
-        with patch.object(p, "validate_stream", return_value=True), \
-             patch.object(p, "set_player_state"):
-            p.play()
-
-        self.assertGreaterEqual(probe.acquire_count, 1)
-        self.assertEqual(probe.acquire_count, probe.release_count)
-        liked_songs_mock.store.assert_called_once()
-
-    def test_handle_unlike_holds_liked_songs_lock(self):
-        p = _make_player()
-        p.media.liked_songs = MagicMock()
-        p.media.liked_songs.__contains__ = MagicMock(return_value=True)
-
-        probe = _LockProbe()
-        p._liked_songs_lock = probe
-
-        from ovos_bus_client.message import Message
-        p.handle_unlike(Message("ovos.common_play.unlike", {"uri": "http://liked.mp3"}))
-
-        self.assertGreaterEqual(probe.acquire_count, 1)
-        self.assertEqual(probe.acquire_count, probe.release_count)
-        p.media.liked_songs.pop.assert_called_once()
-        p.media.liked_songs.store.assert_called_once()
+        p.media.likes.increment_play_count.assert_called_once_with(
+            "http://liked.mp3")
 
 
 class TestPlayerValidateStreamException(unittest.TestCase):

--- a/test/unittests/test_player_handlers.py
+++ b/test/unittests/test_player_handlers.py
@@ -642,7 +642,7 @@ class TestNowPlayingAsDict(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestHandleLikeUnlike(unittest.TestCase):
-    """handle_like and handle_unlike update media.liked_songs."""
+    """handle_like and handle_unlike write through the liked-songs store."""
 
     def test_like_stores_track(self):
         p = _make_player()
@@ -650,26 +650,23 @@ class TestHandleLikeUnlike(unittest.TestCase):
         uri = "http://example.com/song.mp3"
         msg = Message("ovos.common_play.like", {"uri": uri, "title": "Song", "artist": "Artist", "image": ""})
         p.handle_like(msg)
-        p.media.liked_songs.__setitem__.assert_called()
-        p.media.liked_songs.store.assert_called_once()
+        p.media.likes.like.assert_called_once_with(uri, title="Song",
+                                                   artist="Artist", image="")
 
-    def test_unlike_removes_track_when_present(self):
+    def test_unlike_removes_track(self):
         p = _make_player()
         uri = "http://example.com/song.mp3"
         p.now_playing.original_uri = uri
-        p.media.liked_songs.__contains__ = MagicMock(return_value=True)
         msg = Message("ovos.common_play.unlike", {"uri": uri})
         p.handle_unlike(msg)
-        p.media.liked_songs.pop.assert_called_once_with(uri)
-        p.media.liked_songs.store.assert_called_once()
+        p.media.likes.unlike.assert_called_once_with(uri)
 
-    def test_unlike_noop_when_not_present(self):
+    def test_unlike_falls_back_to_the_now_playing_uri(self):
         p = _make_player()
-        uri = "http://example.com/song.mp3"
-        p.media.liked_songs.__contains__ = MagicMock(return_value=False)
-        msg = Message("ovos.common_play.unlike", {"uri": uri})
-        p.handle_unlike(msg)
-        p.media.liked_songs.pop.assert_not_called()
+        p.now_playing.original_uri = "http://example.com/current.mp3"
+        p.handle_unlike(Message("ovos.common_play.unlike", {}))
+        p.media.likes.unlike.assert_called_once_with(
+            "http://example.com/current.mp3")
 
 
 # ---------------------------------------------------------------------------

--- a/test/unittests/test_service_voice_wiring.py
+++ b/test/unittests/test_service_voice_wiring.py
@@ -1,0 +1,75 @@
+"""The production wiring between the player, its catalog and the voice
+front-end.
+
+Every other MediaService test patches OCPVoiceSkill out, so nothing there
+notices if the skill stops being handed the catalog to listen on, or stops
+sharing the player's liked-songs store. This builds the real thing on a
+FakeBus — a real MediaService, a real OCPMediaPlayer and a real
+OCPVoiceSkill — and pins the two wires MediaService is responsible for.
+"""
+import unittest
+from unittest.mock import patch
+
+from ovos_utils.fakebus import FakeBus
+
+
+class TestVoiceSkillWiring(unittest.TestCase):
+
+    def setUp(self):
+        from ovos_media.service import MediaService
+        self.bus = FakeBus()
+        self.service = MediaService(bus=self.bus)
+        self.addCleanup(self.service.shutdown)
+
+    def test_player_dialog_notification_reaches_the_skill(self):
+        """The player announces a failed track by notifying its catalog;
+        the skill listening on that catalog is what turns it into speech.
+        Fails if MediaService stops handing the catalog to the skill."""
+        with patch.object(self.service.voice_skill, "speak_dialog") as speak:
+            self.service.ocp.handle_invalid_media()
+
+        speak.assert_called_once_with("track.failed", None)
+
+    def test_skill_speaks_on_the_bus_end_to_end(self):
+        """The same path with nothing stubbed: a real dialog reaches a real
+        'speak' message."""
+        spoken = []
+        self.bus.on("speak", lambda m: spoken.append(m.data["utterance"]))
+
+        self.service.ocp.handle_invalid_media()
+
+        self.assertEqual(len(spoken), 1)
+        self.assertTrue(spoken[0])
+
+    def test_player_and_skill_share_one_liked_songs_store(self):
+        """A like written through the player must be visible to the search
+        the skill answers - they have to be the same object, not two stores
+        over the same file."""
+        self.assertIs(self.service.voice_skill.likes,
+                      self.service.ocp.media.likes)
+
+    def test_a_like_written_by_the_player_is_searchable_by_the_skill(self):
+        """The identity above, exercised: nothing is persisted, the store's
+        write-through is stubbed."""
+        likes = self.service.voice_skill.likes
+        with patch.object(likes._store, "store"):
+            self.service.ocp.media.likes.like("http://x.mp3", title="Xylophone")
+            try:
+                with patch.object(self.service.voice_skill, "ocp_voc_match",
+                                  side_effect=lambda phrase: {"song_name": "xylophone"}):
+                    results = list(
+                        self.service.voice_skill.search_db("xylophone", None))
+                self.assertEqual([r["title"] for r in results], ["Xylophone"])
+            finally:
+                self.service.ocp.media.likes.unlike("http://x.mp3")
+
+    def test_the_skill_keeps_the_catalog_skill_id(self):
+        """The OCP pipeline keys search results and keyword registrations
+        off this id."""
+        from ovos_utils.ocp import OCP_ID
+        self.assertEqual(self.service.voice_skill.skill_id,
+                         OCP_ID + ".favorites")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_shuffle_bounds_and_handler_cleanup.py
+++ b/test/unittests/test_shuffle_bounds_and_handler_cleanup.py
@@ -146,7 +146,7 @@ class TestShuffleAllFailedBounded(unittest.TestCase):
 
         mock_play.assert_not_called()
         mock_state.assert_called_once_with(PlayerState.STOPPED)
-        p.media.speak_dialog.assert_called_once_with("queue.finished")
+        p.media.notify_dialog.assert_called_once_with("queue.finished")
 
 
 class TestDeadPlayerStopsHandlingDuckTopics(unittest.TestCase):
@@ -209,7 +209,7 @@ class TestShuffleEmptyQueueFailedTrackBounded(unittest.TestCase):
 
         mock_play.assert_not_called()
         mock_state.assert_called_once_with(PlayerState.STOPPED)
-        p.media.speak_dialog.assert_called_once_with("queue.finished")
+        p.media.notify_dialog.assert_called_once_with("queue.finished")
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_voice_skill.py
+++ b/test/unittests/test_voice_skill.py
@@ -11,17 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the "what's playing" / shuffle voice intents on OCPMediaCatalog.
+"""Tests for OCPVoiceSkill: the "what's playing" / shuffle voice intents,
+the dialogs the player asks it to announce, and the liked-songs search.
 
 See https://github.com/OpenVoiceOS/ovos-media/issues/23
 
-OCPMediaCatalog is a real OVOSCommonPlaybackSkill (ovos_media/player.py), so
-it is instantiated directly (not mocked) with a real FakeBus, exactly the way
-OCPMediaPlayer wires it up in production. Because the intent handlers query
-now-playing state via the existing 'ovos.common_play.status' request/response
-bus API (the same one OCPMediaPlayer.handle_status answers), a lightweight
-FakeBus responder stands in for the player here — no bus messages beyond the
-ones ovos-media already defines are used anywhere in this file.
+OCPVoiceSkill is a real OVOSCommonPlaybackSkill, so it is instantiated
+directly (not mocked) with a real FakeBus, exactly the way MediaService
+wires it up in production. Because the intent handlers query now-playing
+state via the existing 'ovos.common_play.status' request/response bus API
+(the same one OCPMediaPlayer.handle_status answers), a lightweight FakeBus
+responder stands in for the player here — no bus messages beyond the ones
+ovos-media already defines are used anywhere in this file.
 """
 import unittest
 from unittest.mock import MagicMock, patch
@@ -31,22 +32,42 @@ from ovos_bus_client.session import Session, SessionManager
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.ocp import LoopState, MediaState, MediaType, PlaybackType, PlayerState
 
-from ovos_media.player import OCPMediaCatalog, OCPMediaPlayer
+from ovos_media.catalog import LikedSongsStore, MediaCatalog
 
 
-def _make_catalog(status: dict, validate_source: bool = True):
-    """Return a real OCPMediaCatalog wired to a FakeBus that answers
+class _FakeStore(dict):
+    """The JsonStorageXDG surface LikedSongsStore writes through, without
+    touching disk."""
+
+    def store(self):
+        pass
+
+
+def _likes(entries=None):
+    return LikedSongsStore(_FakeStore(entries or {}))
+from ovos_media.player import OCPMediaPlayer
+from ovos_media.skill import OCPVoiceSkill
+
+SKILL_ID = "ovos.common_play.favorites"
+
+
+def _make_skill(bus, **kwargs):
+    kwargs.setdefault("likes", _likes())
+    return OCPVoiceSkill(bus=bus, skill_id=SKILL_ID, **kwargs)
+
+
+def _make_wired_skill(status: dict, validate_source: bool = True):
+    """Return a real OCPVoiceSkill wired to a FakeBus that answers
     'ovos.common_play.status' requests with the given canned status dict.
     """
     bus = FakeBus()
     bus.on("ovos.common_play.status",
           lambda m: bus.emit(m.response(dict(status))))
-    catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites",
-                              validate_source=validate_source)
+    skill = _make_skill(bus, validate_source=validate_source)
 
     spoken = []
     bus.on("speak", lambda m: spoken.append(m.data["utterance"]))
-    return catalog, bus, spoken
+    return skill, bus, spoken
 
 
 _NOTHING_PLAYING_LINES = {
@@ -73,21 +94,21 @@ NOTHING_PLAYING_STATUS = {"title": "", "artist": "", "shuffle": False}
 
 class TestWhatSong(unittest.TestCase):
     def test_speaks_title_and_artist_when_playing(self):
-        catalog, bus, spoken = _make_catalog(PLAYING_STATUS)
-        catalog.handle_what_song(Message("WhatSong"))
+        skill, bus, spoken = _make_wired_skill(PLAYING_STATUS)
+        skill.handle_what_song(Message("WhatSong"))
         self.assertEqual(len(spoken), 1)
         self.assertIn("Bohemian Rhapsody", spoken[0])
         self.assertIn("Queen", spoken[0])
 
     def test_speaks_title_only_when_no_artist(self):
-        catalog, bus, spoken = _make_catalog(NO_ARTIST_STATUS)
-        catalog.handle_what_song(Message("WhatSong"))
+        skill, bus, spoken = _make_wired_skill(NO_ARTIST_STATUS)
+        skill.handle_what_song(Message("WhatSong"))
         self.assertEqual(len(spoken), 1)
         self.assertIn("Unknown Track", spoken[0])
 
     def test_speaks_nothing_playing_dialog_when_idle(self):
-        catalog, bus, spoken = _make_catalog(NOTHING_PLAYING_STATUS)
-        catalog.handle_what_song(Message("WhatSong"))
+        skill, bus, spoken = _make_wired_skill(NOTHING_PLAYING_STATUS)
+        skill.handle_what_song(Message("WhatSong"))
         self.assertEqual(len(spoken), 1)
         _assert_nothing_playing(self, spoken[0])
 
@@ -96,10 +117,10 @@ class TestWhatSong(unittest.TestCase):
         # A timeout (player unreachable) must NOT be confused with an
         # answered-but-idle status (nothing playing) - see issue review.
         bus = FakeBus()
-        catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+        skill = _make_skill(bus)
         spoken = []
         bus.on("speak", lambda m: spoken.append(m.data["utterance"]))
-        catalog.handle_what_song(Message("WhatSong"))
+        skill.handle_what_song(Message("WhatSong"))
         self.assertEqual(len(spoken), 1)
         self.assertNotIn(spoken[0].lower(), _NOTHING_PLAYING_LINES)
         self.assertIn(spoken[0].lower(), _NOT_RESPONDING_LINES)
@@ -114,7 +135,7 @@ class TestWhatSong(unittest.TestCase):
         bus = FakeBus()
         bus.on("ovos.common_play.status",
               lambda m: bus.emit(m.response(dict(PLAYING_STATUS))))
-        catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+        skill = _make_skill(bus)
 
         captured = []
         bus.on("ovos.common_play.status", lambda m: captured.append(m))
@@ -122,7 +143,7 @@ class TestWhatSong(unittest.TestCase):
         incoming = Message("WhatSong")
         incoming.context["session"] = Session(session_id="sat-status-99").serialize()
 
-        catalog.handle_what_song(incoming)
+        skill.handle_what_song(incoming)
 
         self.assertEqual(len(captured), 1)
         self.assertEqual(SessionManager.get(captured[0]).session_id, "sat-status-99")
@@ -130,29 +151,29 @@ class TestWhatSong(unittest.TestCase):
 
 class TestWhatArtist(unittest.TestCase):
     def test_speaks_artist_when_playing(self):
-        catalog, bus, spoken = _make_catalog(PLAYING_STATUS)
-        catalog.handle_what_artist(Message("WhatArtist"))
+        skill, bus, spoken = _make_wired_skill(PLAYING_STATUS)
+        skill.handle_what_artist(Message("WhatArtist"))
         self.assertEqual(len(spoken), 1)
         self.assertIn("Queen", spoken[0])
 
     def test_speaks_no_artist_info_when_artist_missing(self):
-        catalog, bus, spoken = _make_catalog(NO_ARTIST_STATUS)
-        catalog.handle_what_artist(Message("WhatArtist"))
+        skill, bus, spoken = _make_wired_skill(NO_ARTIST_STATUS)
+        skill.handle_what_artist(Message("WhatArtist"))
         self.assertEqual(len(spoken), 1)
         self.assertIn("don't", spoken[0].lower())
 
     def test_speaks_nothing_playing_dialog_when_idle(self):
-        catalog, bus, spoken = _make_catalog(NOTHING_PLAYING_STATUS)
-        catalog.handle_what_artist(Message("WhatArtist"))
+        skill, bus, spoken = _make_wired_skill(NOTHING_PLAYING_STATUS)
+        skill.handle_what_artist(Message("WhatArtist"))
         self.assertEqual(len(spoken), 1)
         _assert_nothing_playing(self, spoken[0])
 
     def test_no_status_response_speaks_not_responding(self):
         bus = FakeBus()
-        catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+        skill = _make_skill(bus)
         spoken = []
         bus.on("speak", lambda m: spoken.append(m.data["utterance"]))
-        catalog.handle_what_artist(Message("WhatArtist"))
+        skill.handle_what_artist(Message("WhatArtist"))
         self.assertEqual(len(spoken), 1)
         self.assertIn(spoken[0].lower(), _NOT_RESPONDING_LINES)
 
@@ -163,60 +184,60 @@ class TestWhatAlbum(unittest.TestCase):
     playing (see handle_what_album docstring/comment)."""
 
     def test_speaks_no_album_info_when_playing(self):
-        catalog, bus, spoken = _make_catalog(PLAYING_STATUS)
-        catalog.handle_what_album(Message("WhatAlbum"))
+        skill, bus, spoken = _make_wired_skill(PLAYING_STATUS)
+        skill.handle_what_album(Message("WhatAlbum"))
         self.assertEqual(len(spoken), 1)
         self.assertIn("album", spoken[0].lower())
 
     def test_speaks_nothing_playing_dialog_when_idle(self):
-        catalog, bus, spoken = _make_catalog(NOTHING_PLAYING_STATUS)
-        catalog.handle_what_album(Message("WhatAlbum"))
+        skill, bus, spoken = _make_wired_skill(NOTHING_PLAYING_STATUS)
+        skill.handle_what_album(Message("WhatAlbum"))
         self.assertEqual(len(spoken), 1)
         _assert_nothing_playing(self, spoken[0])
 
     def test_no_status_response_speaks_not_responding(self):
         bus = FakeBus()
-        catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+        skill = _make_skill(bus)
         spoken = []
         bus.on("speak", lambda m: spoken.append(m.data["utterance"]))
-        catalog.handle_what_album(Message("WhatAlbum"))
+        skill.handle_what_album(Message("WhatAlbum"))
         self.assertEqual(len(spoken), 1)
         self.assertIn(spoken[0].lower(), _NOT_RESPONDING_LINES)
 
 
 class TestShuffleIntents(unittest.TestCase):
     def test_shuffle_on_emits_existing_shuffle_set_message_and_speaks(self):
-        catalog, bus, spoken = _make_catalog(PLAYING_STATUS)
+        skill, bus, spoken = _make_wired_skill(PLAYING_STATUS)
         received = []
         bus.on("ovos.common_play.shuffle.set", lambda m: received.append(m))
-        catalog.handle_shuffle_on(Message("ShuffleOn"))
+        skill.handle_shuffle_on(Message("ShuffleOn"))
         self.assertEqual(len(received), 1)
         self.assertEqual(len(spoken), 1)
 
     def test_shuffle_off_emits_existing_shuffle_unset_message_and_speaks(self):
-        catalog, bus, spoken = _make_catalog(PLAYING_STATUS)
+        skill, bus, spoken = _make_wired_skill(PLAYING_STATUS)
         received = []
         bus.on("ovos.common_play.shuffle.unset", lambda m: received.append(m))
-        catalog.handle_shuffle_off(Message("ShuffleOff"))
+        skill.handle_shuffle_off(Message("ShuffleOff"))
         self.assertEqual(len(received), 1)
         self.assertEqual(len(spoken), 1)
 
     def test_shuffle_on_flips_shuffle_flag_via_existing_handler(self):
         """The 'ovos.common_play.shuffle.set'/'unset' messages the intents
         emit are the same ones OCPMediaPlayer.handle_set_shuffle /
-        handle_unset_shuffle already listen for (register_bus_handlers) —
+        handle_unset_shuffle already listen for (see ovos_media.bus.api) —
         registering that exact pair here (without constructing a full
         OCPMediaPlayer, which needs a live service stack) demonstrates no
         new bus message types were introduced."""
-        catalog, bus, spoken = _make_catalog(PLAYING_STATUS)
+        skill, bus, spoken = _make_wired_skill(PLAYING_STATUS)
         state = {"shuffle": False}
         bus.on("ovos.common_play.shuffle.set", lambda m: state.update(shuffle=True))
         bus.on("ovos.common_play.shuffle.unset", lambda m: state.update(shuffle=False))
 
-        catalog.handle_shuffle_on(Message("ShuffleOn"))
+        skill.handle_shuffle_on(Message("ShuffleOn"))
         self.assertTrue(state["shuffle"])
 
-        catalog.handle_shuffle_off(Message("ShuffleOff"))
+        skill.handle_shuffle_off(Message("ShuffleOff"))
         self.assertFalse(state["shuffle"])
 
 
@@ -226,7 +247,7 @@ def _make_real_player(bus, title="Bohemian Rhapsody", artist="Queen"):
     responses and the real payload shape (title/artist keys etc) is proven,
     per the backcompat audit's F5 finding. Mirrors the construction pattern
     used in test_player_handlers.py._make_player - external services are
-    mocked, but handle_status/register_bus_handlers are real.
+    mocked, but handle_status/the bus edge are real.
     """
     with patch("ovos_media.player.AudioService"), \
          patch("ovos_media.player.VideoService"), \
@@ -265,17 +286,17 @@ def _make_real_player(bus, title="Bohemian Rhapsody", artist="Queen"):
 
 class TestRealPlayerStatusResponder(unittest.TestCase):
     """Proves the real OCPMediaPlayer.handle_status payload (not a canned
-    lambda) carries the title/artist keys the catalog handlers read - see
+    lambda) carries the title/artist keys the intent handlers read - see
     backcompat audit F5."""
 
     def test_what_song_reads_real_player_payload(self):
         bus = FakeBus()
         _make_real_player(bus, title="Real Song", artist="Real Artist")
-        catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+        skill = _make_skill(bus)
         spoken = []
         bus.on("speak", lambda m: spoken.append(m.data["utterance"]))
 
-        catalog.handle_what_song(Message("WhatSong"))
+        skill.handle_what_song(Message("WhatSong"))
 
         self.assertEqual(len(spoken), 1)
         self.assertIn("Real Song", spoken[0])
@@ -284,7 +305,7 @@ class TestRealPlayerStatusResponder(unittest.TestCase):
 
 class TestFiveIntentsRegistered(unittest.TestCase):
     """False-green guard (backcompat audit finding #2): if any of the five
-    new .intent files were ever removed/renamed, this must fail instead of
+    .intent files were ever removed/renamed, this must fail instead of
     passing silently. Asserts the actual padatious registration messages
     OVOSCommonPlaybackSkill.register_intent_file emits, with the expected
     intent file names, rather than relying on the handlers being reachable
@@ -296,7 +317,7 @@ class TestFiveIntentsRegistered(unittest.TestCase):
         bus.on("padatious:register_intent",
               lambda m: registrations.append(m.data))
 
-        OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+        _make_skill(bus)
 
         # ovos-workshop registers under the authoring name ("WhatSong.intent")
         # on older versions and the canonical name ("WhatSong") after the
@@ -311,11 +332,11 @@ class TestFiveIntentsRegistered(unittest.TestCase):
 
 
 class TestShuffleSessionGate(unittest.TestCase):
-    """OCPMediaPlayer.handle_set_shuffle/handle_unset_shuffle
-    are gated by @require_default_session() and silently drop the action on a
-    non-default (e.g. HiveMind satellite) session. The catalog's shuffle
-    intent handlers must not claim success (speak "shuffle.on"/"shuffle.off")
-    when that's about to happen - they must mirror the gate themselves."""
+    """OCPMediaPlayer.handle_set_shuffle/handle_unset_shuffle are gated by
+    session at the bus edge and silently drop the action on a non-default
+    (e.g. HiveMind satellite) session. The shuffle intent handlers must not
+    claim success (speak "shuffle.on"/"shuffle.off") when that's about to
+    happen - they must mirror the gate themselves."""
 
     def _named_session_message(self, msg_type):
         m = Message(msg_type)
@@ -323,11 +344,11 @@ class TestShuffleSessionGate(unittest.TestCase):
         return m
 
     def test_shuffle_on_does_not_claim_success_on_named_session(self):
-        catalog, bus, spoken = _make_catalog(PLAYING_STATUS)
+        skill, bus, spoken = _make_wired_skill(PLAYING_STATUS)
         received = []
         bus.on("ovos.common_play.shuffle.set", lambda m: received.append(m))
 
-        catalog.handle_shuffle_on(self._named_session_message("ShuffleOn"))
+        skill.handle_shuffle_on(self._named_session_message("ShuffleOn"))
 
         self.assertEqual(len(received), 0)
         self.assertEqual(len(spoken), 1)
@@ -336,40 +357,81 @@ class TestShuffleSessionGate(unittest.TestCase):
             self.assertNotEqual(spoken[0].lower(), line)
 
     def test_shuffle_off_does_not_claim_success_on_named_session(self):
-        catalog, bus, spoken = _make_catalog(PLAYING_STATUS)
+        skill, bus, spoken = _make_wired_skill(PLAYING_STATUS)
         received = []
         bus.on("ovos.common_play.shuffle.unset", lambda m: received.append(m))
 
-        catalog.handle_shuffle_off(self._named_session_message("ShuffleOff"))
+        skill.handle_shuffle_off(self._named_session_message("ShuffleOff"))
 
         self.assertEqual(len(received), 0)
         self.assertEqual(len(spoken), 1)
 
     def test_shuffle_on_still_acts_on_default_session(self):
-        catalog, bus, spoken = _make_catalog(PLAYING_STATUS)
+        skill, bus, spoken = _make_wired_skill(PLAYING_STATUS)
         received = []
         bus.on("ovos.common_play.shuffle.set", lambda m: received.append(m))
 
-        catalog.handle_shuffle_on(Message("ShuffleOn"))
+        skill.handle_shuffle_on(Message("ShuffleOn"))
 
         self.assertEqual(len(received), 1)
         self.assertEqual(len(spoken), 1)
 
     def test_shuffle_on_acts_on_named_session_when_validate_source_false(self):
         # media.validate_source: false is the documented satellite config
-        # (see ovos_media/utils.py:50-52 / service.py:55-60): the player
-        # itself will execute the shuffle.set on ANY session in that mode,
-        # so the catalog's own gate must agree and not refuse it.
-        catalog, bus, spoken = _make_catalog(PLAYING_STATUS, validate_source=False)
+        # (see ovos_media/utils.py / service.py): the player itself will
+        # execute the shuffle.set on ANY session in that mode, so this
+        # front-end's own gate must agree and not refuse it.
+        skill, bus, spoken = _make_wired_skill(PLAYING_STATUS,
+                                               validate_source=False)
         received = []
         bus.on("ovos.common_play.shuffle.set", lambda m: received.append(m))
 
-        catalog.handle_shuffle_on(self._named_session_message("ShuffleOn"))
+        skill.handle_shuffle_on(self._named_session_message("ShuffleOn"))
 
         self.assertEqual(len(received), 1)
         self.assertEqual(len(spoken), 1)
         self.assertIn("shuffl", spoken[0].lower())
         self.assertNotIn("can't control", spoken[0].lower())
+
+
+class TestDialogNotifications(unittest.TestCase):
+    """The player never speaks: it notifies its catalog, and this skill is
+    the listener that turns a notification into real speech. Without the
+    skill attached the notification must be dropped silently."""
+
+    def test_notified_dialog_is_spoken(self):
+        bus = FakeBus()
+        catalog = MediaCatalog(bus, _likes())
+        _make_skill(bus, catalog=catalog)
+        spoken = []
+        bus.on("speak", lambda m: spoken.append(m.data["utterance"]))
+
+        catalog.notify_dialog("track.failed")
+
+        self.assertEqual(len(spoken), 1)
+        self.assertTrue(spoken[0])
+
+    def test_notification_without_a_listener_is_silent(self):
+        bus = FakeBus()
+        catalog = MediaCatalog(bus, _likes())
+        spoken = []
+        bus.on("speak", lambda m: spoken.append(m.data["utterance"]))
+
+        catalog.notify_dialog("track.failed")
+
+        self.assertEqual(spoken, [])
+
+    def test_shutdown_stops_the_skill_speaking_notifications(self):
+        bus = FakeBus()
+        catalog = MediaCatalog(bus, _likes())
+        skill = _make_skill(bus, catalog=catalog)
+        spoken = []
+        bus.on("speak", lambda m: spoken.append(m.data["utterance"]))
+
+        skill.default_shutdown()
+        catalog.notify_dialog("track.failed")
+
+        self.assertEqual(spoken, [])
 
 
 class TestConstructsWithoutAhocorasickNer(unittest.TestCase):
@@ -381,23 +443,23 @@ class TestConstructsWithoutAhocorasickNer(unittest.TestCase):
     depend on it and must keep registering normally. The OCP pipeline
     classifier should still learn the keywords via the
     'ovos.common_play.register_keyword' bus message even without local NER
-    (see OCPMediaCatalog._emit_ocp_keyword_registration).
+    (see ovos_media.catalog.keywords.KeywordRegistrar).
 
     Simulates ahocorasick_ner's absence by patching ovos_workshop's already-
     imported AhocorasickNER symbol to None (the same state
     ovos_workshop.skills.common_play ends up in when the real import
-    fails), then constructs OCPMediaCatalog."""
+    fails), then constructs the skill."""
 
-    def test_catalog_constructs_and_registers_intents_without_ner(self):
+    def test_skill_constructs_and_registers_intents_without_ner(self):
         with patch("ovos_workshop.skills.common_play.AhocorasickNER", None):
             bus = FakeBus()
             registrations = []
             bus.on("padatious:register_intent",
                   lambda m: registrations.append(m.data))
 
-            catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+            skill = _make_skill(bus)
 
-            self.assertIsNotNone(catalog)
+            self.assertIsNotNone(skill)
             # accept both the authoring ("WhatSong.intent") and canonical
             # ("WhatSong") registration spellings across workshop versions
             names = {r.get("name", "").split(":")[-1].removesuffix(".intent")
@@ -410,8 +472,8 @@ class TestConstructsWithoutAhocorasickNer(unittest.TestCase):
         it must not crash, but it also must not find liked-songs matches."""
         with patch("ovos_workshop.skills.common_play.AhocorasickNER", None):
             bus = FakeBus()
-            catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
-            results = list(catalog.search_db("play my liked songs", MediaType.MUSIC))
+            skill = _make_skill(bus)
+            results = list(skill.search_db("play my liked songs", MediaType.MUSIC))
             self.assertEqual(results, [])
 
     def test_classifier_still_learns_keywords_without_ner(self):
@@ -424,7 +486,7 @@ class TestConstructsWithoutAhocorasickNer(unittest.TestCase):
             bus.on("ovos.common_play.register_keyword",
                   lambda m: registered.append(m.data))
 
-            OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+            _make_skill(bus)
 
             labels = {r["label"] for r in registered}
             self.assertIn("playlist_name", labels)
@@ -443,60 +505,13 @@ class TestConstructsWithoutAhocorasickNer(unittest.TestCase):
             bus.on("ovos.common_play.register_keyword",
                   lambda m: registered.append(m.data))
 
-            OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
+            _make_skill(bus, likes=_likes())
 
             song_name_msgs = [r for r in registered if r["label"] == "song_name"]
             self.assertEqual(len(song_name_msgs), 1)
             self.assertEqual(song_name_msgs[0]["samples"], [])
             self.assertEqual(set(song_name_msgs[0].keys()),
                               {"skill_id", "label", "samples", "media_type"})
-
-
-class TestSkillAnnounceMediaTypesNormalization(unittest.TestCase):
-    """D2: a skill announcing with the singular "media_type" key can send
-    a bare scalar (eg. an int), which used to be stored as-is and blow up
-    get_featured_skills()'s "in media_types" membership checks."""
-
-    def _announce(self, catalog, bus, **data):
-        catalog.handle_skill_announce(Message("ovos.common_play.announce", data))
-
-    def test_singular_int_media_type_is_featured_and_does_not_raise(self):
-        bus = FakeBus()
-        catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
-        self._announce(catalog, bus,
-                       skill_id="skill.a", skill_name="A",
-                       featured_tracks=["t1"],
-                       media_type=int(MediaType.MUSIC))
-
-        skills = catalog.get_featured_skills()  # must not raise
-
-        self.assertEqual(len(skills), 1)
-        self.assertEqual(skills[0]["skill_id"], "skill.a")
-
-    def test_plural_list_media_types_still_works(self):
-        bus = FakeBus()
-        catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
-        self._announce(catalog, bus,
-                       skill_id="skill.b", skill_name="B",
-                       featured_tracks=["t1"],
-                       media_types=[MediaType.MUSIC])
-
-        skills = catalog.get_featured_skills()
-
-        self.assertEqual(len(skills), 1)
-        self.assertEqual(skills[0]["skill_id"], "skill.b")
-
-    def test_adult_singular_media_type_is_filtered_out(self):
-        bus = FakeBus()
-        catalog = OCPMediaCatalog(bus=bus, skill_id="ovos.common_play.favorites")
-        self._announce(catalog, bus,
-                       skill_id="skill.c", skill_name="C",
-                       featured_tracks=["t1"],
-                       media_type=int(MediaType.ADULT))
-
-        skills = catalog.get_featured_skills()  # must not raise
-
-        self.assertEqual(skills, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

The media catalog was a single 370-line `OVOSCommonPlaybackSkill` subclass doing four unrelated jobs at once: it kept the roster of announced OCP skills and the search results, it owned the persisted liked-songs store and its lock, it registered OCP keywords, and it was the skill holding the media intents and every dialog the daemon speaks. This splits it along those seams. `ovos_media/catalog/` holds three plain objects — `MediaCatalog` (skill roster, featured-media filter, search playlist), `LikedSongsStore` (the JSON store, the lock, malformed-entry tolerance, like/unlike/play-count write-through) and `KeywordRegistrar` (title normalization plus the bus half that keeps the OCP classifier informed when the optional `ner` extra is missing). `ovos_media/skill.py` holds `OCPVoiceSkill`, a real but thin skill: the five intents, the liked-songs search, and all the dialogs.

The player no longer speaks. `speak_dialog` calls inside playback code (`track.failed`, `queue.finished`, `no.playback.backend`, the empty-like `nothing.playing`) are now `MediaCatalog.notify_dialog` calls, an in-process callback the voice skill registers itself on; no new bus message types are involved, and a listener that raises can no longer abort playback. A player with no voice front-end attached is silent instead of reaching into a skill it does not own. `MediaService` builds the one `LikedSongsStore` and hands it to both the player and the skill, so likes written by the GUI-facing `ovos.common_play.like` handler and searches answered by the skill see the same object. The skill keeps the `OCP_ID + ".favorites"` id, so its search results and keyword registrations are identical on the wire.

`ovos_media.player.OCPMediaCatalog` stays importable and stays the name the player constructs the catalog through, because ovoscope's `OCPPlayerHarness` patches exactly that attribute with a `MagicMock` to build a real player without a real catalog (`ovoscope/media.py`, `simple_targets`). It only needs constructibility and an attribute surface, so it is now an alias of `MediaCatalog` rather than a wrapper class — the harness replaces it wholesale either way. The full end-to-end suite runs against the installed ovoscope unchanged.

Tests moved with the code. The old catalog test file became `test_voice_skill.py` (intents, session gating, the no-NER paths, and new coverage that a notified dialog is really spoken and that a shut-down skill stops speaking), and `test_catalog.py`, `test_likes.py` and `test_keywords.py` are new files covering the three extracted units — including the concurrency and lock-usage tests that used to reach into `player._liked_songs_lock`, now written against the store that owns the lock. `test_spoken_failure_dialogs.py` became `test_failure_notifications.py`: it still pins *when* the player announces, but against the notification seam rather than a mocked `speak_dialog`. Player-side tests that poked at `media.liked_songs` now assert the delegation instead.

`MediaCatalog` and `OCPVoiceSkill` both require the store to be passed in — one store per process is a wiring invariant, not a convention a default constructor can quietly break. The player is the single place that may open one on its own, for the case where it is built outside `MediaService`. `test_service_voice_wiring.py` builds the real merged world (real service, real player, real skill, FakeBus) and pins both wires: a player-side notification reaching the skill's `speak_dialog`, and the store identity shared between them.

Unit tests go from 906 to 944 (72 subtests unchanged); end-to-end stays at 68, all green. Behavior is meant to be unchanged throughout — the one visible difference is that dialogs are dropped rather than spoken when no voice front-end is attached, which only happens for a bare `OCPMediaPlayer` constructed outside `MediaService`.
