### PR TITLE
fix: refuse non-string uris at the bus edge

### DIFF
--- a/ovos_media/bus/schemas.py
+++ b/ovos_media/bus/schemas.py
@@ -120,12 +120,35 @@ def decode_media_state(data: dict) -> MediaState:
     return state
 
 
+def _requires_uri(media: dict) -> bool:
+    """True when a media dict has no alternate shape standing in for a
+    direct 'uri' - mirrors ``ovos_utils.ocp.dict2entry``'s own precedence
+    (playlist > extractor_id > uri), so :func:`decode_media` and
+    :func:`validated_entries` agree on which dicts are exempt from the uri
+    check.
+    """
+    return not (media.get("playlist") or media.get("extractor_id"))
+
+
+def _has_valid_uri(media: dict) -> bool:
+    """True when a media dict carries a non-empty string 'uri'.
+
+    An int/float/list/etc 'uri' passes ``dict2entry``'s truthiness check
+    and reaches ``MediaEntry``/roster.select unvalidated, where it dies as
+    a logged traceback instead of the warn-and-drop every other malformed
+    bus field gets.
+    """
+    uri = media.get("uri")
+    return isinstance(uri, str) and uri != ""
+
+
 def decode_media(data: dict) -> Optional[dict]:
     """Decode the 'media' track of an ``ovos.common_play.play`` payload.
 
-    Returns None when there is nothing to act on: an absent/empty track, or
-    a track that is not a dict (a list/str would bleed into the now_playing
-    metadata field by field).
+    Returns None when there is nothing to act on: an absent/empty track, a
+    track that is not a dict (a list/str would bleed into the now_playing
+    metadata field by field), or a plain-media dict (no 'playlist'/
+    'extractor_id') whose 'uri' is not a non-empty string.
     """
     media = data.get("media")
     if not media:
@@ -133,6 +156,10 @@ def decode_media(data: dict) -> Optional[dict]:
     if not isinstance(media, dict):
         LOG.warning(f"ignoring play request, expected a dict track, "
                     f"got: {media!r}")
+        return None
+    if _requires_uri(media) and not _has_valid_uri(media):
+        LOG.warning(f"ignoring play request with invalid 'uri': "
+                    f"{media.get('uri')!r}")
         return None
     return media
 
@@ -320,6 +347,9 @@ def validated_entries(tracks) -> list:
     for track in tracks:
         try:
             if isinstance(track, dict):
+                if _requires_uri(track) and not _has_valid_uri(track):
+                    raise ValueError(f"invalid 'uri' in track: "
+                                      f"{track.get('uri')!r}")
                 track = MediaEntry.from_dict(track)
             if not isinstance(track, (MediaEntry, Playlist, PluginStream)):
                 raise ValueError(f"not a valid track: {track!r}")

--- a/test/unittests/test_bus_schemas.py
+++ b/test/unittests/test_bus_schemas.py
@@ -20,8 +20,9 @@ import unittest
 
 from ovos_utils.ocp import MediaEntry, MediaType, PlaybackType, Playlist
 
-from ovos_media.bus.schemas import (decode_playback_time, flatten_media_types,
-                                    is_injection_char, is_real_number, sanitize_nested_playlist,
+from ovos_media.bus.schemas import (decode_media, decode_playback_time,
+                                    flatten_media_types, is_injection_char,
+                                    is_real_number, sanitize_nested_playlist,
                                     sanitize_raw_playlist_dicts,
                                     validated_entries)
 
@@ -205,6 +206,54 @@ class TestValidatedEntries(unittest.TestCase):
                 result = validated_entries([entry])
                 self.assertEqual(result[0].length, 0)
                 self.assertEqual(result[0].position, 0)
+
+    def test_non_string_uri_is_skipped(self):
+        # a non-string 'uri' passes dict2entry's truthiness check and
+        # would otherwise reach MediaEntry unvalidated.
+        self.assertEqual(validated_entries([{"uri": 123, "title": "a"}]), [])
+
+    def test_empty_string_uri_is_skipped(self):
+        self.assertEqual(validated_entries([{"uri": "", "title": "a"}]), [])
+
+    def test_pluginstream_shaped_dict_without_uri_is_kept(self):
+        entries = validated_entries([{"extractor_id": "ovos.some.extractor",
+                                       "stream": "some_stream_id"}])
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].extractor_id, "ovos.some.extractor")
+
+    def test_playlist_shaped_dict_without_uri_is_kept(self):
+        entries = validated_entries([{"playlist": [
+            {"uri": "file:///a.mp3", "title": "a"}]}])
+        self.assertEqual(len(entries), 1)
+        self.assertIsInstance(entries[0], Playlist)
+
+
+class TestDecodeMedia(unittest.TestCase):
+
+    def test_absent_or_empty_media_yields_none(self):
+        for data in ({}, {"media": None}, {"media": {}}):
+            with self.subTest(data=data):
+                self.assertIsNone(decode_media(data))
+
+    def test_non_dict_media_is_refused(self):
+        for media in ("file:///a.mp3", ["file:///a.mp3"], 5):
+            with self.subTest(media=media):
+                self.assertIsNone(decode_media({"media": media}))
+
+    def test_non_string_uri_is_refused(self):
+        self.assertIsNone(decode_media({"media": {"uri": 123}}))
+
+    def test_empty_string_uri_is_refused(self):
+        self.assertIsNone(decode_media({"media": {"uri": ""}}))
+
+    def test_valid_dict_passes(self):
+        media = {"uri": "file:///a.mp3", "title": "a"}
+        self.assertEqual(decode_media({"media": media}), media)
+
+    def test_pluginstream_shaped_dict_without_uri_passes(self):
+        media = {"extractor_id": "ovos.some.extractor",
+                  "stream": "some_stream_id"}
+        self.assertEqual(decode_media({"media": media}), media)
 
     def test_nested_playlist_entries_are_also_sanitized(self):
         # bad values inside a NESTED Playlist's tracks must not reach the


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`decode_media` only checked that the `media` field of an `ovos.common_play.play` payload was a dict. A payload like `{"media": {"uri": 123}}` passed that check and reached `roster.select`, where it died as a logged `ValueError` traceback instead of getting the warn-and-drop every other malformed bus field receives. `validated_entries` had the same gap for playlist/disambiguation entries: a dict with a non-string or empty-string `uri` was deserialized into a `MediaEntry` with that broken `uri` intact.

Both call sites now share one rule, `_requires_uri` / `_has_valid_uri` in `ovos_media/bus/schemas.py`. It mirrors the precedence `ovos_utils.ocp.dict2entry` already uses (`playlist` > `extractor_id` > `uri`): a plain media dict needs a non-empty string `uri`, while Playlist-shaped (`playlist` key) and PluginStream-shaped (`extractor_id` key) dicts are exempt, same as `dict2entry` treats them.

Four new regression tests in `test/unittests/test_bus_schemas.py` were verified to fail against the unfixed code (non-string and empty-string `uri` for both `decode_media` and `validated_entries`), then pass after the fix; valid plain-media and PluginStream-shaped dicts were checked to keep passing. Full suite: unit 1017→1027 passed (72→78 subtests, unrelated to this branch's own count reaching net +6 subtests via two new `subTest`-driven cases), end2end unchanged at 68 passed.